### PR TITLE
fix: import-extensions

### DIFF
--- a/.changeset/lucky-peaches-rescue.md
+++ b/.changeset/lucky-peaches-rescue.md
@@ -1,0 +1,5 @@
+---
+'@forgerock/davinci-client': patch
+---
+
+update imports to use `.js` extension. this is fully supported in node module resolution 16 and next. this also is fully compatible with bundlers.

--- a/.changeset/lucky-peaches-rescue.md
+++ b/.changeset/lucky-peaches-rescue.md
@@ -1,5 +1,0 @@
----
-'@forgerock/davinci-client': patch
----
-
-update imports to use `.js` extension. this is fully supported in node module resolution 16 and next. this also is fully compatible with bundlers.

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "root": true,
-  "plugins": ["@typescript-eslint", "@nx"],
+  "plugins": ["@typescript-eslint", "@nx", "import"],
   "overrides": [
     {
       "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
@@ -89,6 +89,7 @@
   },
   "ignorePatterns": ["dist/*"],
   "rules": {
+    "import/extensions": [2, "ignorePackages"],
     "@typescript-eslint/indent": ["error", 2],
     "@typescript-eslint/no-use-before-define": "warn",
     "max-len": [

--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ docs/packages/javascript-sdk
 packages/*/docs
 **/playwright-report
 **/playwright/.cache
+**/.playwright/*
 
 .nx/*
 !.nx/workflows

--- a/packages/davinci-client/src/lib/collector.utils.ts
+++ b/packages/davinci-client/src/lib/collector.utils.ts
@@ -9,7 +9,7 @@ import type {
   SingleValueCollectorTypes,
   MultiValueCollectorTypes,
   InferActionCollectorType,
-} from './collector.types';
+} from './collector.types.js';
 import type {
   DaVinciField,
   MultiSelect,

--- a/packages/davinci-client/src/lib/davinci.api.ts
+++ b/packages/davinci-client/src/lib/davinci.api.ts
@@ -19,7 +19,7 @@ import type {
   OutgoingQueryParams,
   StartOptions,
   ThrownQueryError,
-} from './davinci.types';
+} from './davinci.types.js';
 import type { ContinueNode } from './node.types.js';
 import type { StartNode } from '../types.js';
 

--- a/packages/davinci-client/src/lib/davinci.utils.ts
+++ b/packages/davinci-client/src/lib/davinci.utils.ts
@@ -12,9 +12,8 @@ import type {
   DaVinciNextResponse,
   DaVinciRequest,
   DaVinciSuccessResponse,
-  StartOptions,
-} from './davinci.types';
-import type { ContinueNode } from './node.types';
+} from './davinci.types.js';
+import type { ContinueNode } from './node.types.js';
 
 /**
  * @function transformSubmitRequest - Transforms a NextNode into a DaVinciRequest for form submissions

--- a/packages/davinci-client/tsconfig.json
+++ b/packages/davinci-client/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "commonjs",
+    "moduleDetection": "force",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
-    "resolveJsonModule": true,
+    "composite": true,
     "noImplicitOverride": true,
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,

--- a/packages/davinci-client/tsconfig.lib.json
+++ b/packages/davinci-client/tsconfig.lib.json
@@ -1,16 +1,22 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
     "target": "ES2023",
     "outDir": "./dist",
     "declaration": true,
     "declarationMap": true,
+    "skipLibCheck": true,
     "sourceMap": true,
     "composite": true,
     "lib": ["es2022", "dom", "dom.iterable"]
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["vite.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+  "exclude": [
+    "vite.config.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts",
+    "src/lib/mock-data/*"
+  ]
 }

--- a/packages/davinci-client/tsconfig.lib.json
+++ b/packages/davinci-client/tsconfig.lib.json
@@ -1,29 +1,16 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ES2023",
     "outDir": "./dist",
-    "skipLibCheck": true,
-    "target": "ES2022",
-    "resolveJsonModule": true,
-    "moduleDetection": "force",
-    "isolatedModules": true,
-    "strict": true,
-    "noUncheckedIndexedAccess": false,
-    "noImplicitOverride": true,
-    "module": "ES2020",
-    "moduleResolution": "Bundler",
-    "sourceMap": true,
     "declaration": true,
-    "composite": true,
     "declarationMap": true,
-    "lib": ["es2022", "DOM", "DOM.iterable"],
-    "types": ["vite/client"]
+    "sourceMap": true,
+    "composite": true,
+    "lib": ["es2022", "dom", "dom.iterable"]
   },
   "include": ["src/**/*.ts"],
-  "exclude": [
-    "vite.config.ts",
-    "src/**/*.spec.ts",
-    "src/**/*.test.ts",
-    "src/**/mock-data/**/*"
-  ]
+  "exclude": ["vite.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
 }

--- a/packages/davinci-client/tsconfig.spec.json
+++ b/packages/davinci-client/tsconfig.spec.json
@@ -2,10 +2,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "module": "NodeNext",
-    "target": "ES2022",
     "outDir": "../../dist/out-tsc",
     "composite": true,
-    "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "target": "ESNext",
     "types": [

--- a/packages/davinci-client/tsconfig.spec.json
+++ b/packages/davinci-client/tsconfig.spec.json
@@ -4,12 +4,16 @@
     "module": "NodeNext",
     "target": "ES2022",
     "outDir": "../../dist/out-tsc",
+    "composite": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ESNext",
     "types": [
+      "vitest/vitest",
       "vitest/globals",
       "vitest/importMeta",
       "vite/client",
-      "node",
-      "vitest/vitest"
+      "node"
     ]
   },
   "include": [

--- a/packages/davinci-client/vite.config.ts
+++ b/packages/davinci-client/vite.config.ts
@@ -27,7 +27,7 @@ export default defineConfig({
         preserveModulesRoot: 'src',
       },
       external: Array.from(Object.keys(pkg.dependencies) || []).concat([
-        './src/lib/mock-data',
+        './src/lib/mock-data/*',
         '@reduxjs/toolkit/query',
         '@forgerock/javascript-sdk',
         '@forgerock/javascript-sdk/src/oauth2-client/state-pkce',

--- a/packages/device-client/tsconfig.json
+++ b/packages/device-client/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "ES2020",
-    "moduleResolution": "Bundler",
+    "moduleDetection": "force",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
+    "composite": true,
     "noImplicitOverride": true,
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,

--- a/packages/device-client/tsconfig.lib.json
+++ b/packages/device-client/tsconfig.lib.json
@@ -1,8 +1,15 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "../../dist/out-tsc",
-    "declaration": true
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ES2023",
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "composite": true,
+    "lib": ["es2022", "dom", "dom.iterable"]
   },
   "include": ["src/**/*.ts"],
   "exclude": [

--- a/packages/device-client/tsconfig.lib.json
+++ b/packages/device-client/tsconfig.lib.json
@@ -7,6 +7,7 @@
     "outDir": "./dist",
     "declaration": true,
     "declarationMap": true,
+    "skipLibCheck": true,
     "sourceMap": true,
     "composite": true,
     "lib": ["es2022", "dom", "dom.iterable"]

--- a/packages/device-client/tsconfig.spec.json
+++ b/packages/device-client/tsconfig.spec.json
@@ -1,6 +1,10 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "composite": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ESNext",
     "outDir": "../../dist/out-tsc",
     "types": [
       "vitest/vitest",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12415,6 +12415,7 @@ packages:
         integrity: sha512-s/ZhSRBusW2o+ZkERyzEIbVL3zo8QLpTQPVoB/pn/Yv6+ngflP+anK4xCYiXXQJhqEdBz3cwApa8UgOEaNSS4Q==,
       }
     engines: { node: '>=12.18' }
+    deprecated: this version is deprecated, please migrate to 6.x versions
     hasBin: true
 
   verror@1.10.0:

--- a/tools/create-package/src/generators/create-package-generator.spec.ts
+++ b/tools/create-package/src/generators/create-package-generator.spec.ts
@@ -1,8 +1,8 @@
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { Tree } from '@nx/devkit';
 
-import { createPackageGeneratorGenerator } from './create-package-generator';
-import { CreatePackageGeneratorGeneratorSchema } from './schema';
+import { createPackageGeneratorGenerator } from './create-package-generator.js';
+import { CreatePackageGeneratorGeneratorSchema } from './schema.js';
 import { beforeEach, describe, expect, it } from 'vitest';
 
 describe('create-package-generator generator', () => {

--- a/tools/create-package/src/generators/create-package-generator.ts
+++ b/tools/create-package/src/generators/create-package-generator.ts
@@ -1,6 +1,6 @@
 import { formatFiles, generateFiles, installPackagesTask, names, Tree } from '@nx/devkit';
 import * as path from 'path';
-import { CreatePackageGeneratorGeneratorSchema } from './schema';
+import { CreatePackageGeneratorGeneratorSchema } from './schema.js';
 
 export async function createPackageGeneratorGenerator(
   tree: Tree,

--- a/tools/create-package/src/generators/files/tsconfig.json.template
+++ b/tools/create-package/src/generators/files/tsconfig.json.template
@@ -1,9 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "NodeNext",
     "moduleDetection": "force",
-    "target": "ES2022",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "composite": true,

--- a/tools/create-package/src/generators/files/tsconfig.lib.json.template
+++ b/tools/create-package/src/generators/files/tsconfig.lib.json.template
@@ -1,6 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ES2023",
     "outDir": "./dist",
     "declaration": true,
     "declarationMap": true,

--- a/tools/create-package/src/generators/files/tsconfig.spec.json.template
+++ b/tools/create-package/src/generators/files/tsconfig.spec.json.template
@@ -1,8 +1,11 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "outDir": "../../dist/out-tsc",
+    "composite": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ESNext",
     "types": [
       "vitest/vitest",
       "vitest/globals",

--- a/tools/create-package/tsconfig.lib.json
+++ b/tools/create-package/tsconfig.lib.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
     "declaration": true,
+    "resolveJsonModule": true,
     "types": ["node"]
   },
   "include": ["src/**/*.ts"],

--- a/tools/create-package/tsconfig.spec.json
+++ b/tools/create-package/tsconfig.spec.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
+    "resolveJsonModule": true,
     "types": [
       "vitest",
       "vitest/globals",


### PR DESCRIPTION
# JIRA Ticket
No Jira

## Description

update import extensions to have js extension where they were not. remove "bundler" in general because node16&nodenext support bundlers but bundler leaves us having inconsistent extensions in import statements.

just use extensions in import statements. this is a more compatible setting for a few reasons.

1) if we ever don't use `vite` as a bundler and just use `tsc` our imports should work in node16+
2) the web just supports this
3) it gives us consistency across all packages in styling (how we write imports).


