### PR TITLE
chore: update-renovate-config

### DIFF
--- a/.github/workflows/changesets-renovate.yml
+++ b/.github/workflows/changesets-renovate.yml
@@ -1,0 +1,28 @@
+name: Generate changeset for Renovate
+
+on:
+  merge_group:
+  pull_request_target:
+    paths:
+      - '.github/workflows/changesets-renovate.yml'
+      - '**/pnpm-lock.yaml'
+      - '**/package.json'
+
+jobs:
+  generate-changeset:
+    runs-on: ubuntu-latest
+    if: github.actor == 'renovate[bot]' && github.repository == 'ForgeRock/ping-javascript-sdk'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+          ref: ${{ github.head_ref }}
+      - name: Git Identity
+        run: |
+          git config --global user.name 'github-actions[bot]'
+
+      - uses: pnpm/action-setup@v4.0.0
+
+      - name: Run changesets-renovate
+        run: pnpm dlx @scaleway/changesets-renovate

--- a/renovate.json
+++ b/renovate.json
@@ -9,16 +9,47 @@
     "fileMatch": ["(^|/)(package\\.json)$"]
   },
   "ignoreDeps": [
-    "@nrwl/*",
-    "@nx/*",
-    "typescript",
-    "swc-loader",
-    "@swc/helpers"
+    "nx",
+    "@nx/devkit",
+    "@nx/eslint",
+    "@nx/eslint-plugin",
+    "@nx/jest",
+    "@nx/js",
+    "@nx/playwright",
+    "@nx/plugin",
+    "@nx/vite",
+    "@nx/web",
+    "@nx/workspace",
+    "typescript"
   ],
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch"],
       "matchDepTypes": ["devDependencies"],
+      "automerge": true,
+      "schedule": ["at 2:00am on Monday"]
+    },
+    {
+      "matchPackageNames": ["effect", "@effect/*"],
+      "groupName": "effect-dependencies",
+      "automerge": true,
+      "schedule": ["at 2:00am on Monday"]
+    },
+    {
+      "matchPackageNames": ["vitest", "@vitest/*", "vite"],
+      "groupName": "vite-vitest-dependencies",
+      "automerge": true,
+      "schedule": ["at 2:00am on Monday"]
+    },
+    {
+      "matchPackageNames": ["typedoc", "typedoc-*"],
+      "groupName": "typedoc-dependencies",
+      "automerge": true,
+      "schedule": ["at 2:00am on Monday"]
+    },
+    {
+      "matchPackageNames": ["@typescript-eslint/*"],
+      "groupName": "typescript-eslint-dependencies",
       "automerge": true,
       "schedule": ["at 2:00am on Monday"]
     }

--- a/renovate.json
+++ b/renovate.json
@@ -1,10 +1,17 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
+  "extends": ["config:recommended", ":combinePatchMinorReleases"],
   "lockFileMaintenance": {
     "enabled": true,
     "automerge": true
   },
+  "automerge": false,
+  "rebaseWhen": "auto",
+  "semanticCommitScope": "deps",
+  "semanticCommitType": "chore",
+  "prHourlyLimit": 5,
+  "prConcurrentLimit": 10,
+  "labels": ["dependencies"],
   "npm": {
     "fileMatch": ["(^|/)(package\\.json)$"]
   },
@@ -24,33 +31,70 @@
   ],
   "packageRules": [
     {
-      "matchUpdateTypes": ["minor", "patch"],
-      "matchDepTypes": ["devDependencies"],
+      "matchManagers": ["github-actions"],
+      "semanticCommitScope": "devDeps",
       "automerge": true,
-      "schedule": ["at 2:00am on Monday"]
+      "autoApprove": true
     },
     {
+      "semanticCommitScope": "devDeps",
+      "matchDepTypes": ["packageManager", "devDependencies"],
+      "matchUpdateTypes": ["minor", "patch"]
+    },
+    {
+      "minimumReleaseAge": "14 days",
+      "matchUpdateTypes": ["major"],
+      "automerge": false,
+      "autoApprove": true
+    },
+    {
+      "labels": ["UPDATE-MINOR"],
+      "minimumReleaseAge": "7 days",
+      "matchUpdateTypes": ["minor"],
+      "automerge": true,
+      "autoApprove": true
+    },
+    {
+      "labels": ["UPDATE-PATCH"],
+      "minimumReleaseAge": "3 days",
+      "matchUpdateTypes": ["patch"],
+      "automerge": true,
+      "autoApprove": true
+    },
+    {
+      "matchDepTypes": ["engines"],
+      "rangeStrategy": "widen"
+    },
+    {
+      "labels": ["effect"],
       "matchPackageNames": ["effect", "@effect/*"],
       "groupName": "effect-dependencies",
       "automerge": true,
+      "autoApprove": true,
       "schedule": ["at 2:00am on Monday"]
     },
     {
+      "labels": ["vite", "vitest"],
       "matchPackageNames": ["vitest", "@vitest/*", "vite"],
       "groupName": "vite-vitest-dependencies",
       "automerge": true,
+      "autoApprove": true,
       "schedule": ["at 2:00am on Monday"]
     },
     {
+      "labels": ["typedoc"],
       "matchPackageNames": ["typedoc", "typedoc-*"],
       "groupName": "typedoc-dependencies",
       "automerge": true,
+      "autoApprove": true,
       "schedule": ["at 2:00am on Monday"]
     },
     {
+      "labels": ["@typescript-eslint"],
       "matchPackageNames": ["@typescript-eslint/*"],
       "groupName": "typescript-eslint-dependencies",
       "automerge": true,
+      "autoApprove": true,
       "schedule": ["at 2:00am on Monday"]
     }
   ]


### PR DESCRIPTION
Groups renovate dependencies so theres less noise. add nx to ignore pattern since we do that with `nx`.

Unfortunately, the `ignore` pattern is exact match only and not glob

adds a GH action that will add changesets for the deps when they are needed. uses https://www.npmjs.com/package/@scaleway/changesets-renovate

Which is seen here: https://github.com/scaleway/scaleway-lib/blob/94fd991db6ac46ea034d486837e4ca4dbc38d8c3/.github/workflows/changesets-renovate.yml 

Which I looked at how some of these actions are run here: https://github.com/scaleway/scaleway-lib/pull/2402

Reason: Some updates require changesets. Simple as that, I have it set right now that only devDependencies will get auto merged, and non-major changes.

So if we update a `dependency` that may require a changeset.

For example: #22 probably requires a changeset, since its a "dependency upgrade" (if we wanted to merge it).

Caveat: I do not see this working for `pnpm catalogs`. 

basically the catalog defines a range, and then renovate mostly just updates the lockfile. So this is probably fine since we aren't actually changing the version range within the package.

If we do, we would do it manually in the `pnpm-workspace` file and then make our own changeset.