### PR TITLE
chore: update-GHTOKEN

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.GH_TOKEN }}
       - uses: pnpm/action-setup@v4
         with:
           run_install: false
@@ -72,7 +73,7 @@ jobs:
         env:
           # See https://github.com/changesets/action/issues/147
           HOME: ${{ github.workspace }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_CONFIG_PROVENANCE: 'true'
           NPM_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
 


### PR DESCRIPTION
# JIRA Ticket

<!--
Add a Jira ticket here if applicable
-->

## Description

This uses my personal GH token - this should allow the changesets action to create a PR (like its me) and then trigger workflows so CI runs on the release PR.

see: https://github.com/changesets/action/issues/187#issuecomment-1220791777