### PR TITLE
chore: lint-package-json-rule

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,6 @@ env:
   PNPM_CACHE_FOLDER: .pnpm-store
   NPM_ACCESS_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
   CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-  HUSKY: 0
 
 jobs:
   publish-or-pr:

--- a/e2e/mock-api-v2/package.json
+++ b/e2e/mock-api-v2/package.json
@@ -1,27 +1,27 @@
 {
   "name": "@forgerock/mock-api-v2",
   "version": "1.0.0",
-  "description": "",
   "private": true,
-  "main": "./dist/index.js",
+  "description": "",
   "type": "module",
-  "dependencies": {
-    "@effect/language-service": "^0.2.0",
-    "@effect/platform": "^0.58.27",
-    "@effect/platform-node": "^0.53.26",
-    "effect": "^3.12.7",
-    "effect-http": "^0.73.0",
-    "effect-http-node": "^0.16.1",
-    "@effect/schema": "^0.68.23"
-  },
-  "devDependencies": {
-    "@effect/vitest": "^0.19.0"
-  },
+  "main": "./dist/index.js",
   "scripts": {
     "lint": "pnpm nx nxLint",
     "serve": "node dist/e2e/mock-api-v2/src/main.js",
     "serve:dev": "nodemon dist/e2e/mock-api-v2/src/main.js",
     "test": "pnpm nx nxTest"
+  },
+  "dependencies": {
+    "@effect/language-service": "^0.2.0",
+    "@effect/platform": "^0.58.27",
+    "@effect/platform-node": "^0.53.26",
+    "@effect/schema": "^0.68.23",
+    "effect": "^3.12.7",
+    "effect-http": "^0.73.0",
+    "effect-http-node": "^0.16.1"
+  },
+  "devDependencies": {
+    "@effect/vitest": "^0.19.0"
   },
   "nx": {
     "tags": ["scope:e2e"],
@@ -33,8 +33,7 @@
           "outputPath": "e2e/mock-api-v2/dist",
           "main": "e2e/mock-api-v2/src/main.ts",
           "tsConfig": "e2e/mock-api-v2/tsconfig.app.json",
-          "generatePackageJson": true,
-          "assets": []
+          "generatePackageJson": true
         }
       }
     }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,6 +2,7 @@ import { FlatCompat } from '@eslint/eslintrc';
 import { dirname } from 'path';
 import { fileURLToPath } from 'url';
 import js from '@eslint/js';
+import packageJson from 'eslint-plugin-package-json/configs/recommended';
 import typescriptEslintEslintPlugin from '@typescript-eslint/eslint-plugin';
 import nxEslintPlugin from '@nx/eslint-plugin';
 import eslintPluginImport from 'eslint-plugin-import';
@@ -133,5 +134,12 @@ export default [
   },
   {
     ignores: ['dist/*', '**/**/tsconfig.spec.vitest-temp.json'],
+  },
+  {
+    ...packageJson,
+    rules: {
+      ...packageJson.rules,
+      'package-json/no-empty-fields': 'off',
+    },
   },
 ];

--- a/package.json
+++ b/package.json
@@ -3,12 +3,15 @@
   "private": true,
   "description": "Ping JavaScript SDK",
   "packageManager": "pnpm@9.15.5+sha512.845196026aab1cc3f098a0474b64dfbab2afe7a1b4e91dd86895d8e4aa32a7a6d03049e2d0ad770bbe4de023a7122fb68c1a1d6e0d033c7076085f9d5d4800d4",
-  "engines": { "node": "^20 || ^22", "pnpm": "9.15.5" },
+  "engines": {
+    "node": "^20 || ^22",
+    "pnpm": "9.15.5"
+  },
   "scripts": {
     "build": "nx affected --target=build",
     "clean": "shx rm -rf ./{coverage,dist,docs,node_modules,tmp}/ ./{packages,e2e}/*/{dist,node_modules}/ && git clean -fX -e \"!.env*,nx-cloud.env\"",
     "ci:release": "pnpm publish -r --no-git-checks && changeset tag",
-    "ci:version": "changeset version && pnpm install --no-frozen-lockfile && pnpm nx format:write",
+    "ci:version": "changeset version && pnpm install --no-frozen-lockfile",
     "changeset": "changeset",
     "commit": "git cz",
     "create-package": "nx g @nx/js:library",
@@ -24,13 +27,17 @@
     "verdaccio": "nx local-registry",
     "commitlint": "commitlint --edit"
   },
-  "lint-staged": { "*": ["pnpm nx sync", "pnpm nx format:write", "git add"] },
+  "lint-staged": {
+    "*": ["pnpm nx sync", "pnpm nx format:write", "git add"]
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/ForgeRock/ping-javascript-sdk.git"
   },
   "author": "ForgeRock",
-  "bugs": { "url": "https://github.com/ForgeRock/ping-javascript-sdk/issues" },
+  "bugs": {
+    "url": "https://github.com/ForgeRock/ping-javascript-sdk/issues"
+  },
   "homepage": "https://github.com/ForgeRock/ping-javascript-sdk#readme",
   "devDependencies": {
     "@changesets/changelog-github": "^0.5.0",
@@ -74,6 +81,7 @@
     "eslint": "^9.8.0",
     "eslint-config-prettier": "10.0.1",
     "eslint-plugin-import": "2.27.5",
+    "eslint-plugin-package-json": "0.26.0",
     "eslint-plugin-playwright": "^2.0.0",
     "eslint-plugin-prettier": "^5.1.3",
     "fast-check": "^3.19.0",
@@ -93,8 +101,8 @@
     "typedoc-github-theme": "0.2.1",
     "typedoc-plugin-rename-defaults": "^0.7.2",
     "typescript": "5.7.3",
-    "verdaccio": "^6.0.0",
     "typescript-eslint": "^8.19.0",
+    "verdaccio": "^6.0.0",
     "vite": "^5.4.8",
     "vite-plugin-dts": "^4.2.2",
     "vite-plugin-eslint": "^1.8.1",
@@ -104,8 +112,11 @@
     "vitest-canvas-mock": "^0.3.3"
   },
   "config": {
-    "commitizen": { "path": "./node_modules/cz-conventional-changelog" }
+    "commitizen": {
+      "path": "./node_modules/cz-conventional-changelog"
+    }
   },
-  "nx": { "includedScripts": [] },
-  "dependencies": { "lint-staged": "15.4.3" }
+  "nx": {
+    "includedScripts": []
+  }
 }

--- a/packages/davinci-client/package.json
+++ b/packages/davinci-client/package.json
@@ -1,19 +1,25 @@
 {
   "name": "@forgerock/davinci-client",
   "version": "1.0.0",
-  "main": "./dist/index.js",
-  "module": "./dist/index.js",
-  "typings": "./dist/index.d.ts",
-  "type": "module",
-  "files": ["dist"],
-  "sideEffects": ["./src/types.js"],
   "repository": {
     "type": "git",
     "url": "git+https://github.com:ForgeRock/forgerock-javascript-sdk.git",
     "directory": "packages/davinci-client"
   },
-  "publishConfig": {
-    "access": "public"
+  "sideEffects": ["./src/types.js"],
+  "type": "module",
+  "exports": {
+    ".": "./dist/src/index.js",
+    "./types": "./dist/src/types.d.ts"
+  },
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "typings": "./dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "lint": "pnpm nx nxLint",
+    "test": "pnpm nx nxTest",
+    "test:watch": "pnpm nx nxTest --watch"
   },
   "dependencies": {
     "@forgerock/javascript-sdk": "4.7.0",
@@ -23,14 +29,8 @@
   "devDependencies": {
     "vitest": "^3.0.4"
   },
-  "exports": {
-    ".": "./dist/src/index.js",
-    "./types": "./dist/src/types.d.ts"
-  },
-  "scripts": {
-    "test": "pnpm nx nxTest",
-    "test:watch": "pnpm nx nxTest --watch",
-    "lint": "pnpm nx nxLint"
+  "publishConfig": {
+    "access": "public"
   },
   "nx": {
     "tags": ["scope:package"],

--- a/packages/device-client/package.json
+++ b/packages/device-client/package.json
@@ -2,9 +2,6 @@
   "name": "@forgerock/device-client",
   "version": "0.0.1",
   "private": true,
-  "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
-  "typings": "./dist/index.d.ts",
   "sideEffects": false,
   "type": "module",
   "exports": {
@@ -12,18 +9,21 @@
     "./package.json": "./package.json",
     "./types": "./dist/lib/types/index.d.ts"
   },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "typings": "./dist/index.d.ts",
   "files": ["./dist"],
+  "scripts": {
+    "lint": "pnpm nx nxLint",
+    "test": "pnpm nx nxTest",
+    "test:watch": "pnpm nx nxTest --watch"
+  },
   "dependencies": {
-    "@reduxjs/toolkit": "catalog:",
-    "@forgerock/javascript-sdk": "4.7.0"
+    "@forgerock/javascript-sdk": "4.7.0",
+    "@reduxjs/toolkit": "catalog:"
   },
   "devDependencies": {
     "msw": "^2.5.1"
-  },
-  "scripts": {
-    "test": "pnpm nx nxTest",
-    "test:watch": "pnpm nx nxTest --watch",
-    "lint": "pnpm nx nxLint"
   },
   "nx": {
     "targets": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,10 +16,6 @@ catalogs:
 importers:
 
   .:
-    dependencies:
-      lint-staged:
-        specifier: 15.4.3
-        version: 15.4.3
     devDependencies:
       '@changesets/changelog-github':
         specifier: ^0.5.0
@@ -144,6 +140,9 @@ importers:
       eslint-plugin-import:
         specifier: 2.27.5
         version: 2.27.5(@typescript-eslint/parser@8.24.0(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3))(eslint@9.20.1(jiti@2.4.2))
+      eslint-plugin-package-json:
+        specifier: 0.26.0
+        version: 0.26.0(@types/estree@1.0.6)(eslint@9.20.1(jiti@2.4.2))(jsonc-eslint-parser@2.4.0)
       eslint-plugin-playwright:
         specifier: ^2.0.0
         version: 2.2.0(eslint@9.20.1(jiti@2.4.2))
@@ -162,6 +161,9 @@ importers:
       jsonc-eslint-parser:
         specifier: ^2.1.0
         version: 2.4.0
+      lint-staged:
+        specifier: ^15.0.0
+        version: 15.4.3
       npm-cli-login:
         specifier: ^1.0.0
         version: 1.0.0
@@ -317,6 +319,9 @@ packages:
 
   '@adobe/css-tools@4.3.3':
     resolution: {integrity: sha512-rE0Pygv0sEZ4vBWHlAgJLGDU7Pm8xoO6p3wsEceb7GYAjScrOHpEo8KK/eVkAcnSM+slAEtXjA2JpdjLp4fJQQ==}
+
+  '@altano/repository-tools@0.1.1':
+    resolution: {integrity: sha512-5vbUs2A98CC3g1AlOBdkBE0BMukkLjLIsMHAtuxg6Pt9dQXxYWdLKOf66v6c/vIqtNcgTMv0oGtddLdMuH9X6w==}
 
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
@@ -3640,6 +3645,10 @@ packages:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
     engines: {node: '>=8'}
 
+  detect-indent@7.0.1:
+    resolution: {integrity: sha512-Mc7QhQ8s+cLrnUfU/Ji94vG/r8M26m8f++vyres4ZoojaRDpZ1eSIh/EpzLNwlWuvzSZ3UbDFspjFvTDXe6e/g==}
+    engines: {node: '>=12.20'}
+
   detect-libc@1.0.3:
     resolution: {integrity: sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==}
     engines: {node: '>=0.10'}
@@ -3648,6 +3657,10 @@ packages:
   detect-newline@3.1.0:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
     engines: {node: '>=8'}
+
+  detect-newline@4.0.1:
+    resolution: {integrity: sha512-qE3Veg1YXzGHQhlA6jzebZN2qVf6NX+A7m7qlhCGG30dJixrAQhYOsJjsnBjJkCSmuOPpCk30145fr8FV0bzog==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   detect-node@2.1.0:
     resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
@@ -3872,6 +3885,16 @@ packages:
     peerDependencies:
       eslint: '>=7.0.0'
 
+  eslint-fix-utils@0.2.1:
+    resolution: {integrity: sha512-vHvLGmqdgPhZgH+cymlAlAqVuV22auB+uk/mgFdg5zotEtMHAHcOzNzhr5XOrDzyKGEQY2uQHoT+tS8P36/2CQ==}
+    engines: {node: '>=18.3.0'}
+    peerDependencies:
+      '@types/estree': '>=1'
+      eslint: '>=8'
+    peerDependenciesMeta:
+      '@types/estree':
+        optional: true
+
   eslint-import-resolver-node@0.3.9:
     resolution: {integrity: sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==}
 
@@ -3905,6 +3928,13 @@ packages:
     peerDependenciesMeta:
       '@typescript-eslint/parser':
         optional: true
+
+  eslint-plugin-package-json@0.26.0:
+    resolution: {integrity: sha512-plYuuP7RyL532yHLPvKtQNzK6ncXRmzWPji5EUlV0tXhhfFc84TDWiwJ+OYvv4pDA9AfV+gKYVUwhojaDameNw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      eslint: '>=8.0.0'
+      jsonc-eslint-parser: ^2.0.0
 
   eslint-plugin-playwright@2.2.0:
     resolution: {integrity: sha512-qSQpAw7RcSzE3zPp8FMGkthaCWovHZ/BsXtpmnGax9vQLIovlh1bsZHEa2+j2lv9DWhnyeLM/qZmp7ffQZfQvg==}
@@ -4304,6 +4334,10 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
+  get-stdin@9.0.0:
+    resolution: {integrity: sha512-dVKBjfWisLAicarI2Sf+JuBE/DghV4UzNAVe9yhEJuzeREd3JhOTE9cUaJTeSa77fsbQUK3pcOpJfM59+VKZaA==}
+    engines: {node: '>=12'}
+
   get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
@@ -4322,6 +4356,9 @@ packages:
 
   getpass@0.1.7:
     resolution: {integrity: sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==}
+
+  git-hooks-list@3.2.0:
+    resolution: {integrity: sha512-ZHG9a1gEhUMX1TvGrLdyWb9kDopCBbTnI8z4JgRMYxsijWipgjSEYoPWqBuIB0DnRnvqlQSEeVmzpeuPm7NdFQ==}
 
   git-raw-commits@4.0.0:
     resolution: {integrity: sha512-ICsMM1Wk8xSGMowkOmPrzo2Fgmfo4bMHLNX6ytHjajRJUqvHOw/TFapQ+QG75c3X/tTDDhOSRPGC52dDbNM8FQ==}
@@ -4742,6 +4779,10 @@ packages:
   is-plain-obj@1.1.0:
     resolution: {integrity: sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==}
     engines: {node: '>=0.10.0'}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
@@ -5695,6 +5736,11 @@ packages:
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
+  package-json-validator@0.10.0:
+    resolution: {integrity: sha512-zaPt4x0ZIxA4KYWpPMkbOEhkEDfQdtkCCC1xhnbnYrQV+Kry3zMAxENujgdT6aPA5BJ+FfpncKoNULWc/qjloQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   package-manager-detector@0.2.9:
     resolution: {integrity: sha512-+vYvA/Y31l8Zk8dwxHhL3JfTuHPm6tlxM2A3GeQyl7ovYnSp1+mzAxClxaOr0qO1TtPxbQxetI7v5XqKLJZk7Q==}
 
@@ -6318,6 +6364,13 @@ packages:
     resolution: {integrity: sha512-vzn8aSqKgytVik0iwdBEi+zevbTYZogewTUM6dtpmGwEcdzbub/TX4bCzRhebDCRC3QzXgJsLRKB2V/Oof7HXg==}
     engines: {node: '>=0.10.0'}
 
+  sort-object-keys@1.1.3:
+    resolution: {integrity: sha512-855pvK+VkU7PaKYPc+Jjnmt4EzejQHyhhF33q31qG8x7maDzkeFhAAThdCYay11CISO+qAMwjOBP+fPZe0IPyg==}
+
+  sort-package-json@2.14.0:
+    resolution: {integrity: sha512-xBRdmMjFB/KW3l51mP31dhlaiFmqkHLfWTfZAno8prb/wbDxwBPWFpxB16GZbiPbYr3wL41H8Kx22QIDWRe8WQ==}
+    hasBin: true
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -6935,6 +6988,10 @@ packages:
     resolution: {integrity: sha512-YuKoXDAhBYxY7SfOKxHBDoSyENFeW5VvIIQp2TGQuit8gpK6MnWaQelBKxso72DoxTZfZdcP3W90LqpSkgPzLQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
+  validate-npm-package-name@6.0.0:
+    resolution: {integrity: sha512-d7KLgL1LD3U3fgnvWEY1cQXoO/q6EQ1BSz48Sa149V/5zVTAbgmZIpyI8TRi6U9/JNyeYLlTKsEMPtLC27RFUg==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
   validator@13.12.0:
     resolution: {integrity: sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==}
     engines: {node: '>= 0.10'}
@@ -7273,6 +7330,8 @@ snapshots:
 
   '@adobe/css-tools@4.3.3':
     optional: true
+
+  '@altano/repository-tools@0.1.1': {}
 
   '@ampproject/remapping@2.3.0':
     dependencies:
@@ -11296,9 +11355,13 @@ snapshots:
 
   detect-indent@6.1.0: {}
 
+  detect-indent@7.0.1: {}
+
   detect-libc@1.0.3: {}
 
   detect-newline@3.1.0: {}
+
+  detect-newline@4.0.1: {}
 
   detect-node@2.1.0: {}
 
@@ -11563,6 +11626,12 @@ snapshots:
     dependencies:
       eslint: 9.20.1(jiti@2.4.2)
 
+  eslint-fix-utils@0.2.1(@types/estree@1.0.6)(eslint@9.20.1(jiti@2.4.2)):
+    dependencies:
+      eslint: 9.20.1(jiti@2.4.2)
+    optionalDependencies:
+      '@types/estree': 1.0.6
+
   eslint-import-resolver-node@0.3.9:
     dependencies:
       debug: 3.2.7
@@ -11605,6 +11674,22 @@ snapshots:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
+
+  eslint-plugin-package-json@0.26.0(@types/estree@1.0.6)(eslint@9.20.1(jiti@2.4.2))(jsonc-eslint-parser@2.4.0):
+    dependencies:
+      '@altano/repository-tools': 0.1.1
+      detect-indent: 6.1.0
+      detect-newline: 3.1.0
+      eslint: 9.20.1(jiti@2.4.2)
+      eslint-fix-utils: 0.2.1(@types/estree@1.0.6)(eslint@9.20.1(jiti@2.4.2))
+      jsonc-eslint-parser: 2.4.0
+      package-json-validator: 0.10.0
+      semver: 7.7.1
+      sort-object-keys: 1.1.3
+      sort-package-json: 2.14.0
+      validate-npm-package-name: 6.0.0
+    transitivePeerDependencies:
+      - '@types/estree'
 
   eslint-plugin-playwright@2.2.0(eslint@9.20.1(jiti@2.4.2)):
     dependencies:
@@ -12076,6 +12161,8 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
+  get-stdin@9.0.0: {}
+
   get-stream@6.0.1: {}
 
   get-stream@8.0.1: {}
@@ -12094,6 +12181,8 @@ snapshots:
   getpass@0.1.7:
     dependencies:
       assert-plus: 1.0.0
+
+  git-hooks-list@3.2.0: {}
 
   git-raw-commits@4.0.0:
     dependencies:
@@ -12541,6 +12630,8 @@ snapshots:
   is-obj@2.0.0: {}
 
   is-plain-obj@1.1.0: {}
+
+  is-plain-obj@4.1.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
 
@@ -13725,6 +13816,10 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
+  package-json-validator@0.10.0:
+    dependencies:
+      yargs: 17.7.2
+
   package-manager-detector@0.2.9: {}
 
   pako@0.2.9: {}
@@ -14383,6 +14478,19 @@ snapshots:
     dependencies:
       is-plain-obj: 1.1.0
 
+  sort-object-keys@1.1.3: {}
+
+  sort-package-json@2.14.0:
+    dependencies:
+      detect-indent: 7.0.1
+      detect-newline: 4.0.1
+      get-stdin: 9.0.0
+      git-hooks-list: 3.2.0
+      is-plain-obj: 4.1.0
+      semver: 7.7.1
+      sort-object-keys: 1.1.3
+      tinyglobby: 0.2.10
+
   source-map-js@1.2.1: {}
 
   source-map-support@0.5.13:
@@ -15001,6 +15109,8 @@ snapshots:
   validate-npm-package-name@5.0.0:
     dependencies:
       builtins: 5.1.0
+
+  validate-npm-package-name@6.0.0: {}
 
   validator@13.12.0: {}
 


### PR DESCRIPTION
# JIRA Ticket
N/A
## Description

Adds a lint rule to make sure package.json's are valid, and are ordered nicely. 

https://www.npmjs.com/package/eslint-plugin-package-json

it's fixable via --fix also so should mostly just not be in our way and fixed when needed. works with prettier. 

Up to date package with maintainers.
