### PR TITLE
chore: fix-imports

### DIFF
--- a/packages/davinci-client/package.json
+++ b/packages/davinci-client/package.json
@@ -12,10 +12,10 @@
     ".": "./dist/src/index.js",
     "./types": "./dist/src/types.d.ts"
   },
-  "main": "./dist/index.js",
-  "module": "./dist/index.js",
-  "typings": "./dist/index.d.ts",
-  "files": ["dist"],
+  "main": "./dist/src/index.js",
+  "module": "./dist/src/index.js",
+  "typings": "./dist/src/index.d.ts",
+  "files": ["dist", "!dist/tsconfig.lib.tsbuildinfo"],
   "scripts": {
     "lint": "pnpm nx nxLint",
     "test": "pnpm nx nxTest",


### PR DESCRIPTION
# JIRA Ticket

<!--
Add a Jira ticket here if applicable
-->

## Description

<!--
Describe the changes
-->
<!--
Did you add a changeset?
-->
Spent longer than I'm willing to admit trying to figure out why this wasn't resolving. must have been a carry over when we moved the packages over. Guess node or vite or whatever is resolving the package when I went to use it was using the incorrect keys (the ones with the wrong path).
