### PR TITLE
fix: handle-form-data-with-more-safety

### DIFF
--- a/.changeset/long-islands-call.md
+++ b/.changeset/long-islands-call.md
@@ -1,0 +1,5 @@
+---
+'@forgerock/davinci-client': patch
+---
+
+handle formData lookup with more saftey in case it is not in response

--- a/packages/davinci-client/src/lib/node.reducer.test.ts
+++ b/packages/davinci-client/src/lib/node.reducer.test.ts
@@ -148,7 +148,9 @@ describe('The node collector reducer', () => {
           },
         ],
         formData: {
-          username: 'This is the default data',
+          value: {
+            username: 'This is the default data',
+          },
         },
       },
     };

--- a/packages/davinci-client/src/lib/node.reducer.ts
+++ b/packages/davinci-client/src/lib/node.reducer.ts
@@ -47,7 +47,7 @@ import {
  */
 export const nextCollectorValues = createAction<{
   fields: DaVinciField[];
-  formData: Record<string, unknown>;
+  formData: { value: Record<string, unknown> };
 }>('node/next');
 export const updateCollectorValues = createAction<{
   id: string;
@@ -97,7 +97,10 @@ export const nodeCollectorReducer = createReducer(initialCollectorValues, (build
             }
 
             // *Some* collectors may have default or existing data to display
-            const data = action.payload.formData[field.key];
+            const data =
+              action.payload.formData &&
+              action.payload.formData.value &&
+              action.payload.formData.value[field.key];
 
             // Match specific collectors
             switch (field.type) {


### PR DESCRIPTION


# JIRA Ticket

n/a
## Description

It's not possible to receive responses from server that have no `formData` key. We should be defensive about how we handle this lookup.