### PR TITLE
chore: provenance-settings

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -86,6 +86,15 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
 
       - name: Publish packages as beta
+        if: ${{ inputs.registry == 'https://registry.npmjs.org' }}
         run: pnpm publish -r --tag beta --no-git-checks --registry ${{ inputs.registry }}
         env:
           NPM_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true # make sure provenance is working on beta releases to npm
+
+      - name: Publish packages as beta
+        if: ${{ inputs.registry != 'https://registry.npmjs.org' }}
+        run: pnpm publish -r --tag beta --no-git-checks --registry ${{ inputs.registry }}
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
+          NPM_CONFIG_PROVENANCE: false # verdaccio doesn't support provenance

--- a/packages/device-client/package.json
+++ b/packages/device-client/package.json
@@ -2,6 +2,12 @@
   "name": "@forgerock/device-client",
   "version": "0.0.1",
   "private": true,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ForgeRock/ping-javascript-sdk.git",
+    "directory": "packages/device-client"
+  },
+
   "sideEffects": false,
   "type": "module",
   "exports": {

--- a/packages/oidc-client/package.json
+++ b/packages/oidc-client/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@forgerock/oidc-client",
   "version": "0.0.1",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ForgeRock/ping-javascript-sdk.git",
+    "directory": "packages/oidc-client"
+  },
   "sideEffects": false,
   "type": "module",
   "exports": {

--- a/packages/sdk-effects/iframe-manager/package.json
+++ b/packages/sdk-effects/iframe-manager/package.json
@@ -2,6 +2,11 @@
   "name": "@forgerock/iframe-manager",
   "version": "0.0.1",
   "private": false,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ForgeRock/ping-javascript-sdk.git",
+    "directory": "packages/sdk-effects/iframe-manager"
+  },
   "type": "module",
   "exports": {
     ".": {

--- a/packages/sdk-types/package.json
+++ b/packages/sdk-types/package.json
@@ -2,6 +2,11 @@
   "name": "@forgerock/sdk-types",
   "version": "0.0.1",
   "private": false,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ForgeRock/ping-javascript-sdk.git",
+    "directory": "packages/sdk-types"
+  },
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
# JIRA Ticket

N/a

## Description
I went through to made sure all packages have provenance settings. Maybe I can see if we have a lint rule to enforce this.

I also added that our beta releases will publish with provenance, so that we are not caught off guard during a real release with a provenance issue.

so we can and should always publish a beta before merging the release PR, that way if that publishes correctly we can ensure we have a successful provenance stamp and our packages are published correctly.
