### PR TITLE
feat: implement-authorize-oidc-client

### DIFF
--- a/.changeset/dirty-queens-design.md
+++ b/.changeset/dirty-queens-design.md
@@ -1,0 +1,7 @@
+---
+'@forgerock/iframe-manager': minor
+'@forgerock/sdk-oidc': minor
+'@forgerock/oidc-client': minor
+---
+
+authorize functionality in oidc-client

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .npm/_logs
 
 # Generated code
+logs/*
 tmp/
 e2e/**/dist
 */dist/*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,91 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is the Ping JavaScript SDK - a monorepo containing multiple packages for web applications integrating with the Ping platform. The SDK provides APIs for user authentication, device management, and accessing Ping-secured resources.
+
+## Development Commands
+
+### Core Commands
+
+- `pnpm build` - Build all affected packages
+- `pnpm test` - Run tests for all affected packages
+- `pnpm lint` - Lint all affected packages
+- `pnpm format` - Format code using Prettier
+- `pnpm nx typecheck` - Run TypeScript type checking
+
+### Package Management
+
+- `pnpm create-package` - Generate a new library package using Nx
+- `pnpm nx serve <package-name>` - Serve a specific package in development
+- `pnpm nx test <package-name> --watch` - Run tests for a specific package in watch mode
+
+### E2E Testing
+
+- `pnpm test:e2e` - Run end-to-end tests for affected packages
+- Individual e2e apps are in `e2e/` directory with their own test suites
+
+## Architecture
+
+### Monorepo Structure
+
+The repository uses **Nx** as the monorepo tool with the following structure:
+
+```
+packages/
+├── davinci-client/          # DaVinci flow orchestration client
+├── device-client/           # Device management (binding, profiles, WebAuthn)
+├── oidc-client/            # OpenID Connect authentication client
+├── protect/                # Ping Protect fraud detection
+├── sdk-effects/            # Effect-based utilities (logger, storage, etc.)
+│   ├── iframe-manager/
+│   ├── logger/
+│   ├── oidc/
+│   ├── sdk-request-middleware/
+│   └── storage/
+├── sdk-types/              # Shared TypeScript types
+└── sdk-utilities/          # Common utilities (PKCE, URL handling)
+```
+
+### Key Packages
+
+- **davinci-client**: State management for DaVinci authentication flows using Redux Toolkit
+- **oidc-client**: OIDC authentication with token management and storage
+- **device-client**: Device binding, profiles, OATH, Push, and WebAuthn capabilities
+- **protect**: Fraud detection and risk assessment integration
+- **sdk-effects**: Effect-based architecture packages for common functionalities
+
+### Technology Stack
+
+- **Package Manager**: pnpm with workspace configuration
+- **Build Tool**: Vite for building and bundling
+- **Testing**: Vitest for unit tests, Playwright for e2e tests
+- **State Management**: Redux Toolkit (in davinci-client)
+- **TypeScript**: Strict typing with composite project configuration
+- **Linting**: ESLint with Prettier integration
+
+### Nx Configuration
+
+- Uses target defaults for build, test, lint, and typecheck
+- Caching enabled for build and test targets
+- Workspace layout configured for packages and e2e apps
+- Parallel execution limited to 1 for consistency
+
+### Package Dependencies
+
+Packages use workspace references (`workspace:*`) for internal dependencies and catalog references (`catalog:`) for shared external dependencies like `@reduxjs/toolkit`.
+
+### Testing Strategy
+
+- Unit tests: Vitest with coverage reporting
+- E2E tests: Playwright with dedicated test apps in `e2e/` directory
+- Mock API server available in `e2e/mock-api-v2/` for testing
+
+## Development Notes
+
+- All packages are built as ES modules with TypeScript declarations
+- Use `pnpm nx affected` commands to run tasks only on changed packages
+- The repository uses conventional commits and automated releases via changesets
+- Individual packages can be tested independently using their specific build/test scripts

--- a/e2e/oidc-app/package.json
+++ b/e2e/oidc-app/package.json
@@ -9,6 +9,7 @@
     "serve": "pnpm nx nxServe"
   },
   "dependencies": {
+    "@forgerock/javascript-sdk": "^4.8.2",
     "@forgerock/oidc-client": "workspace:*"
   },
   "nx": {

--- a/e2e/oidc-app/src/main.ts
+++ b/e2e/oidc-app/src/main.ts
@@ -1,1 +1,64 @@
-console.log('Starting OIDC App...');
+import { oidc } from '@forgerock/oidc-client';
+import {
+  CallbackType,
+  Config,
+  FRAuth,
+  FRStep,
+  NameCallback,
+  PasswordCallback,
+} from '@forgerock/javascript-sdk';
+
+async function app() {
+  await Config.setAsync({
+    clientId: 'WebOAuthClient',
+    redirectUri: window.location.origin + '/',
+    scope: 'openid profile email me.read',
+    serverConfig: {
+      wellknown:
+        'https://openam-sdks.forgeblocks.com/am/oauth2/alpha/.well-known/openid-configuration',
+    },
+  });
+
+  const step = await FRAuth.start();
+  console.log('Step:', step);
+
+  if ('callbacks' in step) {
+    const name = step.getCallbackOfType<NameCallback>(CallbackType.NameCallback);
+
+    const password = step.getCallbackOfType<PasswordCallback>(CallbackType.PasswordCallback);
+
+    name.setName('devicetestuser');
+    password.setPassword('password');
+  }
+
+  const success = await FRAuth.next(step as FRStep);
+  console.log('success:', success);
+
+  const oidcClient = await oidc({
+    serverConfig: {
+      wellknown:
+        'https://openam-sdks.forgeblocks.com/am/oauth2/alpha/.well-known/openid-configuration',
+    },
+  });
+
+  if (oidcClient.error || !oidcClient.authorizeSilently || !oidcClient.createAuthorizeUrl) {
+    console.error('Error initializing oidc client:', oidcClient.error);
+    return;
+  }
+
+  const result = await oidcClient.authorizeSilently({
+    clientId: 'WebOAuthClient',
+    redirectUri: window.location.origin + '/',
+    responseType: 'code',
+    scope: 'openid',
+  });
+
+  if ('error' in result) {
+    console.error('Error during authorization:', result.error);
+    return;
+  } else {
+    console.log('returning resolved params,', result);
+  }
+}
+
+app();

--- a/packages/oidc-client/package.json
+++ b/packages/oidc-client/package.json
@@ -26,8 +26,13 @@
     "test:watch": "pnpm nx nxTest --watch"
   },
   "dependencies": {
+    "@forgerock/iframe-manager": "workspace:*",
+    "@forgerock/sdk-logger": "workspace:*",
+    "@forgerock/sdk-oidc": "workspace:*",
+    "@forgerock/sdk-request-middleware": "workspace:*",
     "@forgerock/sdk-types": "workspace:*",
-    "@forgerock/storage": "workspace:*"
+    "@forgerock/storage": "workspace:*",
+    "@reduxjs/toolkit": "catalog:"
   },
   "nx": {
     "tags": ["scope:package"]

--- a/packages/oidc-client/src/index.ts
+++ b/packages/oidc-client/src/index.ts
@@ -1,1 +1,2 @@
 export * from './lib/token-store.js';
+export * from './lib/client.store.js';

--- a/packages/oidc-client/src/lib/authorize.slice.ts
+++ b/packages/oidc-client/src/lib/authorize.slice.ts
@@ -1,0 +1,23 @@
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query';
+
+const authorizeSlice = createApi({
+  reducerPath: 'authorizeSlice',
+  baseQuery: fetchBaseQuery({
+    credentials: 'include',
+    prepareHeaders: (headers) => {
+      headers.set('Content-Type', 'application/json');
+      headers.set('Accept', 'application/json');
+      headers.set('x-requested-with', 'ping-sdk');
+      headers.set('x-requested-platform', 'javascript');
+
+      return headers;
+    },
+  }),
+  endpoints: (builder) => ({
+    handleAuthorize: builder.query<string, string>({
+      query: (authorizeUrl) => authorizeUrl,
+    }),
+  }),
+});
+
+export { authorizeSlice };

--- a/packages/oidc-client/src/lib/client.store.ts
+++ b/packages/oidc-client/src/lib/client.store.ts
@@ -1,0 +1,120 @@
+import { iFrameManager } from '@forgerock/iframe-manager';
+import { createAuthorizeUrl, GetAuthorizationUrlOptions } from '@forgerock/sdk-oidc';
+import { createOidcStore } from './store.js';
+import { fetchWellKnownConfig } from './wellknown.api.js';
+import { RequestMiddleware } from '@forgerock/sdk-request-middleware';
+import { handleAuthorize, recreateAuthorizeUrl } from './client.store.utils.js';
+
+interface OIDCConfig {
+  prefix?: string;
+  serverConfig: {
+    wellknown: string;
+  };
+  middleware?: RequestMiddleware[];
+  logger?: ReturnType<typeof import('@forgerock/sdk-logger').logger>;
+}
+
+interface AuthorizeSuccessResponse {
+  code: string;
+  state: string;
+  redirectUrl?: string; // Optional, used when the response is from a P1 server
+}
+
+interface AuthorizeUrlResponse {
+  authorizeUrl: string;
+}
+
+interface AuthorizeErrorResponse {
+  error: string;
+  error_description?: string;
+  state?: string;
+}
+
+type AuthorizeResponse = AuthorizeSuccessResponse | AuthorizeUrlResponse | AuthorizeErrorResponse;
+
+export type { AuthorizeSuccessResponse, AuthorizeErrorResponse, AuthorizeResponse, OIDCConfig };
+
+export async function oidc(config: OIDCConfig) {
+  const store = createOidcStore({ requestMiddleware: config.middleware, logger: config.logger });
+  const iframeMgr = iFrameManager();
+
+  if (!config?.serverConfig?.wellknown) {
+    return {
+      error: 'requires a wellknown url initializing this factory.',
+    };
+  }
+
+  const wellKnownUrl = config.serverConfig.wellknown;
+  const { data, error } = await store.dispatch(
+    fetchWellKnownConfig.endpoints.fetchWellKnownConfig.initiate(wellKnownUrl),
+  );
+  if (error || !data) {
+    return {
+      error: `Error fetching wellknown config`,
+    };
+  }
+
+  /**
+   * if true, then we need to use GET or POST (p1?)
+   * if false, we use iframe.
+   */
+  const supportsPiFlow = data.response_modes_supported?.includes('pi.flow');
+
+  return {
+    createAuthorizeUrl: createAuthorizeUrl,
+    authorizeSilently: async (
+      options: GetAuthorizationUrlOptions,
+      timeout = 3000,
+    ): Promise<AuthorizeResponse | { error: string }> => {
+      const authorizePath = data.authorization_endpoint;
+
+      const authorizeUrl = await createAuthorizeUrl(authorizePath, options);
+
+      try {
+        /**
+         * If we support the pi flow field,
+         * this means we are using a p1 server. p1 servers
+         * do not support redirection through iframes because they
+         * set iframe's to DENY.
+         */
+        if (supportsPiFlow) {
+          /**
+           * We need to make a post (or a get) request
+           * and both are supported by p1.
+           */
+          return handleAuthorize(authorizeUrl);
+        }
+
+        const resolvedParams = await iframeMgr.getParamsByRedirect({
+          url: authorizeUrl,
+          /***
+           * https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2
+           * The client MUST ignore unrecognized response parameters.
+           * The authorization code string size is left undefined by this specification.
+           * The client should avoid making assumptions about code value sizes.
+           * The authorization server SHOULD document the size of any value it issues.
+           */
+          successParams: ['code', 'state'],
+          errorParams: ['error', 'error_description'],
+          timeout,
+        });
+
+        if ('error' in resolvedParams) {
+          return recreateAuthorizeUrl(resolvedParams, authorizePath, options);
+        }
+
+        const { code, state } = resolvedParams;
+
+        return {
+          code,
+          state,
+        };
+      } catch (iframeError: unknown) {
+        return {
+          error: 'iframe_error',
+          error_description: (iframeError as Error)?.message || 'Authorization iframe failed',
+        };
+      }
+    },
+  };
+}

--- a/packages/oidc-client/src/lib/client.store.utils.test.ts
+++ b/packages/oidc-client/src/lib/client.store.utils.test.ts
@@ -1,0 +1,67 @@
+import { recreateAuthorizeUrl, handleAuthorize } from './client.store.utils.js';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock createAuthorizeUrl from sdk to avoid actual URL generation logic or network calls
+vi.mock('@forgerock/sdk-oidc', () => {
+  return {
+    createAuthorizeUrl: vi
+      .fn()
+      .mockResolvedValue(
+        'https://example.com/authorize?client_id=client_id&redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&scope=openid&state=state&response_type=code',
+      ),
+  };
+});
+
+// Stub the global fetch used inside handleAuthorize so it returns predictable JSON
+beforeEach(() => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      json: async () => ({
+        authorizeResponse: {
+          code: 'code',
+          state: 'state',
+        },
+      }),
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('client-store utilities', () => {
+  it('should handle authorize', async () => {
+    const result = await handleAuthorize('https://example.com/authorize');
+    expect(result).toEqual({
+      code: 'code',
+      state: 'state',
+    });
+  });
+
+  it('should recreate authorize url', async () => {
+    const result = await recreateAuthorizeUrl(
+      {
+        error: 'error',
+        error_description: 'error_description',
+        state: 'state',
+      },
+      'https://example.com/authorize',
+      {
+        clientId: 'client_id',
+        redirectUri: 'https://example.com/redirect',
+        scope: 'openid',
+        state: 'state',
+        responseType: 'code',
+      },
+    );
+    expect(result).toEqual({
+      error: 'error',
+      error_description: 'error_description',
+      state: 'state',
+      redirectUrl:
+        'https://example.com/authorize?client_id=client_id&redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&scope=openid&state=state&response_type=code',
+    });
+  });
+});

--- a/packages/oidc-client/src/lib/client.store.utils.ts
+++ b/packages/oidc-client/src/lib/client.store.utils.ts
@@ -1,0 +1,36 @@
+import type { ResolvedParams } from '@forgerock/iframe-manager';
+import { createAuthorizeUrl, GetAuthorizationUrlOptions } from '@forgerock/sdk-oidc';
+
+export async function handleAuthorize(authorizeUrl: string) {
+  const response = await fetch(authorizeUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    credentials: 'include',
+  });
+
+  const body = await response.json();
+
+  if ('authorizeResponse' in body) {
+    return body.authorizeResponse;
+  }
+  return {
+    error: 'invalid_response',
+    error_description: 'Missing code or state in authorization response after redirect',
+  };
+}
+
+export async function recreateAuthorizeUrl(
+  resolvedParams: ResolvedParams,
+  authorizePath: string,
+  options: GetAuthorizationUrlOptions,
+) {
+  const newAuthorizeUrl = await createAuthorizeUrl(authorizePath, options);
+  return {
+    error: resolvedParams.error,
+    error_description: resolvedParams.error_description,
+    state: resolvedParams.state,
+    redirectUrl: newAuthorizeUrl,
+  };
+}

--- a/packages/oidc-client/src/lib/store.ts
+++ b/packages/oidc-client/src/lib/store.ts
@@ -1,0 +1,36 @@
+import type { ActionTypes, RequestMiddleware } from '@forgerock/sdk-request-middleware';
+import type { logger as loggerFn } from '@forgerock/sdk-logger';
+
+import { configureStore } from '@reduxjs/toolkit';
+import { fetchWellKnownConfig } from './wellknown.api.js';
+import { authorizeSlice } from './authorize.slice.js';
+
+export function createOidcStore<ActionType extends ActionTypes>({
+  requestMiddleware,
+  logger,
+}: {
+  requestMiddleware?: RequestMiddleware<ActionType, unknown>[];
+  logger?: ReturnType<typeof loggerFn>;
+}) {
+  return configureStore({
+    reducer: {
+      [fetchWellKnownConfig.reducerPath]: fetchWellKnownConfig.reducer,
+      [authorizeSlice.reducerPath]: authorizeSlice.reducer,
+    },
+    middleware: (getDefaultMiddleware) =>
+      getDefaultMiddleware({
+        thunk: {
+          extraArgument: {
+            /**
+             * This becomes the `api.extra` argument, and will be passed into the
+             * customer query wrapper for `baseQuery`
+             */
+            requestMiddleware,
+            logger,
+          },
+        },
+      })
+        .concat(fetchWellKnownConfig.middleware)
+        .concat(authorizeSlice.middleware),
+  });
+}

--- a/packages/oidc-client/src/lib/wellknown.api.ts
+++ b/packages/oidc-client/src/lib/wellknown.api.ts
@@ -1,0 +1,28 @@
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query';
+
+// Define the shape of the wellknown config
+// Matches DaVinci client wellknown config shape
+export interface WellknownConfig {
+  issuer: string;
+  authorization_endpoint: string;
+  token_endpoint: string;
+  userinfo_endpoint?: string;
+  jwks_uri?: string;
+  response_types_supported?: string[];
+  scopes_supported?: string[];
+  subject_types_supported?: string[];
+  id_token_signing_alg_values_supported?: string[];
+  token_endpoint_auth_methods_supported?: string[];
+  claims_supported?: string[];
+  [key: string]: any;
+}
+
+export const fetchWellKnownConfig = createApi({
+  reducerPath: 'fetchWellKnown',
+  baseQuery: fetchBaseQuery(),
+  endpoints: (builder) => ({
+    fetchWellKnownConfig: builder.query<WellknownConfig, string>({
+      query: (endpoint) => `${endpoint}`,
+    }),
+  }),
+});

--- a/packages/oidc-client/tsconfig.json
+++ b/packages/oidc-client/tsconfig.json
@@ -10,6 +10,18 @@
       "path": "../sdk-types"
     },
     {
+      "path": "../sdk-effects/sdk-request-middleware"
+    },
+    {
+      "path": "../sdk-effects/oidc"
+    },
+    {
+      "path": "../sdk-effects/logger"
+    },
+    {
+      "path": "../sdk-effects/iframe-manager"
+    },
+    {
       "path": "./tsconfig.lib.json"
     },
     {

--- a/packages/oidc-client/tsconfig.lib.json
+++ b/packages/oidc-client/tsconfig.lib.json
@@ -21,6 +21,18 @@
     },
     {
       "path": "../sdk-types/tsconfig.lib.json"
+    },
+    {
+      "path": "../sdk-effects/sdk-request-middleware/tsconfig.lib.json"
+    },
+    {
+      "path": "../sdk-effects/oidc/tsconfig.lib.json"
+    },
+    {
+      "path": "../sdk-effects/logger/tsconfig.lib.json"
+    },
+    {
+      "path": "../sdk-effects/iframe-manager/tsconfig.lib.json"
     }
   ],
   "exclude": [

--- a/packages/sdk-effects/iframe-manager/src/lib/iframe-manager.effects.ts
+++ b/packages/sdk-effects/iframe-manager/src/lib/iframe-manager.effects.ts
@@ -18,7 +18,7 @@ export interface GetParamsFromIFrameOptions {
   errorParams: string[];
 }
 
-type ResolvedParams = Record<string, string>;
+export type ResolvedParams = Record<string, string>;
 
 type Noop = () => void;
 
@@ -48,7 +48,7 @@ function searchParamsToRecord(params: URLSearchParams): ResolvedParams {
  * Initializes the Iframe Manager effect.
  * @returns An object containing the API for managing iframe requests.
  */
-export default function iFrameManager() {
+export function iFrameManager() {
   /**
    * Creates a hidden iframe to navigate to the specified URL,
    * waits for a redirect back to the application's origin,

--- a/packages/sdk-effects/oidc/src/index.ts
+++ b/packages/sdk-effects/oidc/src/index.ts
@@ -1,2 +1,3 @@
 export * from './lib//authorize.effects.js';
 export * from './lib//authorize.types.js';
+export * from './lib/state-pkce.effects.js';

--- a/packages/sdk-effects/oidc/src/lib/authorize.effects.ts
+++ b/packages/sdk-effects/oidc/src/lib/authorize.effects.ts
@@ -32,7 +32,7 @@ export async function createAuthorizeUrl(
   const [authorizeUrlOptions, storeOptions] = generateAndStoreAuthUrlValues({
     clientId: options.clientId,
     serverConfig: { baseUrl },
-    responseType: 'code',
+    responseType: options.responseType,
     redirectUri: options.redirectUri,
     scope: options.scope,
   });

--- a/packages/sdk-effects/oidc/src/lib/authorize.types.ts
+++ b/packages/sdk-effects/oidc/src/lib/authorize.types.ts
@@ -16,6 +16,9 @@ import type { LegacyConfigOptions } from '@forgerock/sdk-types';
  */
 export type ResponseType = 'code' | 'token';
 export interface GetAuthorizationUrlOptions extends LegacyConfigOptions {
+  successParams?: string[];
+  errorParams?: string[];
+
   /**
    * These three properties clientid, scope and redirectUri are required
    * when using this type, which are not required when defining Config.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -220,7 +220,7 @@ importers:
         version: 6.2.6(@types/node@22.14.1)(jiti@2.4.2)(terser@5.42.0)(yaml@2.8.0)
       vitest:
         specifier: 3.0.5
-        version: 3.0.5(@types/node@22.14.1)(@vitest/ui@3.0.4(vitest@3.0.5))(jiti@2.4.2)(jsdom@26.1.0)(msw@2.8.5(@types/node@22.14.1)(typescript@5.8.3))(terser@5.42.0)(yaml@2.8.0)
+        version: 3.0.5(@types/node@22.14.1)(@vitest/ui@3.0.4)(jiti@2.4.2)(jsdom@26.1.0)(msw@2.8.5(@types/node@22.14.1)(typescript@5.8.3))(terser@5.42.0)(yaml@2.8.0)
       vitest-canvas-mock:
         specifier: ^0.3.3
         version: 0.3.3(vitest@3.0.5)
@@ -281,10 +281,13 @@ importers:
     devDependencies:
       '@effect/vitest':
         specifier: ^0.19.0
-        version: 0.19.10(effect@3.16.0)(vitest@3.0.5(@types/node@22.14.1)(@vitest/ui@3.0.4(vitest@3.0.5))(jiti@2.4.2)(jsdom@26.1.0)(msw@2.8.5(@types/node@22.14.1)(typescript@5.8.3))(terser@5.42.0)(yaml@2.8.0))
+        version: 0.19.10(effect@3.16.0)(vitest@3.0.5(@types/node@22.14.1)(@vitest/ui@3.0.4)(jiti@2.4.2)(jsdom@26.1.0)(msw@2.8.5(@types/node@22.14.1)(typescript@5.8.3))(terser@5.42.0)(yaml@2.8.0))
 
   e2e/oidc-app:
     dependencies:
+      '@forgerock/javascript-sdk':
+        specifier: ^4.8.2
+        version: 4.8.2
       '@forgerock/oidc-client':
         specifier: workspace:*
         version: link:../../packages/oidc-client
@@ -328,7 +331,7 @@ importers:
     devDependencies:
       vitest:
         specifier: ^3.0.4
-        version: 3.0.5(@types/node@22.14.1)(@vitest/ui@3.0.4(vitest@3.0.5))(jiti@2.4.2)(jsdom@26.1.0)(msw@2.8.5(@types/node@22.14.1)(typescript@5.8.3))(terser@5.42.0)(yaml@2.8.0)
+        version: 3.0.5(@types/node@22.14.1)(@vitest/ui@3.0.4)(jiti@2.4.2)(jsdom@26.1.0)(msw@2.8.5(@types/node@22.14.1)(typescript@5.8.3))(terser@5.42.0)(yaml@2.8.0)
 
   packages/device-client:
     dependencies:
@@ -345,12 +348,27 @@ importers:
 
   packages/oidc-client:
     dependencies:
+      '@forgerock/iframe-manager':
+        specifier: workspace:*
+        version: link:../sdk-effects/iframe-manager
+      '@forgerock/sdk-logger':
+        specifier: workspace:*
+        version: link:../sdk-effects/logger
+      '@forgerock/sdk-oidc':
+        specifier: workspace:*
+        version: link:../sdk-effects/oidc
+      '@forgerock/sdk-request-middleware':
+        specifier: workspace:*
+        version: link:../sdk-effects/sdk-request-middleware
       '@forgerock/sdk-types':
         specifier: workspace:*
         version: link:../sdk-types
       '@forgerock/storage':
         specifier: workspace:*
         version: link:../sdk-effects/storage
+      '@reduxjs/toolkit':
+        specifier: 'catalog:'
+        version: 2.8.2
 
   packages/protect:
     dependencies:
@@ -1490,6 +1508,9 @@ packages:
 
   '@forgerock/javascript-sdk@4.7.0':
     resolution: {integrity: sha512-0wpy2/ii9F9yKI3r+huqQtp6bVAeajf2+Llq25dvkfxQX19FKKi9KPPMF7JTVti6heYHyo36lxweB7xerB5UTQ==}
+
+  '@forgerock/javascript-sdk@4.8.2':
+    resolution: {integrity: sha512-vk30flcVa0ypa92YOqEPiIZlXxTF+QVrd/ADtn0G5fIAGNUE2LMKpiGVZGAooqdaT9DpAymvaXrWCV9JLDDlMA==}
 
   '@gerrit0/mini-shiki@1.27.2':
     resolution: {integrity: sha512-GeWyHz8ao2gBiUW4OJnQDxXQnFgZQwwQk05t/CVVgNBN7/rK8XZ7xY6YhLVv9tH3VppWWmr9DCl3MwemB/i+Og==}
@@ -8460,15 +8481,15 @@ snapshots:
     dependencies:
       effect: 3.16.0
 
-  '@effect/vitest@0.19.10(effect@3.16.0)(vitest@3.0.5(@types/node@22.14.1)(@vitest/ui@3.0.4(vitest@3.0.5))(jiti@2.4.2)(jsdom@26.1.0)(msw@2.8.5(@types/node@22.14.1)(typescript@5.8.3))(terser@5.42.0)(yaml@2.8.0))':
+  '@effect/vitest@0.19.10(effect@3.16.0)(vitest@3.0.5(@types/node@22.14.1)(@vitest/ui@3.0.4)(jiti@2.4.2)(jsdom@26.1.0)(msw@2.8.5(@types/node@22.14.1)(typescript@5.8.3))(terser@5.42.0)(yaml@2.8.0))':
     dependencies:
       effect: 3.16.0
-      vitest: 3.0.5(@types/node@22.14.1)(@vitest/ui@3.0.4(vitest@3.0.5))(jiti@2.4.2)(jsdom@26.1.0)(msw@2.8.5(@types/node@22.14.1)(typescript@5.8.3))(terser@5.42.0)(yaml@2.8.0)
+      vitest: 3.0.5(@types/node@22.14.1)(@vitest/ui@3.0.4)(jiti@2.4.2)(jsdom@26.1.0)(msw@2.8.5(@types/node@22.14.1)(typescript@5.8.3))(terser@5.42.0)(yaml@2.8.0)
 
   '@effect/vitest@0.6.12(effect@3.16.0)(vitest@3.0.5)':
     dependencies:
       effect: 3.16.0
-      vitest: 3.0.5(@types/node@22.14.1)(@vitest/ui@3.0.4(vitest@3.0.5))(jiti@2.4.2)(jsdom@26.1.0)(msw@2.8.5(@types/node@22.14.1)(typescript@5.8.3))(terser@5.42.0)(yaml@2.8.0)
+      vitest: 3.0.5(@types/node@22.14.1)(@vitest/ui@3.0.4)(jiti@2.4.2)(jsdom@26.1.0)(msw@2.8.5(@types/node@22.14.1)(typescript@5.8.3))(terser@5.42.0)(yaml@2.8.0)
 
   '@emnapi/core@1.4.3':
     dependencies:
@@ -8607,6 +8628,14 @@ snapshots:
   '@fastify/busboy@2.1.1': {}
 
   '@forgerock/javascript-sdk@4.7.0':
+    dependencies:
+      '@reduxjs/toolkit': 2.8.2
+      immer: 10.1.1
+    transitivePeerDependencies:
+      - react
+      - react-redux
+
+  '@forgerock/javascript-sdk@4.8.2':
     dependencies:
       '@reduxjs/toolkit': 2.8.2
       immer: 10.1.1
@@ -9166,7 +9195,7 @@ snapshots:
       semver: 7.7.2
       tsconfig-paths: 4.2.0
       vite: 6.2.6(@types/node@22.14.1)(jiti@2.4.2)(terser@5.42.0)(yaml@2.8.0)
-      vitest: 3.0.5(@types/node@22.14.1)(@vitest/ui@3.0.4(vitest@3.0.5))(jiti@2.4.2)(jsdom@26.1.0)(msw@2.8.5(@types/node@22.14.1)(typescript@5.8.3))(terser@5.42.0)(yaml@2.8.0)
+      vitest: 3.0.5(@types/node@22.14.1)(@vitest/ui@3.0.4)(jiti@2.4.2)(jsdom@26.1.0)(msw@2.8.5(@types/node@22.14.1)(typescript@5.8.3))(terser@5.42.0)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -10026,7 +10055,7 @@ snapshots:
       std-env: 3.9.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.0.5(@types/node@22.14.1)(@vitest/ui@3.0.4(vitest@3.0.5))(jiti@2.4.2)(jsdom@26.1.0)(msw@2.8.5(@types/node@22.14.1)(typescript@5.8.3))(terser@5.42.0)(yaml@2.8.0)
+      vitest: 3.0.5(@types/node@22.14.1)(@vitest/ui@3.0.4)(jiti@2.4.2)(jsdom@26.1.0)(msw@2.8.5(@types/node@22.14.1)(typescript@5.8.3))(terser@5.42.0)(yaml@2.8.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -10082,7 +10111,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.14
       tinyrainbow: 2.0.0
-      vitest: 3.0.5(@types/node@22.14.1)(@vitest/ui@3.0.4(vitest@3.0.5))(jiti@2.4.2)(jsdom@26.1.0)(msw@2.8.5(@types/node@22.14.1)(typescript@5.8.3))(terser@5.42.0)(yaml@2.8.0)
+      vitest: 3.0.5(@types/node@22.14.1)(@vitest/ui@3.0.4)(jiti@2.4.2)(jsdom@26.1.0)(msw@2.8.5(@types/node@22.14.1)(typescript@5.8.3))(terser@5.42.0)(yaml@2.8.0)
 
   '@vitest/utils@3.0.4':
     dependencies:
@@ -14942,9 +14971,9 @@ snapshots:
   vitest-canvas-mock@0.3.3(vitest@3.0.5):
     dependencies:
       jest-canvas-mock: 2.5.2
-      vitest: 3.0.5(@types/node@22.14.1)(@vitest/ui@3.0.4(vitest@3.0.5))(jiti@2.4.2)(jsdom@26.1.0)(msw@2.8.5(@types/node@22.14.1)(typescript@5.8.3))(terser@5.42.0)(yaml@2.8.0)
+      vitest: 3.0.5(@types/node@22.14.1)(@vitest/ui@3.0.4)(jiti@2.4.2)(jsdom@26.1.0)(msw@2.8.5(@types/node@22.14.1)(typescript@5.8.3))(terser@5.42.0)(yaml@2.8.0)
 
-  vitest@3.0.5(@types/node@22.14.1)(@vitest/ui@3.0.4(vitest@3.0.5))(jiti@2.4.2)(jsdom@26.1.0)(msw@2.8.5(@types/node@22.14.1)(typescript@5.8.3))(terser@5.42.0)(yaml@2.8.0):
+  vitest@3.0.5(@types/node@22.14.1)(@vitest/ui@3.0.4)(jiti@2.4.2)(jsdom@26.1.0)(msw@2.8.5(@types/node@22.14.1)(typescript@5.8.3))(terser@5.42.0)(yaml@2.8.0):
     dependencies:
       '@vitest/expect': 3.0.5
       '@vitest/mocker': 3.0.5(msw@2.8.5(@types/node@22.14.1)(typescript@5.8.3))(vite@6.2.6(@types/node@22.14.1)(jiti@2.4.2)(terser@5.42.0)(yaml@2.8.0))

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -4,6 +4,9 @@
     "declaration": true,
     "declarationMap": true,
     "skipLibCheck": true,
-    "baseUrl": "."
+    "baseUrl": ".",
+    "paths": {
+      "@sdk-effects/*": ["packages/sdk-effects/*"]
+    }
   }
 }


### PR DESCRIPTION
This starts the implementation of authorize in the oidc-client package

# JIRA Ticket

[<!--
Add a Jira ticket here if applicable
-->](https://pingidentity.atlassian.net/browse/SDKS-4051)

## Description

Initial go at adding `authorize`. i wasn't 100% sure if we wanted to delegate the parameters to the user fully, or if we wanted to also check that state's match here.

There's probably a few things that need adjusting. I think the need to expose a better way to access the state in sessionStorage than what i'm doing here also (if we want to check they match at this point?) wasn't sure about that either
