### PR TITLE
Update Protect module and E2E tests

### DIFF
--- a/e2e/davinci-suites/src/middleware.test.ts
+++ b/e2e/davinci-suites/src/middleware.test.ts
@@ -6,6 +6,7 @@
  */
 import { expect, test } from '@playwright/test';
 import { asyncEvents } from './utils/async-events.js';
+import { password, username } from './utils/demo-user.js';
 
 test('Test middleware on test page', async ({ page }) => {
   const networkArray = [];
@@ -23,6 +24,13 @@ test('Test middleware on test page', async ({ page }) => {
   expect(page.url()).toBe('http://localhost:5829/');
 
   await expect(page.getByText('Username/Password Form')).toBeVisible();
+
+  await page.getByLabel('Username').fill(username);
+  await page.getByLabel('Password').fill(password);
+
+  await page.getByRole('button', { name: 'Sign On' }).click();
+
+  await expect(page.getByText('Complete')).toBeVisible();
 
   const startRequest = networkArray.find((req) => req.url.includes('/authorize'));
   const nextRequest = networkArray.find((req) => req.url.includes('/customHTMLTemplate'));

--- a/e2e/davinci-suites/src/phone-number-field.test.ts
+++ b/e2e/davinci-suites/src/phone-number-field.test.ts
@@ -65,7 +65,7 @@ test('Login - add phone device - authenticate with phone device', async ({ page 
    * Go to page
    ***/
   expect(page.url()).toContain(
-    'http://localhost:5829/?clientId=20dd0ed0-bb9b-4c8f-9a60-9ebeb4b348e',
+    'http://localhost:5829/?clientId=20dd0ed0-bb9b-4c8f-9a60-9ebeb4b348e0',
   );
 
   /**

--- a/packages/protect/src/lib/protect.test.ts
+++ b/packages/protect/src/lib/protect.test.ts
@@ -29,7 +29,7 @@ const config: ProtectConfig = {
   disableHub: false,
 };
 
-describe('protect (success tests)', () => {
+describe('protect (with successfully loaded signals sdk)', () => {
   beforeAll(() => {
     vi.doMock('./signals-sdk.js', () => {
       return {
@@ -67,99 +67,117 @@ describe('protect (success tests)', () => {
     expect(protect).toBeDefined();
   });
 
-  it('should return protect methods', async () => {
-    const protectAPI = await protect(config);
-    expect(protectAPI).toBeDefined();
-    assertType<Protect>(protectAPI);
-    expect(protectAPI.start).toBeDefined();
-    expect(protectAPI.getData).toBeDefined();
-    expect(protectAPI.pauseBehavioralData).toBeDefined();
-    expect(protectAPI.resumeBehavioralData).toBeDefined();
-    expect(protectAPI.getPauseBehavioralData).toBeDefined();
-    expect(protectAPI.getNodeConfig).toBeDefined();
-    expect(protectAPI.getProtectType).toBeDefined();
-    expect(protectAPI.setNodeClientError).toBeDefined();
-    expect(protectAPI.setNodeInputValue).toBeDefined();
+  it('should return protect methods', () => {
+    const protectApi = protect(config);
+    expect(protectApi).toBeDefined();
+    assertType<Protect>(protectApi);
+    expect(protectApi.start).toBeDefined();
+    expect(protectApi.getData).toBeDefined();
+    expect(protectApi.pauseBehavioralData).toBeDefined();
+    expect(protectApi.resumeBehavioralData).toBeDefined();
+    expect(protectApi.getPauseBehavioralData).toBeDefined();
+    expect(protectApi.getNodeConfig).toBeDefined();
+    expect(protectApi.getProtectType).toBeDefined();
+    expect(protectApi.setNodeClientError).toBeDefined();
+    expect(protectApi.setNodeInputValue).toBeDefined();
   });
 
   describe('native node methods', () => {
     it('should call start', async () => {
-      const protectAPI = await protect(config);
-      const protectMock = vi.spyOn(protectAPI, 'start');
-      await protectAPI.start();
+      const protectApi = protect(config);
+      const protectMock = vi.spyOn(protectApi, 'start');
+      await protectApi.start();
       expect(protectMock).toHaveBeenCalled();
       expect(window._pingOneSignals.init).toHaveBeenCalledWith(config);
     });
 
     it('should call getData', async () => {
-      const protectAPI = await protect(config);
-      const protectMock = vi.spyOn(protectAPI, 'getData');
-      await protectAPI.getData();
+      const protectApi = protect(config);
+      const protectMock = vi.spyOn(protectApi, 'getData');
+      await protectApi.getData();
       expect(protectMock).toHaveBeenCalled();
     });
 
-    it('should call pauseBehavioralData', async () => {
-      const protectAPI = await protect(config);
-      const protectMock = vi.spyOn(protectAPI, 'pauseBehavioralData');
-      protectAPI.pauseBehavioralData();
+    it('should call pauseBehavioralData', () => {
+      const protectApi = protect(config);
+      const protectMock = vi.spyOn(protectApi, 'pauseBehavioralData');
+      protectApi.pauseBehavioralData();
       expect(protectMock).toHaveBeenCalled();
     });
 
-    it('should call resume behavioralData', async () => {
-      const protectAPI = await protect(config);
-      const protectMock = vi.spyOn(protectAPI, 'resumeBehavioralData');
-      protectAPI.resumeBehavioralData();
+    it('should call resumeBehavioralData', () => {
+      const protectApi = protect(config);
+      const protectMock = vi.spyOn(protectApi, 'resumeBehavioralData');
+      protectApi.resumeBehavioralData();
       expect(protectMock).toHaveBeenCalled();
+    });
+
+    it('getData should error if start has not been called', async () => {
+      const protectApi = protect(config);
+      const error = await protectApi.getData();
+      expect(error).toEqual({ error: 'PingOne Signals SDK is not initialized' });
+    });
+
+    it('pauseBehavioralData should error if start has not been called', async () => {
+      const protectApi = protect(config);
+      const error = await protectApi.pauseBehavioralData();
+      expect(error).toEqual({ error: 'PingOne Signals SDK is not initialized' });
+    });
+
+    it('resumeBehavioralData should error if start has not been called', async () => {
+      const protectApi = protect(config);
+      const error = await protectApi.resumeBehavioralData();
+      expect(error).toEqual({ error: 'PingOne Signals SDK is not initialized' });
     });
   });
 
   describe('marketplace node methods', () => {
-    it('should test getPauseBehavioralData with marketplace data', async () => {
-      const protectAPI = await protect(config);
-      const result = protectAPI.getPauseBehavioralData(standardPingProtectEvaluationStep);
+    it('should test getPauseBehavioralData with marketplace data', () => {
+      const protectApi = protect(config);
+      const result = protectApi.getPauseBehavioralData(standardPingProtectEvaluationStep);
       expect(result).toEqual(false);
 
-      const secondResult = protectAPI.getPauseBehavioralData(standardPingProtectInitializeStep);
+      const secondResult = protectApi.getPauseBehavioralData(standardPingProtectInitializeStep);
       expect(secondResult).toEqual(true);
     });
 
-    it('should get the node config', async () => {
-      const protectAPI = await protect(config);
-      const result = protectAPI.getNodeConfig(standardPingProtectInitializeStep);
+    it('should get the node config', () => {
+      const protectApi = protect(config);
+      const result = protectApi.getNodeConfig(standardPingProtectInitializeStep);
       expect(result).toEqual(
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         standardPingProtectInitializeStep!.payload.callbacks![0].output[0].value,
       );
 
-      const result2 = protectAPI.getNodeConfig(noProtectType);
+      const result2 = protectApi.getNodeConfig(noProtectType);
       expect(result2).toBeUndefined();
     });
 
-    it('should test the getPingProtectType method', async () => {
-      const protectAPI = await protect(config);
-      const result = protectAPI.getProtectType(standardPingProtectInitializeStep);
+    it('should test the getPingProtectType method', () => {
+      const protectApi = protect(config);
+      const result = protectApi.getProtectType(standardPingProtectInitializeStep);
       expect(result).toEqual('initialize');
 
-      const result2 = protectAPI.getProtectType(standardPingProtectEvaluationStep);
+      const result2 = protectApi.getProtectType(standardPingProtectEvaluationStep);
       expect(result2).toEqual('evaluate');
 
-      const result3 = protectAPI.getProtectType(noProtectType);
+      const result3 = protectApi.getProtectType(noProtectType);
       expect(result3).toEqual('none');
     });
 
-    it('should set the input with marketplace nodes', async () => {
-      const protectAPI = await protect(config);
+    it('should set the input with marketplace nodes', () => {
+      const protectApi = protect(config);
       const step = standardPingProtectEvaluationStep as FRStep;
 
-      protectAPI.setNodeInputValue(step, 'the value');
+      protectApi.setNodeInputValue(step, 'the value');
       const [hc] = step.getCallbacksOfType<HiddenValueCallback>(CallbackType.HiddenValueCallback);
 
       expect(hc.getInputValue()).toEqual('the value');
     });
 
-    it('should set an error with marketplace nodes', async () => {
-      const protectAPI = await protect(config);
-      protectAPI.setNodeClientError(standardPingProtectEvaluationStep, 'we errored!');
+    it('should set an error with marketplace nodes', () => {
+      const protectApi = protect(config);
+      protectApi.setNodeClientError(standardPingProtectEvaluationStep, 'we errored!');
 
       const [, err] = (
         standardPingProtectEvaluationStep as FRStep
@@ -170,16 +188,41 @@ describe('protect (success tests)', () => {
   });
 });
 
-describe('protect (error tests)', () => {
+describe('protect (with failed signals sdk load)', () => {
   beforeAll(() => {
     vi.doMock('./signals-sdk.js', () => {
       throw new Error('Failed to load PingOne Signals SDK');
     });
   });
+
   afterAll(() => {
     vi.doUnmock('./signals-sdk.js');
   });
-  it('should error on failed signals sdk load', async () => {
-    await expect(protect(config)).rejects.toThrowError('Failed to load PingOne Signals SDK');
+
+  it('start method should error', async () => {
+    const protectApi = protect(config);
+    const error = await protectApi.start();
+    await expect(error).toEqual({ error: 'Failed to load PingOne Signals SDK' });
+  });
+
+  it('getData method should error', async () => {
+    const protectApi = protect(config);
+    await protectApi.start();
+    const error = await protectApi.getData();
+    await expect(error).toEqual({ error: 'PingOne Signals SDK is not initialized' });
+  });
+
+  it('pauseBehavioralData method should error', async () => {
+    const protectApi = protect(config);
+    await protectApi.start();
+    const error = await protectApi.pauseBehavioralData();
+    await expect(error).toEqual({ error: 'PingOne Signals SDK is not initialized' });
+  });
+
+  it('resumeBehavioralData method should error', async () => {
+    const protectApi = protect(config);
+    await protectApi.start();
+    const error = await protectApi.resumeBehavioralData();
+    await expect(error).toEqual({ error: 'PingOne Signals SDK is not initialized' });
   });
 });

--- a/packages/protect/src/lib/protect.ts
+++ b/packages/protect/src/lib/protect.ts
@@ -41,8 +41,6 @@ declare global {
  * @param {ProtectConfig} options - the configuration options for the PingOne Signals SDK
  * @returns {Promise<Protect>} - a set of methods to interact with the PingOne Signals SDK
  */
-// TODO: Handle initialization errors
-// TODO: changeset?
 export function protect(options: ProtectConfig): Protect {
   let protectApiInitialized = false;
 

--- a/packages/protect/src/lib/protect.ts
+++ b/packages/protect/src/lib/protect.ts
@@ -41,202 +41,217 @@ declare global {
  * @param {ProtectConfig} options - the configuration options for the PingOne Signals SDK
  * @returns {Promise<Protect>} - a set of methods to interact with the PingOne Signals SDK
  */
-export async function protect(options: ProtectConfig): Promise<Protect> {
-  try {
-    /*
-     * Load the Ping Signals SDK
-     * this automatically pollutes the window
-     * there are no exports of this module
-     */
-    await import('./signals-sdk.js' as string);
-    return {
-      start: async (): Promise<void> => {
-        await window._pingOneSignals.init(options);
+// TODO: Handle initialization errors
+// TODO: changeset?
+export function protect(options: ProtectConfig): Protect {
+  let protectApiInitialized = false;
 
-        if (options.behavioralDataCollection === true) {
-          window._pingOneSignals.resumeBehavioralData();
-        }
-      },
-      getData: async (): Promise<string> => {
-        return await window._pingOneSignals.getData();
-      },
-      pauseBehavioralData: (): void => {
-        window._pingOneSignals.pauseBehavioralData();
-      },
-      resumeBehavioralData: (): void => {
+  return {
+    start: async (): Promise<void | { error: unknown }> => {
+      try {
+        /*
+         * Load the Ping Signals SDK
+         * this automatically pollutes the window
+         * there are no exports of this module
+         */
+        await import('./signals-sdk.js' as string);
+        protectApiInitialized = true;
+      } catch (err) {
+        console.error('error loading ping signals', err);
+        return { error: 'Failed to load PingOne Signals SDK' };
+      }
+
+      await window._pingOneSignals.init(options);
+
+      if (options.behavioralDataCollection === true) {
         window._pingOneSignals.resumeBehavioralData();
-      },
+      }
+    },
+    getData: async (): Promise<string | { error: unknown }> => {
+      if (!protectApiInitialized) {
+        return { error: 'PingOne Signals SDK is not initialized' };
+      }
+      return await window._pingOneSignals.getData();
+    },
+    pauseBehavioralData: (): void | { error: unknown } => {
+      if (!protectApiInitialized) {
+        return { error: 'PingOne Signals SDK is not initialized' };
+      }
+      window._pingOneSignals.pauseBehavioralData();
+    },
+    resumeBehavioralData: (): void | { error: unknown } => {
+      if (!protectApiInitialized) {
+        return { error: 'PingOne Signals SDK is not initialized' };
+      }
+      window._pingOneSignals.resumeBehavioralData();
+    },
 
-      /** ***********************************************************************************************
-       * The following methods are required when using the Ping Protect Marketplace nodes, which has
-       * generic callbacks, but can be used for native nodes and/or either callback type.
-       *
-       * TODO: Marketplace node verfication with these methods has not yet been completed
-       */
+    /** ***********************************************************************************************
+     * The following methods are required when using the Ping Protect Marketplace nodes, which has
+     * generic callbacks, but can be used for native nodes and/or either callback type.
+     *
+     * TODO: Marketplace node verfication with these methods has not yet been completed
+     */
 
-      getPauseBehavioralData: (step: FRStep): boolean => {
-        // Check for native callback first
-        try {
-          const nativeCallback = step.getCallbackOfType<PingOneProtectEvaluationCallback>(
-            CallbackType.PingOneProtectEvaluationCallback,
-          );
-
-          const shouldPause = nativeCallback?.getPauseBehavioralData();
-          return shouldPause || false;
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        } catch (err) {
-          // Do nothing
-        }
-
-        // If we are here, we are dealing with Marketplace nodes
-        const cbs = step.getCallbacksOfType<MetadataCallback>(CallbackType.MetadataCallback);
-
-        if (!cbs.length) {
-          return false;
-        }
-
-        const protectMetadataCb = cbs.find((metadataCallback: MetadataCallback) => {
-          const data = metadataCallback.getData() as { _type: string; _action: string };
-          return data._type === 'PingOneProtect';
-        });
-
-        if (!protectMetadataCb) {
-          return false;
-        }
-
-        const data: ProtectInitializeConfig | ProtectEvaluationConfig = (
-          protectMetadataCb as MetadataCallback
-        ).getData();
-
-        if (data._action === 'protect_risk_evaluation') {
-          return false;
-        } else {
-          return !!(data as ProtectInitializeConfig).behavioralDataCollection;
-        }
-      },
-      getNodeConfig: (step: FRStep): ProtectInitializeConfig | undefined => {
-        // Check for native callback first
-        try {
-          const nativeCallback = step.getCallbackOfType<PingOneProtectInitializeCallback>(
-            CallbackType.PingOneProtectInitializeCallback,
-          );
-
-          const config = nativeCallback?.getConfig() as ProtectInitializeConfig;
-          return config;
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        } catch (err) {
-          // Do nothing
-        }
-
-        const cbs = step.getCallbacksOfType<MetadataCallback>(CallbackType.MetadataCallback);
-
-        if (!cbs.length) {
-          return undefined;
-        }
-
-        const protectMetadataCb = cbs.find((metadataCallback) => {
-          const data = metadataCallback.getData() as { _type: string; _action: string };
-          return data._action === 'protect_initialize';
-        });
-
-        if (!protectMetadataCb) {
-          return undefined;
-        }
-
-        const data = (protectMetadataCb as MetadataCallback).getData() as ProtectInitializeConfig;
-
-        return data;
-      },
-      getProtectType: (step: FRStep): ProtectType => {
-        const cbs = step.getCallbacksOfType(CallbackType.MetadataCallback);
-
-        if (!cbs.length) {
-          return 'none';
-        }
-
-        const protectMetadataCb = cbs.find((cb) => {
-          const metadataCallback = cb as MetadataCallback;
-          const data = metadataCallback.getData() as { _type: string; _action: string };
-          return data._type === 'PingOneProtect';
-        });
-
-        if (!protectMetadataCb) {
-          return 'none';
-        }
-
-        const data = (protectMetadataCb as MetadataCallback).getData() as ProtectInitializeConfig;
-
-        return data._action === 'protect_initialize' ? 'initialize' : 'evaluate';
-      },
-      setNodeClientError: (step: FRStep, value: string): void => {
-        // Check for native callback first
-        const nativeEvaluationCallback = step.getCallbacksOfType<PingOneProtectEvaluationCallback>(
+    getPauseBehavioralData: (step: FRStep): boolean => {
+      // Check for native callback first
+      try {
+        const nativeCallback = step.getCallbackOfType<PingOneProtectEvaluationCallback>(
           CallbackType.PingOneProtectEvaluationCallback,
         );
-        const nativeInitializeCallback = step.getCallbacksOfType<PingOneProtectInitializeCallback>(
+
+        const shouldPause = nativeCallback?.getPauseBehavioralData();
+        return shouldPause || false;
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      } catch (err) {
+        // Do nothing
+      }
+
+      // If we are here, we are dealing with Marketplace nodes
+      const cbs = step.getCallbacksOfType<MetadataCallback>(CallbackType.MetadataCallback);
+
+      if (!cbs.length) {
+        return false;
+      }
+
+      const protectMetadataCb = cbs.find((metadataCallback: MetadataCallback) => {
+        const data = metadataCallback.getData() as { _type: string; _action: string };
+        return data._type === 'PingOneProtect';
+      });
+
+      if (!protectMetadataCb) {
+        return false;
+      }
+
+      const data: ProtectInitializeConfig | ProtectEvaluationConfig = (
+        protectMetadataCb as MetadataCallback
+      ).getData();
+
+      if (data._action === 'protect_risk_evaluation') {
+        return false;
+      } else {
+        return !!(data as ProtectInitializeConfig).behavioralDataCollection;
+      }
+    },
+    getNodeConfig: (step: FRStep): ProtectInitializeConfig | undefined => {
+      // Check for native callback first
+      try {
+        const nativeCallback = step.getCallbackOfType<PingOneProtectInitializeCallback>(
           CallbackType.PingOneProtectInitializeCallback,
         );
-        const arr = [...nativeEvaluationCallback, ...nativeInitializeCallback];
 
-        if (arr.length) {
-          const cb = arr[0];
-          cb.setClientError(value);
-          return;
-        }
+        const config = nativeCallback?.getConfig() as ProtectInitializeConfig;
+        return config;
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      } catch (err) {
+        // Do nothing
+      }
 
-        // If we are here, we are dealing with Marketplace nodes
-        const cbs = step.getCallbacksOfType<HiddenValueCallback>(CallbackType.HiddenValueCallback);
+      const cbs = step.getCallbacksOfType<MetadataCallback>(CallbackType.MetadataCallback);
 
-        if (!cbs.length) {
-          return;
-        }
+      if (!cbs.length) {
+        return undefined;
+      }
 
-        const clientErrorCb = cbs.find((hiddenValueCallback) => {
-          const output = hiddenValueCallback.getOutputByName<string>('id', '');
-          return output === 'clientError';
-        });
+      const protectMetadataCb = cbs.find((metadataCallback) => {
+        const data = metadataCallback.getData() as { _type: string; _action: string };
+        return data._action === 'protect_initialize';
+      });
 
-        if (!clientErrorCb) {
-          return;
-        }
+      if (!protectMetadataCb) {
+        return undefined;
+      }
 
-        clientErrorCb.setInputValue(value);
-      },
-      setNodeInputValue: (step: FRStep, value: string): void => {
-        // Check for native callback first
-        try {
-          const nativeCallback = step.getCallbackOfType<PingOneProtectEvaluationCallback>(
-            CallbackType.PingOneProtectEvaluationCallback,
-          );
+      const data = (protectMetadataCb as MetadataCallback).getData() as ProtectInitializeConfig;
 
-          nativeCallback?.setData(value);
-          return;
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        } catch (err) {
-          // Do nothing
-        }
+      return data;
+    },
+    getProtectType: (step: FRStep): ProtectType => {
+      const cbs = step.getCallbacksOfType(CallbackType.MetadataCallback);
 
-        // If we are here, we are dealing with Marketplace nodes
-        const cbs = step.getCallbacksOfType<HiddenValueCallback>(CallbackType.HiddenValueCallback);
+      if (!cbs.length) {
+        return 'none';
+      }
 
-        if (!cbs.length) {
-          return;
-        }
+      const protectMetadataCb = cbs.find((cb) => {
+        const metadataCallback = cb as MetadataCallback;
+        const data = metadataCallback.getData() as { _type: string; _action: string };
+        return data._type === 'PingOneProtect';
+      });
 
-        const inputCb = cbs.find((hiddenValueCallback) => {
-          const output = hiddenValueCallback.getOutputByName<string>('id', '');
-          return output === 'pingone_risk_evaluation_signals';
-        });
+      if (!protectMetadataCb) {
+        return 'none';
+      }
 
-        if (!inputCb) {
-          return;
-        }
+      const data = (protectMetadataCb as MetadataCallback).getData() as ProtectInitializeConfig;
 
-        inputCb.setInputValue(value);
-      },
-    };
-  } catch (err) {
-    console.error('error loading ping signals', err);
-    throw new Error('Failed to load PingOne Signals SDK');
-  }
+      return data._action === 'protect_initialize' ? 'initialize' : 'evaluate';
+    },
+    setNodeClientError: (step: FRStep, value: string): void => {
+      // Check for native callback first
+      const nativeEvaluationCallback = step.getCallbacksOfType<PingOneProtectEvaluationCallback>(
+        CallbackType.PingOneProtectEvaluationCallback,
+      );
+      const nativeInitializeCallback = step.getCallbacksOfType<PingOneProtectInitializeCallback>(
+        CallbackType.PingOneProtectInitializeCallback,
+      );
+      const arr = [...nativeEvaluationCallback, ...nativeInitializeCallback];
+
+      if (arr.length) {
+        const cb = arr[0];
+        cb.setClientError(value);
+        return;
+      }
+
+      // If we are here, we are dealing with Marketplace nodes
+      const cbs = step.getCallbacksOfType<HiddenValueCallback>(CallbackType.HiddenValueCallback);
+
+      if (!cbs.length) {
+        return;
+      }
+
+      const clientErrorCb = cbs.find((hiddenValueCallback) => {
+        const output = hiddenValueCallback.getOutputByName<string>('id', '');
+        return output === 'clientError';
+      });
+
+      if (!clientErrorCb) {
+        return;
+      }
+
+      clientErrorCb.setInputValue(value);
+    },
+    setNodeInputValue: (step: FRStep, value: string): void => {
+      // Check for native callback first
+      try {
+        const nativeCallback = step.getCallbackOfType<PingOneProtectEvaluationCallback>(
+          CallbackType.PingOneProtectEvaluationCallback,
+        );
+
+        nativeCallback?.setData(value);
+        return;
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      } catch (err) {
+        // Do nothing
+      }
+
+      // If we are here, we are dealing with Marketplace nodes
+      const cbs = step.getCallbacksOfType<HiddenValueCallback>(CallbackType.HiddenValueCallback);
+
+      if (!cbs.length) {
+        return;
+      }
+
+      const inputCb = cbs.find((hiddenValueCallback) => {
+        const output = hiddenValueCallback.getOutputByName<string>('id', '');
+        return output === 'pingone_risk_evaluation_signals';
+      });
+
+      if (!inputCb) {
+        return;
+      }
+
+      inputCb.setInputValue(value);
+    },
+  };
 }

--- a/packages/protect/src/lib/protect.types.ts
+++ b/packages/protect/src/lib/protect.types.ts
@@ -99,30 +99,30 @@ export interface Protect {
   /**
    * @async
    * @method start - Method to initialize and start the PingOne Signals SDK
-   * @returns {Promise<void>} - Returns a promise
+   * @returns {Promise<void | { error: unknown }>} - Returns an error if PingOne Signals SDK failed to load
    */
-  start: () => Promise<void>;
+  start: () => Promise<void | { error: unknown }>;
 
   /**
    * @async
    * @method getData - Method to get the device data
-   * @returns {Promise<string>} - Returns the device data
+   * @returns {Promise<string | { error: unknown }>} - Returns the device data or an error if PingOne Signals SDK failed to load
    */
-  getData: () => Promise<string>;
+  getData: () => Promise<string | { error: unknown }>;
 
   /**
    * @method pauseBehavioralData - Method to pause the behavioral data collection
-   * @returns {void}
+   * @returns {void | { error: unknown }} - Returns an error if PingOne Signals SDK failed to load
    * @description Pause the behavioral data collection only; device profile data will still be collected
    */
-  pauseBehavioralData: () => void;
+  pauseBehavioralData: () => void | { error: unknown };
 
   /**
    * @method resumeBehavioralData - Method to resume the behavioral data collection
-   * @returns {void}
+   * @returns {void | { error: unknown }} - Returns an error if PingOne Signals SDK failed to load
    * @description Resume the behavioral data collection
    */
-  resumeBehavioralData: () => void;
+  resumeBehavioralData: () => void | { error: unknown };
 
   /**
    * @method getPauseBehavioralData


### PR DESCRIPTION
## Description

This PR updates the protect module to be synchronous and also fixes the E2E middleware test which was failing when we removed the `protectsdk` start node from our DaVinci test flow. These changes are necessary for the ProtectCollector implementation within the React DaVinci sample app (see https://pingidentity.atlassian.net/browse/SDKS-4147)

No changeset is necessary since the protect module is still ignored.
