### PR TITLE
Fix Vite vulnerability

### DIFF
--- a/e2e/davinci-suites/src/phone-number-field.test.ts
+++ b/e2e/davinci-suites/src/phone-number-field.test.ts
@@ -59,7 +59,10 @@ test('Login - add email device - authenticate with email device', async ({ page 
   await page.getByRole('heading', { name: 'Success' });
   await page.getByRole('button', { name: 'Start over' }).click();
 });
-test('Login - add phone device - authenticate with phone device', async ({ page }) => {
+
+// This test is failing due to a new phone number feature flag for pre-filling country codes.
+// A fix will be addressed in https://pingidentity.atlassian.net/browse/SDKS-4200
+test.skip('Login - add phone device - authenticate with phone device', async ({ page }) => {
   await page.goto('/?clientId=20dd0ed0-bb9b-4c8f-9a60-9ebeb4b348e0');
   /***
    * Go to page

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "typescript": "5.8.3",
     "typescript-eslint": "^8.19.0",
     "verdaccio": "6.1.2",
-    "vite": "6.2.6",
+    "vite": "6.3.4",
     "vitest": "catalog:vitest",
     "vitest-canvas-mock": "^0.3.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,7 +58,7 @@ importers:
         version: 2.29.5
       '@codecov/vite-plugin':
         specifier: 1.9.0
-        version: 1.9.0(vite@6.2.6(@types/node@22.14.1)(jiti@2.4.2)(terser@5.43.1)(tsx@4.17.0)(yaml@2.8.1))
+        version: 1.9.0(vite@6.3.4(@types/node@22.14.1)(jiti@2.4.2)(terser@5.43.1)(tsx@4.17.0)(yaml@2.8.1))
       '@commitlint/cli':
         specifier: ^19.1.0
         version: 19.8.1(@types/node@22.14.1)(typescript@5.8.3)
@@ -100,7 +100,7 @@ importers:
         version: 21.2.3(@babel/traverse@7.28.0)(@swc-node/register@1.10.10(@swc/core@1.11.21(@swc/helpers@0.5.17))(@swc/types@0.1.24)(typescript@5.8.3))(@swc/core@1.11.21(@swc/helpers@0.5.17))(@types/node@22.14.1)(@zkochan/js-yaml@0.0.7)(babel-plugin-macros@3.1.0)(eslint@9.33.0(jiti@2.4.2))(nx@21.2.3(@swc-node/register@1.10.10(@swc/core@1.11.21(@swc/helpers@0.5.17))(@swc/types@0.1.24)(typescript@5.8.3))(@swc/core@1.11.21(@swc/helpers@0.5.17)))(ts-node@10.9.2(@swc/core@1.11.21(@swc/helpers@0.5.17))(@types/node@22.14.1)(typescript@5.8.3))(typescript@5.8.3)(verdaccio@6.1.2(typanion@3.14.0))
       '@nx/vite':
         specifier: 21.2.3
-        version: 21.2.3(@babel/traverse@7.28.0)(@swc-node/register@1.10.10(@swc/core@1.11.21(@swc/helpers@0.5.17))(@swc/types@0.1.24)(typescript@5.8.3))(@swc/core@1.11.21(@swc/helpers@0.5.17))(nx@21.2.3(@swc-node/register@1.10.10(@swc/core@1.11.21(@swc/helpers@0.5.17))(@swc/types@0.1.24)(typescript@5.8.3))(@swc/core@1.11.21(@swc/helpers@0.5.17)))(typescript@5.8.3)(verdaccio@6.1.2(typanion@3.14.0))(vite@6.2.6(@types/node@22.14.1)(jiti@2.4.2)(terser@5.43.1)(tsx@4.17.0)(yaml@2.8.1))(vitest@3.2.4)
+        version: 21.2.3(@babel/traverse@7.28.0)(@swc-node/register@1.10.10(@swc/core@1.11.21(@swc/helpers@0.5.17))(@swc/types@0.1.24)(typescript@5.8.3))(@swc/core@1.11.21(@swc/helpers@0.5.17))(nx@21.2.3(@swc-node/register@1.10.10(@swc/core@1.11.21(@swc/helpers@0.5.17))(@swc/types@0.1.24)(typescript@5.8.3))(@swc/core@1.11.21(@swc/helpers@0.5.17)))(typescript@5.8.3)(verdaccio@6.1.2(typanion@3.14.0))(vite@6.3.4(@types/node@22.14.1)(jiti@2.4.2)(terser@5.43.1)(tsx@4.17.0)(yaml@2.8.1))(vitest@3.2.4)
       '@nx/web':
         specifier: 21.2.3
         version: 21.2.3(@babel/traverse@7.28.0)(@swc-node/register@1.10.10(@swc/core@1.11.21(@swc/helpers@0.5.17))(@swc/types@0.1.24)(typescript@5.8.3))(@swc/core@1.11.21(@swc/helpers@0.5.17))(nx@21.2.3(@swc-node/register@1.10.10(@swc/core@1.11.21(@swc/helpers@0.5.17))(@swc/types@0.1.24)(typescript@5.8.3))(@swc/core@1.11.21(@swc/helpers@0.5.17)))(verdaccio@6.1.2(typanion@3.14.0))
@@ -234,8 +234,8 @@ importers:
         specifier: 6.1.2
         version: 6.1.2(typanion@3.14.0)
       vite:
-        specifier: 6.2.6
-        version: 6.2.6(@types/node@22.14.1)(jiti@2.4.2)(terser@5.43.1)(tsx@4.17.0)(yaml@2.8.1)
+        specifier: 6.3.4
+        version: 6.3.4(@types/node@22.14.1)(jiti@2.4.2)(terser@5.43.1)(tsx@4.17.0)(yaml@2.8.1)
       vitest:
         specifier: catalog:vitest
         version: 3.2.4(@types/node@22.14.1)(@vitest/ui@3.0.4)(jiti@2.4.2)(jsdom@26.1.0)(msw@2.10.4(@types/node@22.14.1)(typescript@5.8.3))(terser@5.43.1)(tsx@4.17.0)(yaml@2.8.1)
@@ -488,7 +488,7 @@ importers:
         specifier: catalog:effect
         version: 3.17.7
       vitest:
-        specifier: 3.2.4
+        specifier: catalog:vitest
         version: 3.2.4(@types/node@22.14.1)(@vitest/ui@3.0.4)(jiti@2.4.2)(jsdom@26.1.0)(msw@2.10.4(@types/node@22.14.1)(typescript@5.8.3))(terser@5.43.1)(tsx@4.17.0)(yaml@2.8.1)
     devDependencies:
       '@effect/language-service':
@@ -7423,8 +7423,8 @@ packages:
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
-  vite@6.2.6:
-    resolution: {integrity: sha512-9xpjNl3kR4rVDZgPNdTL0/c6ao4km69a/2ihNQbcANz8RuCOK3hQBmLSJf3bRKVQjVMda+YvizNE8AwvogcPbw==}
+  vite@6.3.4:
+    resolution: {integrity: sha512-BiReIiMS2fyFqbqNT/Qqt4CVITDU9M9vE+DKcVAsB+ZV0wvTKd+3hMbkpxz1b+NmEDMegpVbisKiAZOnvO92Sw==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
@@ -8700,11 +8700,11 @@ snapshots:
       unplugin: 1.16.1
       zod: 3.25.76
 
-  '@codecov/vite-plugin@1.9.0(vite@6.2.6(@types/node@22.14.1)(jiti@2.4.2)(terser@5.43.1)(tsx@4.17.0)(yaml@2.8.1))':
+  '@codecov/vite-plugin@1.9.0(vite@6.3.4(@types/node@22.14.1)(jiti@2.4.2)(terser@5.43.1)(tsx@4.17.0)(yaml@2.8.1))':
     dependencies:
       '@codecov/bundler-plugin-core': 1.9.1
       unplugin: 1.16.1
-      vite: 6.2.6(@types/node@22.14.1)(jiti@2.4.2)(terser@5.43.1)(tsx@4.17.0)(yaml@2.8.1)
+      vite: 6.3.4(@types/node@22.14.1)(jiti@2.4.2)(terser@5.43.1)(tsx@4.17.0)(yaml@2.8.1)
 
   '@commitlint/cli@19.8.1(@types/node@22.14.1)(typescript@5.8.3)':
     dependencies:
@@ -9778,7 +9778,7 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/vite@21.2.3(@babel/traverse@7.28.0)(@swc-node/register@1.10.10(@swc/core@1.11.21(@swc/helpers@0.5.17))(@swc/types@0.1.24)(typescript@5.8.3))(@swc/core@1.11.21(@swc/helpers@0.5.17))(nx@21.2.3(@swc-node/register@1.10.10(@swc/core@1.11.21(@swc/helpers@0.5.17))(@swc/types@0.1.24)(typescript@5.8.3))(@swc/core@1.11.21(@swc/helpers@0.5.17)))(typescript@5.8.3)(verdaccio@6.1.2(typanion@3.14.0))(vite@6.2.6(@types/node@22.14.1)(jiti@2.4.2)(terser@5.43.1)(tsx@4.17.0)(yaml@2.8.1))(vitest@3.2.4)':
+  '@nx/vite@21.2.3(@babel/traverse@7.28.0)(@swc-node/register@1.10.10(@swc/core@1.11.21(@swc/helpers@0.5.17))(@swc/types@0.1.24)(typescript@5.8.3))(@swc/core@1.11.21(@swc/helpers@0.5.17))(nx@21.2.3(@swc-node/register@1.10.10(@swc/core@1.11.21(@swc/helpers@0.5.17))(@swc/types@0.1.24)(typescript@5.8.3))(@swc/core@1.11.21(@swc/helpers@0.5.17)))(typescript@5.8.3)(verdaccio@6.1.2(typanion@3.14.0))(vite@6.3.4(@types/node@22.14.1)(jiti@2.4.2)(terser@5.43.1)(tsx@4.17.0)(yaml@2.8.1))(vitest@3.2.4)':
     dependencies:
       '@nx/devkit': 21.2.3(nx@21.2.3(@swc-node/register@1.10.10(@swc/core@1.11.21(@swc/helpers@0.5.17))(@swc/types@0.1.24)(typescript@5.8.3))(@swc/core@1.11.21(@swc/helpers@0.5.17)))
       '@nx/js': 21.2.3(@babel/traverse@7.28.0)(@swc-node/register@1.10.10(@swc/core@1.11.21(@swc/helpers@0.5.17))(@swc/types@0.1.24)(typescript@5.8.3))(@swc/core@1.11.21(@swc/helpers@0.5.17))(nx@21.2.3(@swc-node/register@1.10.10(@swc/core@1.11.21(@swc/helpers@0.5.17))(@swc/types@0.1.24)(typescript@5.8.3))(@swc/core@1.11.21(@swc/helpers@0.5.17)))(verdaccio@6.1.2(typanion@3.14.0))
@@ -9789,7 +9789,7 @@ snapshots:
       picomatch: 4.0.2
       semver: 7.7.2
       tsconfig-paths: 4.2.0
-      vite: 6.2.6(@types/node@22.14.1)(jiti@2.4.2)(terser@5.43.1)(tsx@4.17.0)(yaml@2.8.1)
+      vite: 6.3.4(@types/node@22.14.1)(jiti@2.4.2)(terser@5.43.1)(tsx@4.17.0)(yaml@2.8.1)
       vitest: 3.2.4(@types/node@22.14.1)(@vitest/ui@3.0.4)(jiti@2.4.2)(jsdom@26.1.0)(msw@2.10.4(@types/node@22.14.1)(typescript@5.8.3))(terser@5.43.1)(tsx@4.17.0)(yaml@2.8.1)
     transitivePeerDependencies:
       - '@babel/traverse'
@@ -10735,14 +10735,14 @@ snapshots:
       chai: 5.2.1
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(msw@2.10.4(@types/node@22.14.1)(typescript@5.8.3))(vite@6.2.6(@types/node@22.14.1)(jiti@2.4.2)(terser@5.43.1)(tsx@4.17.0)(yaml@2.8.1))':
+  '@vitest/mocker@3.2.4(msw@2.10.4(@types/node@22.14.1)(typescript@5.8.3))(vite@6.3.4(@types/node@22.14.1)(jiti@2.4.2)(terser@5.43.1)(tsx@4.17.0)(yaml@2.8.1))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
       msw: 2.10.4(@types/node@22.14.1)(typescript@5.8.3)
-      vite: 6.2.6(@types/node@22.14.1)(jiti@2.4.2)(terser@5.43.1)(tsx@4.17.0)(yaml@2.8.1)
+      vite: 6.3.4(@types/node@22.14.1)(jiti@2.4.2)(terser@5.43.1)(tsx@4.17.0)(yaml@2.8.1)
 
   '@vitest/pretty-format@3.0.4':
     dependencies:
@@ -15696,7 +15696,7 @@ snapshots:
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.2.6(@types/node@22.14.1)(jiti@2.4.2)(terser@5.43.1)(tsx@4.17.0)(yaml@2.8.1)
+      vite: 6.3.4(@types/node@22.14.1)(jiti@2.4.2)(terser@5.43.1)(tsx@4.17.0)(yaml@2.8.1)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -15711,11 +15711,14 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.2.6(@types/node@22.14.1)(jiti@2.4.2)(terser@5.43.1)(tsx@4.17.0)(yaml@2.8.1):
+  vite@6.3.4(@types/node@22.14.1)(jiti@2.4.2)(terser@5.43.1)(tsx@4.17.0)(yaml@2.8.1):
     dependencies:
       esbuild: 0.25.8
+      fdir: 6.4.6(picomatch@4.0.3)
+      picomatch: 4.0.3
       postcss: 8.5.6
       rollup: 4.46.2
+      tinyglobby: 0.2.14
     optionalDependencies:
       '@types/node': 22.14.1
       fsevents: 2.3.3
@@ -15733,7 +15736,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(msw@2.10.4(@types/node@22.14.1)(typescript@5.8.3))(vite@6.2.6(@types/node@22.14.1)(jiti@2.4.2)(terser@5.43.1)(tsx@4.17.0)(yaml@2.8.1))
+      '@vitest/mocker': 3.2.4(msw@2.10.4(@types/node@22.14.1)(typescript@5.8.3))(vite@6.3.4(@types/node@22.14.1)(jiti@2.4.2)(terser@5.43.1)(tsx@4.17.0)(yaml@2.8.1))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -15751,7 +15754,7 @@ snapshots:
       tinyglobby: 0.2.14
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 6.2.6(@types/node@22.14.1)(jiti@2.4.2)(terser@5.43.1)(tsx@4.17.0)(yaml@2.8.1)
+      vite: 6.3.4(@types/node@22.14.1)(jiti@2.4.2)(terser@5.43.1)(tsx@4.17.0)(yaml@2.8.1)
       vite-node: 3.2.4(@types/node@22.14.1)(jiti@2.4.2)(terser@5.43.1)(tsx@4.17.0)(yaml@2.8.1)
       why-is-node-running: 2.3.0
     optionalDependencies:

--- a/tools/user-scripts/package.json
+++ b/tools/user-scripts/package.json
@@ -18,7 +18,7 @@
     "@effect/platform": "catalog:effect",
     "@effect/platform-node": "catalog:effect",
     "effect": "catalog:effect",
-    "vitest": "3.2.4"
+    "vitest": "catalog:vitest"
   },
   "devDependencies": {
     "@effect/language-service": "catalog:effect",


### PR DESCRIPTION
Fixes issue #360. Mend Security Check assessed that there was a vulnerability in vite v6.2.6. I've upgraded to v6.3.4 as advised [here](https://github.com/advisories/GHSA-859w-5945-r5v3).

Note: Phone number field test has been skipped. It is failing due to a pre-fill country code feature flag being turned on.
https://pingidentity.slack.com/archives/GNFNZBFE3/p1755560007399209
