### PR TITLE
SDKS-4361: Improve storage client type

### DIFF
--- a/.changeset/slow-teeth-melt.md
+++ b/.changeset/slow-teeth-melt.md
@@ -1,0 +1,7 @@
+---
+'@forgerock/storage': minor
+'@forgerock/oidc-client': minor
+---
+
+- Standardizes return types on storage client and updates tests
+- Improves OIDC client where storage client methods are used

--- a/packages/oidc-client/src/lib/client.store.test.ts
+++ b/packages/oidc-client/src/lib/client.store.test.ts
@@ -13,6 +13,8 @@ import { oidc } from './client.store.js';
 
 import type { OidcConfig } from './config.types.js';
 
+Object.defineProperty(global, 'localStorage', { value: null });
+
 vi.stubGlobal(
   'sessionStorage',
   (() => {

--- a/packages/oidc-client/src/lib/client.store.ts
+++ b/packages/oidc-client/src/lib/client.store.ts
@@ -372,14 +372,10 @@ export async function oidc<ActionType extends ActionTypes = ActionTypes>({
           // Delete local token and return combined results
           Micro.flatMap((revokeResponse) =>
             Micro.promise(() => storageClient.remove()).pipe(
-              Micro.flatMap((deleteRes) => {
-                const deleteResponse = typeof deleteRes === 'undefined' ? null : deleteRes;
-
+              Micro.flatMap((deleteResponse) => {
                 const isInnerRequestError =
                   (revokeResponse && 'error' in revokeResponse) ||
-                  (deleteResponse &&
-                    typeof deleteResponse === 'object' &&
-                    'error' in deleteResponse);
+                  (deleteResponse && 'error' in deleteResponse);
 
                 if (isInnerRequestError) {
                   const result: RevokeErrorResult = {

--- a/packages/oidc-client/src/lib/client.types.ts
+++ b/packages/oidc-client/src/lib/client.types.ts
@@ -9,20 +9,25 @@ export interface GetTokensOptions {
 }
 
 export type RevokeSuccessResult = {
+  revokeResponse: null;
+  deleteResponse: null;
+};
+
+export type RevokeErrorResult = {
+  error: string;
   revokeResponse: GenericError | null;
   deleteResponse: GenericError | null;
 };
 
-export type RevokeErrorResult = RevokeSuccessResult & {
-  error: string;
-};
-
 export type LogoutSuccessResult = RevokeSuccessResult & {
-  sessionResponse: GenericError | null;
+  sessionResponse: null;
 };
 
-export type LogoutErrorResult = LogoutSuccessResult & {
+export type LogoutErrorResult = {
   error: string;
+  sessionResponse: GenericError | null;
+  revokeResponse: GenericError | null;
+  deleteResponse: GenericError | null;
 };
 
 export type UserInfoResponse = {

--- a/packages/oidc-client/src/lib/logout.request.test.ts
+++ b/packages/oidc-client/src/lib/logout.request.test.ts
@@ -66,6 +66,9 @@ const config: OidcConfig = {
   responseType: 'code',
 };
 
+Object.defineProperty(global, 'sessionStorage', { value: null });
+Object.defineProperty(global, 'localStorage', { value: null });
+
 const customStorage: Record<string, string> = {};
 const storageClient = createStorage<OauthTokens>({
   type: 'custom',

--- a/packages/sdk-types/src/lib/tokens.types.ts
+++ b/packages/sdk-types/src/lib/tokens.types.ts
@@ -5,6 +5,8 @@
  * of the MIT license. See the LICENSE file for details.
  */
 
+import type { GenericError } from './error.types.js';
+
 export interface Tokens {
   accessToken: string;
   idToken?: string;
@@ -16,7 +18,7 @@ export interface Tokens {
  * API for implementing a custom token store
  */
 export interface CustomStorageObject {
-  get: (key: string) => Promise<string | null>;
-  set: (key: string, valueToSet: string) => Promise<void>;
-  remove: (key: string) => Promise<void>;
+  get: (key: string) => Promise<string | null | GenericError>;
+  set: (key: string, valueToSet: string) => Promise<void | GenericError>;
+  remove: (key: string) => Promise<void | GenericError>;
 }


### PR DESCRIPTION
# JIRA Ticket

https://pingidentity.atlassian.net/browse/SDKS-4361

## Description

- standardizes `set` and `remove` storage client return type to `GenericError | null`
- updates storage unit tests to check for errors in custom storage
- improves OIDC client where storage client methods are used

Added changeset minor for OIDC client and storage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Revoke/logout flows: clearer success/error signaling and more consistent surfaced responses.
  - Storage operations now return null on success and standardized structured error objects on failure.

- Refactor
  - Unified storage behavior and standardized error shape (GenericError) across backends.
  - Result/response types for revoke/logout/storage clarified and consolidated.

- Tests
  - Expanded storage and logout tests for success, error, and complex-value scenarios.

- Chores
  - Dependency and changelog updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->