### PR TITLE
ci: use-trusted-publishers

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,22 +3,46 @@ on:
   push:
     branches:
       - main
+  # allow other workflows to call this one (for snapshots)
+  workflow_call:
+    inputs:
+      branch:
+        description: 'Branch or ref to publish from'
+        required: false
+        type: string
+        default: 'main'
+      dist_tag:
+        description: 'npm dist-tag'
+        required: false
+        type: string
+        default: 'beta'
+      prerelease:
+        description: 'changesets prerelease tag (e.g., beta, canary)'
+        required: false
+        type: string
+        default: 'beta'
+      access:
+        description: 'npm access'
+        required: false
+        type: string
+        default: 'public'
+
 env:
   NX_CLOUD_ENCRYPTION_KEY: ${{ secrets.NX_CLOUD_ENCRYPTION_KEY }}
   NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
   NX_CLOUD_DISTRIBUTED_EXECUTION: true
   PNPM_CACHE_FOLDER: .pnpm-store
-  NPM_ACCESS_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
   CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   CI: true
 
 jobs:
   publish-or-pr:
+    if: github.event_name == 'push'
     permissions:
-      contents: write #  to create release (changesets/action)
-      issues: write # to post issue comments (changesets/action)
-      pull-requests: write #  to create pull request (changesets/action)
-      id-token: write # give id token write for provenance
+      contents: write # changesets/action
+      issues: write
+      pull-requests: write
+      id-token: write # OIDC for provenance if npm publish happens here
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -36,8 +60,6 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      # This line enables distribution
-      # The "--stop-agents-after" is optional, but allows idle agents to shut down once the "e2e-ci" targets have been requested
       - run: pnpm dlx nx-cloud start-ci-run --distribute-on=".nx/workflows/dynamic-changesets.yml" --stop-agents-after="e2e-ci" --with-env-vars="CODECOV_TOKEN"
 
       - name: Cache Playwright browsers
@@ -77,11 +99,8 @@ jobs:
           commit: 'chore: version-packages'
           setupGitUser: true
         env:
-          # See https://github.com/changesets/action/issues/147
           HOME: ${{ github.workspace }}
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-          NPM_CONFIG_PROVENANCE: 'true'
-          NPM_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
 
       - name: Send GitHub Action data to a Slack workflow
         if: steps.changesets.outputs.published == 'true'
@@ -119,26 +138,85 @@ jobs:
         with:
           folder: docs
           commit-message: 'chore: release-api-docs-beta'
-          target-folder: 'beta' # we push to beta folder when we are updating "main"
+          target-folder: 'beta'
 
-      # Calculate and save baseline bundle sizes
       - name: Calculate baseline bundle sizes
         run: |
           chmod +x ./scripts/bundle-sizes.sh
-
-          # Don't use any previous baseline for main branch - always create fresh
           rm -f previous_sizes.json
-
           echo "📊 Calculating fresh baseline bundle sizes for main branch"
           ./scripts/bundle-sizes.sh
-
           echo "✅ Baseline bundle sizes calculated"
           cat previous_sizes.json
 
-      # Save baseline for PR comparisons
       - name: Upload baseline bundle sizes
         uses: actions/upload-artifact@v4
         with:
           name: bundle-size-baseline
           path: previous_sizes.json
-          retention-days: 30 # Keep baseline for 30 days
+          retention-days: 30
+
+  # --- new reusable job used by the snapshot wrapper ---
+  trusted-publish:
+    if: ${{ github.event_name == 'workflow_call' }}
+    name: Trusted Snapshot Publish
+    permissions:
+      contents: write # read+write repo (okay for artifacts/logs)
+      id-token: write # REQUIRED: OIDC for npm Trusted Publishers
+      issues: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    env:
+      HUSKY: 0
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.branch }}
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.node-version'
+          cache: 'pnpm'
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm dlx nx-cloud start-ci-run --distribute-on=".nx/workflows/dynamic-changesets.yml" --stop-agents-after="e2e-ci" --with-env-vars="CODECOV_TOKEN"
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
+      - run: pnpm exec playwright install
+
+      - uses: nrwl/nx-set-shas@v4
+        with:
+          main-branch-name: main
+
+      - name: setup pnpm config
+        run: pnpm config set store-dir $PNPM_CACHE_FOLDER
+
+      - run: pnpm exec nx run-many -t build test e2e-ci
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: |
+            ./**/.playwright/**
+          retention-days: 30
+
+      - name: Version Packages as prerelease
+        run: pnpm changeset version --snapshot ${{ inputs.prerelease }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+
+      # The actual npm publish that must occur in the authorized file
+      - name: Publish packages with dist-tag
+        run: pnpm publish -r --tag ${{ inputs.dist_tag }} --no-git-checks --access ${{ inputs.access }}

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -2,107 +2,24 @@ name: Snapshots
 on:
   workflow_dispatch:
     inputs:
-      registry:
-        description: 'Npm Registry or Private Registry'
-        required: false
-        default: 'https://registry.npmjs.org/'
-        type: choice
-        options:
-          - https://registry.npmjs.org/
-          - https://npm.petrov.ca
       branch:
         description: 'Branch to publish from'
         required: false
         default: 'main'
         type: string
 
-env:
-  NX_CLOUD_ENCRYPTION_KEY: ${{ secrets.NX_CLOUD_ENCRYPTION_KEY }}
-  NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
-  NX_CLOUD_DISTRIBUTED_EXECUTION: true
-  PNPM_CACHE_FOLDER: .pnpm-store
-  NPM_ACCESS_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
-  CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-  HUSKY: 0
-
 jobs:
-  publish-snapshot:
+  call-trusted-publish:
+    name: Call trusted publish (beta dist-tag)
+    uses: ./.github/workflows/publish.yml
+    with:
+      branch: ${{ inputs.branch }}
+      dist_tag: beta
+      prerelease: beta
+      access: public
     permissions:
-      contents: write #  to create release (changesets/action)
-      issues: write # to post issue comments (changesets/action)
-      pull-requests: write #  to create pull request (changesets/action)
-      id-token: write # give id token write for provenance
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: ${{ inputs.branch }}
-      - uses: pnpm/action-setup@v4
-        with:
-          run_install: false
-      - uses: actions/setup-node@v4
-        id: cache
-        with:
-          node-version-file: '.node-version'
-          cache: 'pnpm'
-
-      - run: pnpm install --frozen-lockfile
-
-      # This line enables distribution
-      # The "--stop-agents-after" is optional, but allows idle agents to shut down once the "e2e-ci" targets have been requested
-      - run: pnpm dlx nx-cloud start-ci-run --distribute-on=".nx/workflows/dynamic-changesets.yml" --stop-agents-after="e2e-ci" --with-env-vars="CODECOV_TOKEN"
-
-      - name: Cache Playwright browsers
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-playwright-
-
-      - run: pnpm exec playwright install
-
-      - uses: nrwl/nx-set-shas@v4
-        with:
-          main-branch-name: main
-
-      - name: setup pnpm config
-        run: pnpm config set store-dir $PNPM_CACHE_FOLDER
-
-      - run: pnpm exec nx run-many -t build test e2e-ci
-
-      - uses: actions/upload-artifact@v4
-        if: ${{ !cancelled() }}
-        with:
-          name: playwright-report
-          path: |
-            ./**/.playwright/**
-          retention-days: 30
-
-      - name: Update npmrc
-        run: |
-          cat << EOF > ".npmrc"
-            //registry.npmjs.org/:_authToken=$NPM_TOKEN
-            //npm.petrov.ca/:_authToken=$NPM_TOKEN
-          EOF
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
-      - name: Version Packages as Beta
-        run: pnpm changeset version --snapshot beta
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-
-      - name: Publish packages as beta
-        if: ${{ inputs.registry == 'https://registry.npmjs.org/' }}
-        run: pnpm publish -r --tag beta --no-git-checks --registry ${{ inputs.registry }}
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
-          NPM_CONFIG_PROVENANCE: 'true' # make sure provenance is working on beta releases to npm
-
-      - name: Publish packages as beta
-        if: ${{ inputs.registry != 'https://registry.npmjs.org/' }}
-        run: pnpm publish -r --tag beta --no-git-checks --registry ${{ inputs.registry }}
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
-          NPM_CONFIG_PROVENANCE: false # verdaccio doesn't support provenance
+      contents: write
+      id-token: write
+      issues: write
+      pull-requests: write
+    secrets: inherit


### PR DESCRIPTION
# JIRA Ticket
N/A

## Description
From a security perspective, we should leverage the npm trusted publishers instead of NPM tokens. This enforces publishes come from a pipeline and not anywhere else.

This also removes the use of tokens from the pipeline because there is a trusted setup between the package (on npm) and the pipeline.

A package _must_ be published first before this can be setup, so in order to publish the package first, we should publish a beta (can do it in ci or locally).

@cerebrl to review this, please go through the packages on `npm` and verify you see the trusted publishers setup with the correct github repository & the correct workflow file (publish.yml)

because we can only have 1 workflow defined as "trusted" this breaks our old "snapshot.yml".

to ensure this functionality, we have the snapshot.yml "call" the publish.yml, but a different job.

the publish-or-pr job should remain unchanged.

the publish.yml should have a trusted publish job that is specifically allowing itself to be called from another workflow (snapshot.yml) so the publish still occurs from the trusted workflow.

we can also remove tokens from this workflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reworked CI to consolidate publishing into a reusable, callable trusted-publish workflow that centralizes build, test, and publish steps.
  * Streamlined inputs, reduced permissions, and moved to OIDC-style provenance to improve security and maintainability.
  * Simplified snapshot flow to call the trusted publish path and standardized beta dist-tag and deployment targets.
* **Notes**
  * No user-facing behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->