### PR TITLE
ci: change-event-for-publish-snapshot

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -158,7 +158,7 @@ jobs:
 
   # --- new reusable job used by the snapshot wrapper ---
   trusted-publish:
-    if: ${{ github.event_name == 'workflow_call' }}
+    if: ${{ github.event_name != 'push' }}
     name: Trusted Snapshot Publish
     permissions:
       contents: write # read+write repo (okay for artifacts/logs)


### PR DESCRIPTION
# JIRA Ticket

n/a
## Description

the event was wrong which made snapshots not work. sorry!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release publishing workflow to run on more event types, ensuring the Trusted Snapshot Publish step executes consistently during non-push events. This broadens automation coverage and reduces the chance of missed publishes. Improves reliability of the release pipeline and transparency in publishing. No changes to product features or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->