### PR TITLE
ci: update-npm-cli

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,6 +57,9 @@ jobs:
           cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Update npm
+        run: npm install -g npm@latest
+
       - run: pnpm install --frozen-lockfile
 
       - run: pnpm dlx nx-cloud start-ci-run --distribute-on=".nx/workflows/dynamic-changesets.yml" --stop-agents-after="e2e-ci" --with-env-vars="CODECOV_TOKEN"
@@ -178,6 +181,9 @@ jobs:
         with:
           node-version-file: '.node-version'
           cache: 'pnpm'
+
+      - name: Update npm
+        run: npm install -g npm@latest
 
       - run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
# JIRA Ticket

N/A

## Description

Ok, have to force npm cli because it was defaulting to v10 and it needs to be 11.5.1 or >

https://docs.npmjs.com/trusted-publishers#step-2-configure-your-cicd-workflow
