### PR TITLE
chore: init-nix

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,8 @@
+# Ensure Nix is available even in non-login shells (what direnv uses)
+if [ -r /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then
+  . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+elif [ -r "$HOME/.nix-profile/etc/profile.d/nix.sh" ]; then
+  . "$HOME/.nix-profile/etc/profile.d/nix.sh"
+fi
+
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,9 @@ test-output
 # Gemini local knowledge base files
 GEMINI.md
 **/GEMINI.md
+
+# Nix and direnv
+.direnv/
+result*
+!.envrc
+

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,39 @@
+{
+  description = "Development environment for the ping-javascript-sdk monorepo";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        # Get the pkgs set for the specific system
+        pkgs = import nixpkgs { inherit system; };
+
+        # Node.js version from your .node-version file
+        nodejs = pkgs.nodejs_22;
+      in
+      {
+        # The `devShell` is the development environment activated by `nix develop`
+        devShells.default = pkgs.mkShell {
+          # The packages available in the development shell.
+          packages = [
+            nodejs
+            pkgs.pnpm
+            pkgs.git
+          ];
+
+          shellHook = ''
+            # This hook runs when you enter the shell
+            echo "---"
+            echo "Welcome to the Nix development environment for ping-javascript-sdk!"
+            echo ""
+            echo "Node.js version: $(node --version)"
+            echo "pnpm version: $(pnpm --version)"
+            echo "---"
+          '';
+        };
+      });
+}


### PR DESCRIPTION
# JIRA Ticket
N/A

## Description
This is an interesting concept. Granted we probably don't _need_ it. but I trialied it here for now.

This type of setup probably could happen in the sdk-samples because it is language agnostic but also probably interesting in other parts of the company.


This has 0 effect on any day to day operations as they are now.

You can setup nix locally & `cachix` and then have a 1:1 reproducible setup between ci and your local env.

if you setup direnv, it will automatically spawn the nix env and you won't need to do anything otherwise

`nix develop` will start the shell, and load everything needed to run the sdk, node, pnpm. you can call all your normal commands in the terminal.

cachix caches every nix step. because nix steps are fully reproducible, this also carries to ci, that every step is cached / reproducible.

for now, it seems cachix is free because we are OSS.


