### PR TITLE
fix(oidc-client): append query params when provided

### DIFF
--- a/.changeset/vast-dogs-make.md
+++ b/.changeset/vast-dogs-make.md
@@ -1,0 +1,6 @@
+---
+'@forgerock/sdk-oidc': patch
+'@forgerock/oidc-client': patch
+---
+
+Append query params to authorization url when provided

--- a/packages/oidc-client/src/lib/authorize.request.ts
+++ b/packages/oidc-client/src/lib/authorize.request.ts
@@ -37,7 +37,7 @@ export function authorizeµ(
   options?: GetAuthorizationUrlOptions,
 ) {
   return buildAuthorizeOptionsµ(wellknown, config, options).pipe(
-    Micro.flatMap(([url, config, options]) => createAuthorizeUrlµ(url, config, options)),
+    Micro.flatMap(([url, options]) => createAuthorizeUrlµ(url, options)),
     Micro.tap((url) => log.debug('Authorize URL created', url)),
     Micro.tapError((url) => Micro.sync(() => log.error('Error creating authorize URL', url))),
     Micro.flatMap(

--- a/packages/oidc-client/src/lib/authorize.request.utils.test.ts
+++ b/packages/oidc-client/src/lib/authorize.request.utils.test.ts
@@ -39,7 +39,6 @@ it.effect('buildAuthorizeOptionsµ succeeds with BuildAuthorizationData', () =>
 
     expect(result).toStrictEqual([
       wellknown.authorization_endpoint,
-      config,
       {
         clientId,
         redirectUri,
@@ -56,7 +55,6 @@ it.effect('buildAuthorizeOptionsµ with pi.flow succeeds with BuildAuthorization
 
     expect(result).toStrictEqual([
       wellknown.authorization_endpoint,
-      config,
       {
         clientId,
         redirectUri,

--- a/packages/oidc-client/src/lib/authorize.request.utils.ts
+++ b/packages/oidc-client/src/lib/authorize.request.utils.ts
@@ -12,14 +12,13 @@ import type { WellKnownResponse, GetAuthorizationUrlOptions } from '@forgerock/s
 import type { AuthorizationError, AuthorizationSuccess } from './authorize.request.types.js';
 import type { OidcConfig } from './config.types.js';
 
-type BuildAuthorizationData = [string, OidcConfig, GetAuthorizationUrlOptions];
+type BuildAuthorizationData = [string, GetAuthorizationUrlOptions];
 export type OptionalAuthorizeOptions = Partial<GetAuthorizationUrlOptions>;
 
 /**
  * @function buildAuthorizeOptionsµ
  * @description Builds the authorization options for the OIDC client.
  * @param {WellKnownResponse} wellknown - The well-known configuration for the OIDC server.
- * @param {OidcConfig} config - The OIDC client configuration.
  * @param {OptionalAuthorizeOptions} options - Optional parameters for the authorization request.
  * @returns {Micro.Micro<BuildAuthorizationData, AuthorizeErrorResponse, never>}
  */
@@ -32,7 +31,6 @@ export function buildAuthorizeOptionsµ(
   return Micro.sync(
     (): BuildAuthorizationData => [
       wellknown.authorization_endpoint,
-      config,
       {
         clientId: config.clientId,
         redirectUri: config.redirectUri,
@@ -91,13 +89,11 @@ export function createAuthorizeErrorµ(
  * @function createAuthorizeUrlµ
  * @description Creates an authorization URL and related options/config for the Authorize request.
  * @param {string} path - The path to the authorization endpoint.
- * @param { OidcConfig } config - The OIDC client configuration.
  * @param { GetAuthorizationUrlOptions } options - Optional parameters for the authorization request.
- * @returns { Micro.Micro<[string, OidcConfig, GetAuthorizationUrlOptions], AuthorizationError, never> }
+ * @returns { Micro.Micro<[string, GetAuthorizationUrlOptions], AuthorizationError, never> }
  */
 export function createAuthorizeUrlµ(
   path: string,
-  config: OidcConfig,
   options: GetAuthorizationUrlOptions,
 ): Micro.Micro<[string, GetAuthorizationUrlOptions], AuthorizationError, never> {
   return Micro.tryPromise({

--- a/packages/sdk-effects/oidc/src/lib/authorize.effects.ts
+++ b/packages/sdk-effects/oidc/src/lib/authorize.effects.ts
@@ -40,6 +40,7 @@ export async function createAuthorizeUrl(
   const challenge = await createChallenge(authorizeUrlOptions.verifier);
 
   const requestParams = new URLSearchParams({
+    ...options.query,
     code_challenge: challenge,
     code_challenge_method: 'S256',
     client_id: options.clientId,

--- a/packages/sdk-effects/oidc/src/lib/authorize.test.ts
+++ b/packages/sdk-effects/oidc/src/lib/authorize.test.ts
@@ -83,6 +83,42 @@ describe('createAuthorizeUrl', () => {
     expect(params.get('response_mode')).toBe(responseMode);
   });
 
+  it('should include query parameters when provided', async () => {
+    const queryA = 'valueA';
+    const queryB = 'valueB';
+    const optionsWithOptionals: GenerateAndStoreAuthUrlValues = {
+      ...mockOptions,
+      query: {
+        queryA,
+        queryB,
+      },
+    };
+
+    const url = await createAuthorizeUrl(baseUrl, optionsWithOptionals);
+    const params = new URL(url).searchParams;
+
+    expect(params.get('queryA')).toBe(queryA);
+    expect(params.get('queryB')).toBe(queryB);
+  });
+
+  it('should ensure standard config params override conflicting query params', async () => {
+    const optionsWithConflict: GenerateAndStoreAuthUrlValues = {
+      ...mockOptions,
+      query: {
+        client_id: 'malicious-client',
+        custom_param: 'value',
+      },
+    };
+
+    const url = await createAuthorizeUrl(baseUrl, optionsWithConflict);
+    const params = new URL(url).searchParams;
+
+    // Standard param should override query param
+    expect(params.get('client_id')).toBe(mockOptions.clientId);
+    // Custom param should be preserved
+    expect(params.get('custom_param')).toBe('value');
+  });
+
   it('should store the authorize options in session storage', async () => {
     await createAuthorizeUrl(baseUrl, mockOptions);
     const storageKey = getStorageKey(mockOptions.clientId);


### PR DESCRIPTION
# JIRA Ticket

https://pingidentity.atlassian.net/browse/SDKS-4445

## Description

Bug fix. Appends query params to authorization url when provided in options to `oidcClient.tokens.get` or `oidcClient.authorize`. Adds unit test.

Includes patch changeset


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Authorization URLs now accept and append custom query parameters from request options, while ensuring standard auth parameters take precedence.

* **Tests**
  * Added tests verifying query parameters are included and that standard params override conflicting query values.

* **Chores**
  * Added a changelog entry and applied patch-level package updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->