### PR TITLE
chore(oidc-client): re-export necessary types

### DIFF
--- a/e2e/oidc-app/package.json
+++ b/e2e/oidc-app/package.json
@@ -9,9 +9,7 @@
     "serve": "pnpm nx nxServe"
   },
   "dependencies": {
-    "@forgerock/javascript-sdk": "^4.8.2",
-    "@forgerock/oidc-client": "workspace:*",
-    "@forgerock/sdk-types": "workspace:*"
+    "@forgerock/oidc-client": "workspace:*"
   },
   "nx": {
     "tags": ["scope:e2e"]

--- a/e2e/oidc-app/tsconfig.app.json
+++ b/e2e/oidc-app/tsconfig.app.json
@@ -20,9 +20,6 @@
   "include": ["src/**/*.ts"],
   "references": [
     {
-      "path": "../../packages/sdk-types/tsconfig.lib.json"
-    },
-    {
       "path": "../../packages/oidc-client/tsconfig.lib.json"
     }
   ]

--- a/e2e/oidc-app/tsconfig.json
+++ b/e2e/oidc-app/tsconfig.json
@@ -4,9 +4,6 @@
   "include": [],
   "references": [
     {
-      "path": "../../packages/sdk-types"
-    },
-    {
       "path": "../../packages/oidc-client"
     },
     {

--- a/packages/oidc-client/README.md
+++ b/packages/oidc-client/README.md
@@ -4,21 +4,22 @@ A generic OpenID Connect (OIDC) client library for JavaScript and TypeScript, de
 
 ```js
 // Initialize OIDC Client
-const oidcClient = oidc({
+const oidcClient = await oidc({
   /* config */
 });
 
 // Authorize API
-const authResponse = oidcClient.authorize.background(); // Returns code and state if successful, error and Auth URL if not
-const authUrl = oidcClient.authorize.url(); // Returns Auth URL or error
+const authResponse = await oidcClient.authorize.background(); // Returns code and state if successful, error if not
+const authUrl = await oidcClient.authorize.url(); // Returns Auth URL or error
 
 // Tokens API
-const newTokens = oidcClient.token.exchange({
+const newTokens = await oidcClient.token.exchange({
   /* code, state */
 }); // Returns new tokens or error
-const existingTokens = oidcClient.token.get(); // Returns existing tokens or error
+const existingTokens = await oidcClient.token.get(); // Returns existing tokens or error
+const response = await oidcClient.token.revoke(); // Revokes an access token and returns the response or an error
 
 // User API
-const user = oidcClient.user.info(); // Returns user object or error
-const logoutResponse = oidcClient.user.logout(); // Returns null or error
+const user = await oidcClient.user.info(); // Returns user object or error
+const logoutResponse = await oidcClient.user.logout(); // Logs the user out and returns the response or an error
 ```

--- a/packages/oidc-client/src/lib/authorize.request.ts
+++ b/packages/oidc-client/src/lib/authorize.request.ts
@@ -12,13 +12,12 @@ import {
   buildAuthorizeOptionsµ,
   createAuthorizeErrorµ,
 } from './authorize.request.utils.js';
-
-import type { GetAuthorizationUrlOptions, WellKnownResponse } from '@forgerock/sdk-types';
-
-import type { AuthorizationError, AuthorizationSuccess } from './authorize.request.types.js';
-import type { createClientStore } from './client.store.utils.js';
-import type { OidcConfig } from './config.types.js';
 import { oidcApi } from './oidc.api.js';
+
+import type { ClientStore } from './client.types.js';
+import type { GetAuthorizationUrlOptions, WellKnownResponse } from '@forgerock/sdk-types';
+import type { AuthorizationError, AuthorizationSuccess } from './authorize.request.types.js';
+import type { OidcConfig } from './config.types.js';
 
 /**
  * @function authorizeµ
@@ -26,6 +25,7 @@ import { oidcApi } from './oidc.api.js';
  * @param {WellKnownResponse} wellknown - The well-known configuration for the OIDC server.
  * @param {OidcConfig} config - The OIDC client configuration.
  * @param {CustomLogger} log - The logger instance for logging debug information.
+ * @param {ClientStore} store - The Redux store instance for managing OIDC state.
  * @param {GetAuthorizationUrlOptions} options - Optional parameters for the authorization request.
  * @returns {Micro.Micro<AuthorizationSuccess, AuthorizationError, never>} - A micro effect that resolves to the authorization response.
  */
@@ -33,7 +33,7 @@ export function authorizeµ(
   wellknown: WellKnownResponse,
   config: OidcConfig,
   log: CustomLogger,
-  store: ReturnType<typeof createClientStore>,
+  store: ClientStore,
   options?: GetAuthorizationUrlOptions,
 ) {
   return buildAuthorizeOptionsµ(wellknown, config, options).pipe(

--- a/packages/oidc-client/src/lib/authorize.request.types.ts
+++ b/packages/oidc-client/src/lib/authorize.request.types.ts
@@ -4,6 +4,10 @@
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
  */
+import type { GetAuthorizationUrlOptions } from '@forgerock/sdk-types';
+
+export type BuildAuthorizationData = [string, GetAuthorizationUrlOptions];
+export type OptionalAuthorizeOptions = Partial<GetAuthorizationUrlOptions>;
 export interface AuthorizeErrorResponse {
   id?: string;
   code?: string;

--- a/packages/oidc-client/src/lib/authorize.request.utils.ts
+++ b/packages/oidc-client/src/lib/authorize.request.utils.ts
@@ -8,19 +8,20 @@ import { createAuthorizeUrl } from '@forgerock/sdk-oidc';
 import { Micro } from 'effect';
 
 import type { WellKnownResponse, GetAuthorizationUrlOptions } from '@forgerock/sdk-types';
-
-import type { AuthorizationError, AuthorizationSuccess } from './authorize.request.types.js';
+import type {
+  AuthorizationError,
+  AuthorizationSuccess,
+  BuildAuthorizationData,
+  OptionalAuthorizeOptions,
+} from './authorize.request.types.js';
 import type { OidcConfig } from './config.types.js';
-
-type BuildAuthorizationData = [string, GetAuthorizationUrlOptions];
-export type OptionalAuthorizeOptions = Partial<GetAuthorizationUrlOptions>;
 
 /**
  * @function buildAuthorizeOptionsµ
  * @description Builds the authorization options for the OIDC client.
  * @param {WellKnownResponse} wellknown - The well-known configuration for the OIDC server.
  * @param {OptionalAuthorizeOptions} options - Optional parameters for the authorization request.
- * @returns {Micro.Micro<BuildAuthorizationData, AuthorizeErrorResponse, never>}
+ * @returns {Micro.Micro<BuildAuthorizationData, AuthorizationError, never>}
  */
 export function buildAuthorizeOptionsµ(
   wellknown: WellKnownResponse,
@@ -50,7 +51,7 @@ export function buildAuthorizeOptionsµ(
  * @param {WellKnownResponse} wellknown- The well-known configuration for the OIDC server.
  * @param { OidcConfig } config- The OIDC client configuration.
  * @param { GetAuthorizationUrlOptions } options- Optional parameters for the authorization request.
- * @returns { Micro.Micro<never, AuthorizeErrorResponse, never> }
+ * @returns { Micro.Micro<never, AuthorizationError, never> }
  */
 export function createAuthorizeErrorµ(
   res: { error: string; error_description: string },
@@ -121,7 +122,6 @@ export function createAuthorizeUrlµ(
 export function handleResponseµ(
   response: AuthorizationSuccess | AuthorizationError,
   wellknown: WellKnownResponse,
-  config: OidcConfig,
   options: GetAuthorizationUrlOptions,
 ): Micro.Micro<AuthorizationSuccess, AuthorizationError, never> {
   if ('code' in response) {

--- a/packages/oidc-client/src/lib/authorize.slice.ts
+++ b/packages/oidc-client/src/lib/authorize.slice.ts
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query';
 
 const authorizeSlice = createApi({

--- a/packages/oidc-client/src/lib/client.store.ts
+++ b/packages/oidc-client/src/lib/client.store.ts
@@ -4,9 +4,9 @@
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
  */
-import { CustomLogger, logger as loggerFn, LogLevel } from '@forgerock/sdk-logger';
+import { logger as loggerFn } from '@forgerock/sdk-logger';
 import { createAuthorizeUrl } from '@forgerock/sdk-oidc';
-import { createStorage, StorageConfig } from '@forgerock/storage';
+import { createStorage } from '@forgerock/storage';
 import { Micro } from 'effect';
 import { exitIsFail, exitIsSuccess } from 'effect/Micro';
 
@@ -18,6 +18,8 @@ import { wellknownApi, wellknownSelector } from './wellknown.api.js';
 
 import type { ActionTypes, RequestMiddleware } from '@forgerock/sdk-request-middleware';
 import type { GenericError, GetAuthorizationUrlOptions } from '@forgerock/sdk-types';
+import type { CustomLogger, LogLevel } from '@forgerock/sdk-logger';
+import type { StorageConfig } from '@forgerock/storage';
 
 import type {
   GetTokensOptions,

--- a/packages/oidc-client/src/lib/client.store.utils.ts
+++ b/packages/oidc-client/src/lib/client.store.utils.ts
@@ -5,14 +5,14 @@
  * of the MIT license. See the LICENSE file for details.
  */
 import type { ActionTypes, RequestMiddleware } from '@forgerock/sdk-request-middleware';
-import type { logger as loggerFn } from '@forgerock/sdk-logger';
+import { logger as loggerFn } from '@forgerock/sdk-logger';
 
-import { configureStore, SerializedError } from '@reduxjs/toolkit';
+import { configureStore, type SerializedError } from '@reduxjs/toolkit';
 import { oidcApi } from './oidc.api.js';
 import { wellknownApi } from './wellknown.api.js';
 
 import type { GenericError } from '@forgerock/sdk-types';
-import { FetchBaseQueryError } from '@reduxjs/toolkit/query';
+import type { FetchBaseQueryError } from '@reduxjs/toolkit/query';
 
 /**
  * @function createClientStore
@@ -113,9 +113,3 @@ export function createTokenError(type: 'no_tokens' | 'no_access_token' | 'no_id_
 
   return error;
 }
-
-type ClientStore = typeof createClientStore;
-
-export type RootState = ReturnType<ReturnType<ClientStore>['getState']>;
-
-export type AppDispatch = ReturnType<ReturnType<ClientStore>['dispatch']>;

--- a/packages/oidc-client/src/lib/client.types.ts
+++ b/packages/oidc-client/src/lib/client.types.ts
@@ -1,5 +1,18 @@
+/*
+ * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
 import type { GenericError, GetAuthorizationUrlOptions } from '@forgerock/sdk-types';
 import type { StorageConfig } from '@forgerock/storage';
+import { createClientStore } from './client.store.utils.js';
+
+export type ClientStore = ReturnType<typeof createClientStore>;
+
+export type RootState = ReturnType<ClientStore['getState']>;
+
+export type AppDispatch = ReturnType<ClientStore['dispatch']>;
 
 export interface GetTokensOptions {
   authorizeOptions?: GetAuthorizationUrlOptions;

--- a/packages/oidc-client/src/lib/exchange.request.ts
+++ b/packages/oidc-client/src/lib/exchange.request.ts
@@ -10,11 +10,11 @@ import { logger } from '@forgerock/sdk-logger';
 
 import { createValuesµ, handleTokenResponseµ, validateValuesµ } from './exchange.utils.js';
 import { oidcApi } from './oidc.api.js';
-import { createClientStore } from './client.store.utils.js';
 
+import type { ClientStore } from './client.types.js';
 import type { OauthTokens, OidcConfig } from './config.types.js';
-import type { StorageConfig } from 'node_modules/@forgerock/storage/src/lib/storage.effects.js';
-import { TokenExchangeErrorResponse } from './exchange.types.js';
+import type { StorageConfig } from '@forgerock/storage';
+import type { TokenExchangeErrorResponse } from './exchange.types.js';
 
 interface BuildTokenExchangeµParams {
   code: string;
@@ -22,7 +22,7 @@ interface BuildTokenExchangeµParams {
   endpoint: string;
   log: ReturnType<typeof logger>;
   state: string;
-  store: ReturnType<typeof createClientStore>;
+  store: ClientStore;
   options?: Partial<StorageConfig>;
 }
 

--- a/packages/oidc-client/src/lib/exchange.types.ts
+++ b/packages/oidc-client/src/lib/exchange.types.ts
@@ -4,7 +4,7 @@
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
  */
-import { OidcConfig } from './config.types.js';
+import type { OidcConfig } from './config.types.js';
 
 export interface TokenExchangeResponse {
   access_token: string;

--- a/packages/oidc-client/src/lib/exchange.utils.test.ts
+++ b/packages/oidc-client/src/lib/exchange.utils.test.ts
@@ -7,8 +7,8 @@
 import { it, expect } from '@effect/vitest';
 import { Micro } from 'effect';
 import { handleTokenResponseµ, validateValuesµ } from './exchange.utils.js';
-import { OidcConfig } from './config.types.js';
-import { GetAuthorizationUrlOptions } from '@forgerock/sdk-types';
+import type { OidcConfig } from './config.types.js';
+import type { GetAuthorizationUrlOptions } from '@forgerock/sdk-types';
 
 const clientId = '123456789';
 const redirectUri = 'https://example.com/callback.html';

--- a/packages/oidc-client/src/lib/exchange.utils.ts
+++ b/packages/oidc-client/src/lib/exchange.utils.ts
@@ -4,8 +4,8 @@
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
  */
-import { SerializedError } from '@reduxjs/toolkit';
-import { FetchBaseQueryError } from '@reduxjs/toolkit/query';
+import type { SerializedError } from '@reduxjs/toolkit';
+import type { FetchBaseQueryError } from '@reduxjs/toolkit/query';
 import { Micro } from 'effect';
 
 import { getStoredAuthUrlValues } from '@forgerock/sdk-oidc';

--- a/packages/oidc-client/src/lib/logout.request.test.ts
+++ b/packages/oidc-client/src/lib/logout.request.test.ts
@@ -8,13 +8,12 @@ import { it, expect, describe } from '@effect/vitest';
 import { Micro } from 'effect';
 import { deepStrictEqual } from 'node:assert';
 import { setupServer } from 'msw/node';
+import { http, HttpResponse } from 'msw';
 import { logoutµ } from './logout.request.js';
-import { OauthTokens, OidcConfig } from './config.types.js';
 import { createStorage } from '@forgerock/storage';
 import { createClientStore } from './client.store.utils.js';
 import { logger as loggerFn } from '@forgerock/sdk-logger';
-
-import { http, HttpResponse } from 'msw';
+import type { OauthTokens, OidcConfig } from './config.types.js';
 
 const server = setupServer(
   // Ping AM End Session

--- a/packages/oidc-client/src/lib/logout.request.ts
+++ b/packages/oidc-client/src/lib/logout.request.ts
@@ -6,11 +6,12 @@
  */
 import { Micro } from 'effect';
 import { oidcApi } from './oidc.api.js';
-import { createClientStore, createLogoutError } from './client.store.utils.js';
+import { createLogoutError } from './client.store.utils.js';
+
 import type { OauthTokens, OidcConfig } from './config.types.js';
 import type { WellKnownResponse } from '@forgerock/sdk-types';
 import type { StorageClient } from '@forgerock/storage';
-import type { LogoutErrorResult, LogoutSuccessResult } from './client.types.js';
+import type { ClientStore, LogoutErrorResult, LogoutSuccessResult } from './client.types.js';
 
 export function logoutµ({
   tokens,
@@ -22,7 +23,7 @@ export function logoutµ({
   tokens: OauthTokens;
   config: OidcConfig;
   wellknown: WellKnownResponse;
-  store: ReturnType<typeof createClientStore>;
+  store: ClientStore;
   storageClient: StorageClient<OauthTokens>;
 }) {
   return Micro.zip(

--- a/packages/oidc-client/src/lib/oidc.api.ts
+++ b/packages/oidc-client/src/lib/oidc.api.ts
@@ -1,18 +1,28 @@
-import { createApi, FetchArgs, fetchBaseQuery, FetchBaseQueryError } from '@reduxjs/toolkit/query';
-import { OidcConfig } from './config.types.js';
+/*
+ * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+import {
+  createApi,
+  fetchBaseQuery,
+  type FetchArgs,
+  type FetchBaseQueryError,
+} from '@reduxjs/toolkit/query';
+import type { OidcConfig } from './config.types.js';
 import { transformError } from './oidc.api.utils.js';
-
-import type { logger as loggerFn } from '@forgerock/sdk-logger';
+import { iFrameManager } from '@forgerock/iframe-manager';
 import {
   initQuery,
   type ActionTypes,
   type RequestMiddleware,
 } from '@forgerock/sdk-request-middleware';
 
+import type { logger as loggerFn } from '@forgerock/sdk-logger';
 import type { TokenExchangeResponse } from './exchange.types.js';
-import { AuthorizationSuccess, AuthorizeSuccessResponse } from './authorize.request.types.js';
-import { iFrameManager } from '@forgerock/iframe-manager';
-import { UserInfoResponse } from './client.types.js';
+import type { AuthorizationSuccess, AuthorizeSuccessResponse } from './authorize.request.types.js';
+import type { UserInfoResponse } from './client.types.js';
 
 interface Extras<ActionType extends ActionTypes = ActionTypes, Payload = unknown> {
   requestMiddleware: RequestMiddleware<ActionType, Payload>[];

--- a/packages/oidc-client/src/lib/wellknown.api.ts
+++ b/packages/oidc-client/src/lib/wellknown.api.ts
@@ -7,9 +7,8 @@
 import { createSelector } from '@reduxjs/toolkit';
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query';
 
-import { WellKnownResponse } from '@forgerock/sdk-types';
-
-import type { RootState } from './client.store.utils.js';
+import type { WellKnownResponse } from '@forgerock/sdk-types';
+import type { RootState } from './client.types.js';
 
 export const wellknownApi = createApi({
   reducerPath: 'wellknown',

--- a/packages/oidc-client/src/types.ts
+++ b/packages/oidc-client/src/types.ts
@@ -3,15 +3,16 @@
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
  */
-
-// Re-export types from internal packages that consumers need
-export type { LogLevel, CustomLogger } from '@forgerock/sdk-logger';
-export type { RequestMiddleware } from '@forgerock/sdk-request-middleware';
-export type { GenericError, GetAuthorizationUrlOptions } from '@forgerock/sdk-types';
-export type { StorageConfig } from '@forgerock/storage';
-
-// Re-export local types
 export * from './lib/client.types.js';
 export * from './lib/config.types.js';
 export * from './lib/authorize.request.types.js';
 export * from './lib/exchange.types.js';
+
+export type {
+  GenericError,
+  GetAuthorizationUrlOptions,
+  WellKnownResponse,
+} from '@forgerock/sdk-types';
+export type { ActionTypes, RequestMiddleware } from '@forgerock/sdk-request-middleware';
+export type { CustomLogger, LogLevel } from '@forgerock/sdk-logger';
+export type { StorageConfig } from '@forgerock/storage';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,44 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-catalogs:
-  default:
-    '@reduxjs/toolkit':
-      specifier: ^2.8.2
-      version: 2.10.1
-    immer:
-      specifier: ^10.1.1
-      version: 10.2.0
-    msw:
-      specifier: ^2.5.1
-      version: 2.12.1
-  effect:
-    '@effect/cli':
-      specifier: ^0.69.0
-      version: 0.69.2
-    '@effect/language-service':
-      specifier: ^0.35.2
-      version: 0.35.2
-    '@effect/opentelemetry':
-      specifier: ^0.56.1
-      version: 0.56.6
-    '@effect/platform':
-      specifier: ^0.90.0
-      version: 0.90.10
-    '@effect/platform-node':
-      specifier: 0.94.2
-      version: 0.94.2
-    '@effect/vitest':
-      specifier: ^0.23.9
-      version: 0.23.13
-    effect:
-      specifier: ^3.17.2
-      version: 3.19.3
-  vitest:
-    vitest:
-      specifier: ^3.0.4
-      version: 3.2.4
-
 importers:
 
   .:
@@ -364,15 +326,9 @@ importers:
 
   e2e/oidc-app:
     dependencies:
-      '@forgerock/javascript-sdk':
-        specifier: ^4.8.2
-        version: 4.8.2
       '@forgerock/oidc-client':
         specifier: workspace:*
         version: link:../../packages/oidc-client
-      '@forgerock/sdk-types':
-        specifier: workspace:*
-        version: link:../../packages/sdk-types
 
   e2e/oidc-suites: {}
 
@@ -1890,9 +1846,6 @@ packages:
 
   '@forgerock/javascript-sdk@4.7.0':
     resolution: {integrity: sha512-0wpy2/ii9F9yKI3r+huqQtp6bVAeajf2+Llq25dvkfxQX19FKKi9KPPMF7JTVti6heYHyo36lxweB7xerB5UTQ==}
-
-  '@forgerock/javascript-sdk@4.8.2':
-    resolution: {integrity: sha512-vk30flcVa0ypa92YOqEPiIZlXxTF+QVrd/ADtn0G5fIAGNUE2LMKpiGVZGAooqdaT9DpAymvaXrWCV9JLDDlMA==}
 
   '@gerrit0/mini-shiki@1.27.2':
     resolution: {integrity: sha512-GeWyHz8ao2gBiUW4OJnQDxXQnFgZQwwQk05t/CVVgNBN7/rK8XZ7xY6YhLVv9tH3VppWWmr9DCl3MwemB/i+Og==}
@@ -9633,14 +9586,6 @@ snapshots:
   '@fastify/busboy@2.1.1': {}
 
   '@forgerock/javascript-sdk@4.7.0':
-    dependencies:
-      '@reduxjs/toolkit': 2.10.1
-      immer: 10.2.0
-    transitivePeerDependencies:
-      - react
-      - react-redux
-
-  '@forgerock/javascript-sdk@4.8.2':
     dependencies:
       '@reduxjs/toolkit': 2.10.1
       immer: 10.2.0


### PR DESCRIPTION
# JIRA Ticket

https://pingidentity.atlassian.net/browse/SDKS-4532

## Description

Re-exports needed types from packages external to oidc-client. Updates API description in README. Adds `access: public` to package.json
No changeset.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added token.revoke() to support revoking tokens.

* **Documentation**
  * Updated examples and docs to use async/await for all OIDC client calls (initialization, authorize.background, authorize.url, token.exchange, token.get, token.revoke, user.info, user.logout).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->