### PR TITLE
chore: temporarily disable nx cloud

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -38,11 +38,12 @@ runs:
       run: pnpm install --frozen-lockfile
       shell: bash
 
-    - name: Nx Cloud start
-      run: pnpm dlx nx-cloud start-ci-run --distribute-on=".nx/workflows/dynamic-changesets.yml" --stop-agents-after="e2e-ci" --with-env-vars="CODECOV_TOKEN"
-      shell: bash
-      env:
-        CODECOV_TOKEN: ${{ inputs.CODECOV_TOKEN }}
+    # Temporarily disable Nx Cloud until security concern is resolved
+    # - name: Nx Cloud start
+    #   run: pnpm dlx nx-cloud start-ci-run --distribute-on=".nx/workflows/dynamic-changesets.yml" --stop-agents-after="e2e-ci" --with-env-vars="CODECOV_TOKEN"
+    #   shell: bash
+    #   env:
+    #     CODECOV_TOKEN: ${{ inputs.CODECOV_TOKEN }}
 
     - name: Cache Playwright browsers
       uses: actions/cache@v4
@@ -64,7 +65,8 @@ runs:
       run: pnpm nx sync:check
 
     - name: Run Nx build/lint/test/e2e
-      run: pnpm exec nx affected -t build lint test e2e-ci
+      # Temporarily disable e2e-ci until we get Nx Cloud back
+      run: pnpm exec nx affected -t build lint test e2e
       shell: bash
 
     - name: Upload Playwright report

--- a/.github/workflows/ci-fork.yml
+++ b/.github/workflows/ci-fork.yml
@@ -55,4 +55,6 @@ jobs:
       - uses: nrwl/nx-set-shas@v4
 
       - run: pnpm nx format:check
-      - run: pnpm nx affected -t build typecheck lint test e2e-ci --no-agents
+
+      # Temporarily disable e2e-ci until we get Nx Cloud back
+      - run: pnpm nx affected -t build typecheck lint test e2e --no-agents

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,9 @@ jobs:
         with:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
-      - run: npx nx-cloud fix-ci
-        if: always()
+      # Temporarily disable Nx Cloud until security concern is resolved
+      # - run: npx nx-cloud fix-ci
+      #   if: always()
 
       - uses: codecov/codecov-action@v5
         with:


### PR DESCRIPTION
## Description

Temporarily disable Nx Cloud until security concerns with Nx Cloud Github app are resolved. This disables remote caching for CI so it will be slower for now. Self-healing will also be disabled.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI/CD pipeline updated: cloud optimization step temporarily disabled and end-to-end check simplified (e2e-ci replaced with e2e).  
  * Other workflow steps (build, test, coverage, docs) remain unchanged; overall behavior preserved.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->