### PR TITLE
fix: resolve typecheck failures in wellknown test mocks

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -64,7 +64,7 @@ runs:
       run: pnpm nx sync:check
 
     - name: Run Nx build/lint/test/e2e
-      run: pnpm exec nx affected -t build lint test e2e-ci
+      run: pnpm exec nx affected -t build lint test typecheck e2e-ci
       shell: bash
 
     - name: Upload Playwright report

--- a/packages/journey-client/src/lib/config.slice.test.ts
+++ b/packages/journey-client/src/lib/config.slice.test.ts
@@ -9,6 +9,7 @@ import { describe, it, expect } from 'vitest';
 import { configSlice } from './config.slice.js';
 
 import type { WellknownResponse } from '@forgerock/sdk-types';
+import type { RequestMiddleware } from '@forgerock/sdk-request-middleware';
 import type { ResolvedConfig } from './config.slice.js';
 
 function createMockWellknown(overrides: Partial<WellknownResponse> = {}): WellknownResponse {
@@ -18,6 +19,8 @@ function createMockWellknown(overrides: Partial<WellknownResponse> = {}): Wellkn
     token_endpoint: 'https://am.example.com/am/oauth2/alpha/access_token',
     userinfo_endpoint: 'https://am.example.com/am/oauth2/alpha/userinfo',
     end_session_endpoint: 'https://am.example.com/am/oauth2/alpha/connect/endSession',
+    introspection_endpoint: 'https://am.example.com/am/oauth2/alpha/introspect',
+    revocation_endpoint: 'https://am.example.com/am/oauth2/alpha/token/revoke',
     ...overrides,
   };
 }
@@ -87,7 +90,7 @@ describe('journey-client config.slice', () => {
   describe('configSlice_Middleware_StoresMiddleware', () => {
     it('should store the provided middleware array', () => {
       // Arrange
-      const mockMiddleware = [{ type: 'test-middleware' as const }];
+      const mockMiddleware: RequestMiddleware[] = [(_req, _action, next) => next()];
       const payload: ResolvedConfig = {
         wellknownResponse: createMockWellknown(),
         middleware: mockMiddleware,

--- a/packages/journey-client/src/lib/wellknown.utils.test.ts
+++ b/packages/journey-client/src/lib/wellknown.utils.test.ts
@@ -9,6 +9,12 @@ import { describe, it, expect } from 'vitest';
 import { convertWellknown } from './wellknown.utils.js';
 
 import type { WellknownResponse } from '@forgerock/sdk-types';
+import type { ResolvedServerConfig } from './wellknown.utils.js';
+
+function assertResolved(result: unknown): asserts result is ResolvedServerConfig {
+  expect(result).toBeDefined();
+  expect(result).not.toHaveProperty('error');
+}
 
 function createMockWellknown(overrides: Partial<WellknownResponse> = {}): WellknownResponse {
   return {
@@ -34,6 +40,7 @@ describe('wellknown.utils', () => {
         const result = convertWellknown(data);
 
         // Assert
+        assertResolved(result);
         expect(result.baseUrl).toBe('https://am.example.com');
         expect(result.paths.authenticate).toBe('/am/json/alpha/authenticate');
         expect(result.paths.sessions).toBe('/am/json/alpha/sessions/');
@@ -52,6 +59,7 @@ describe('wellknown.utils', () => {
         const result = convertWellknown(data);
 
         // Assert
+        assertResolved(result);
         expect(result.baseUrl).toBe('https://test.com');
         expect(result.paths.authenticate).toBe('/am/json/realms/root/authenticate');
         expect(result.paths.sessions).toBe('/am/json/realms/root/sessions/');
@@ -70,6 +78,7 @@ describe('wellknown.utils', () => {
         const result = convertWellknown(data);
 
         // Assert
+        assertResolved(result);
         expect(result.baseUrl).toBe('https://test.com');
         expect(result.paths.authenticate).toBe('/am/json/realms/root/realms/alpha/authenticate');
         expect(result.paths.sessions).toBe('/am/json/realms/root/realms/alpha/sessions/');
@@ -89,6 +98,7 @@ describe('wellknown.utils', () => {
         const result = convertWellknown(data);
 
         // Assert
+        assertResolved(result);
         expect(result.baseUrl).toBe('https://test.com');
         expect(result.paths.authenticate).toBe(
           '/am/json/realms/root/realms/customers/realms/premium/authenticate',
@@ -111,6 +121,7 @@ describe('wellknown.utils', () => {
         const result = convertWellknown(data);
 
         // Assert
+        assertResolved(result);
         expect(result.baseUrl).toBe('https://am.example.com:8443');
         expect(result.paths.authenticate).toBe('/am/json/alpha/authenticate');
       });
@@ -128,6 +139,7 @@ describe('wellknown.utils', () => {
         const result = convertWellknown(data);
 
         // Assert
+        assertResolved(result);
         expect(result.baseUrl).toBe('https://am.example.com');
         expect(result.paths.authenticate).toBe('/json/alpha/authenticate');
         expect(result.paths.sessions).toBe('/json/alpha/sessions/');
@@ -185,6 +197,7 @@ describe('wellknown.utils', () => {
         const result = convertWellknown(data);
 
         // Assert
+        assertResolved(result);
         expect(result.baseUrl).toBe('http://localhost:9443');
         expect(result.paths.authenticate).toBe('/am/json/realms/root/authenticate');
         expect(result.paths.sessions).toBe('/am/json/realms/root/sessions/');

--- a/packages/sdk-effects/oidc/src/lib/wellknown.effects.test.ts
+++ b/packages/sdk-effects/oidc/src/lib/wellknown.effects.test.ts
@@ -17,6 +17,10 @@ function createMockWellknown(overrides: Partial<WellknownResponse> = {}): Wellkn
     issuer: 'https://am.example.com/am/oauth2/alpha',
     authorization_endpoint: 'https://am.example.com/am/oauth2/alpha/authorize',
     token_endpoint: 'https://am.example.com/am/oauth2/alpha/access_token',
+    userinfo_endpoint: 'https://am.example.com/am/oauth2/alpha/userinfo',
+    end_session_endpoint: 'https://am.example.com/am/oauth2/alpha/connect/endSession',
+    introspection_endpoint: 'https://am.example.com/am/oauth2/alpha/introspect',
+    revocation_endpoint: 'https://am.example.com/am/oauth2/alpha/token/revoke',
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary
- Added missing required `WellknownResponse` fields (`userinfo_endpoint`, `end_session_endpoint`, `introspection_endpoint`, `revocation_endpoint`) to test mock factories in `sdk-oidc` and `journey-client`
- Fixed `RequestMiddleware` mock in `config.slice.test.ts` to use a proper function instead of an invalid object literal
- Added `assertResolved` type narrowing helper in `wellknown.utils.test.ts` to safely access `ResolvedServerConfig` properties from the `ResolvedServerConfig | GenericError` union

## Test plan
- [x] `nx run-many --target=typecheck --all` passes (24 projects)
- [x] `nx run @forgerock/sdk-oidc:test` passes (25 tests)
- [x] `nx run @forgerock/journey-client:test` passes (166 tests)
- [x] Pre-commit hooks (typecheck, lint, build) pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced test validation for configuration and OAuth2/OpenID Connect endpoints with improved mock data coverage.

* **Chores**
  * Added typecheck to CI/CD pipeline for improved code quality assurance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->