### PR TITLE
chore: fix-publish-steps

### DIFF
--- a/.github/actions/publish-beta/action.yml
+++ b/.github/actions/publish-beta/action.yml
@@ -10,7 +10,7 @@ runs:
 
     - name: Run Builds
       shell: bash
-      run: pnpm nx run-many -t build --no-agents
+      run: pnpm nx run-many -t build --no-agents --skip-nx-cache
 
     - name: Generate API Docs
       shell: bash

--- a/.github/actions/publish-release/action.yml
+++ b/.github/actions/publish-release/action.yml
@@ -32,7 +32,7 @@ runs:
 
     - name: Run Builds
       shell: bash
-      run: pnpm nx run-many -t build --no-agents
+      run: pnpm nx run-many -t build --no-agents --skip-nx-cache
 
     - name: Generate API Docs
       shell: bash

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,19 +6,19 @@ on:
   workflow_dispatch:
     inputs:
       snapshot_tag:
-        description: "changesets snapshot tag (beta/canary)"
+        description: 'changesets snapshot tag (beta/canary)'
         required: false
-        default: "beta"
+        default: 'beta'
         type: string
       npm_tag:
-        description: "npm dist-tag for publishing snapshot"
+        description: 'npm dist-tag for publishing snapshot'
         required: false
-        default: "beta"
+        default: 'beta'
         type: string
       npm_access:
-        description: "access level for publishing snapshot to npm"
+        description: 'access level for publishing snapshot to npm'
         required: false
-        default: "public"
+        default: 'public'
         type: choice
         options:
           - public
@@ -61,7 +61,7 @@ jobs:
           version: pnpm ci:version
           title: Release PR
           branch: main
-          commit: "chore: version-packages"
+          commit: 'chore: version-packages'
           setupGitUser: true
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
@@ -95,15 +95,10 @@ jobs:
 
   snapshot:
     # Guard against publishing snapshots from the protected release branch.
-    # Both github.ref (the branch selected in the UI) and inputs.branch (the
-    # free-text checkout ref) must be checked, since they are independent values
-    # and the checkout step uses inputs.branch directly.
     if: >-
       ${{
         github.event_name == 'workflow_dispatch' &&
-        github.ref != 'refs/heads/changeset-release/main' &&
-        github.event.inputs.branch != 'changeset-release/main' &&
-        github.event.inputs.branch != 'refs/heads/changeset-release/main'
+        github.ref != 'refs/heads/changeset-release/main'
       }}
     name: Publish Snapshots
     permissions:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,19 +6,19 @@ on:
   workflow_dispatch:
     inputs:
       snapshot_tag:
-        description: 'changesets snapshot tag (beta/canary)'
+        description: "changesets snapshot tag (beta/canary)"
         required: false
-        default: 'beta'
+        default: "beta"
         type: string
       npm_tag:
-        description: 'npm dist-tag for publishing snapshot'
+        description: "npm dist-tag for publishing snapshot"
         required: false
-        default: 'beta'
+        default: "beta"
         type: string
       npm_access:
-        description: 'access level for publishing snapshot to npm'
+        description: "access level for publishing snapshot to npm"
         required: false
-        default: 'public'
+        default: "public"
         type: choice
         options:
           - public
@@ -61,7 +61,7 @@ jobs:
           version: pnpm ci:version
           title: Release PR
           branch: main
-          commit: 'chore: version-packages'
+          commit: "chore: version-packages"
           setupGitUser: true
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
@@ -94,8 +94,18 @@ jobs:
           retention-days: 30
 
   snapshot:
-    if: ${{ github.event_name == 'workflow_dispatch' }}
-    name: Publish snapshot/beta to npm
+    # Guard against publishing snapshots from the protected release branch.
+    # Both github.ref (the branch selected in the UI) and inputs.branch (the
+    # free-text checkout ref) must be checked, since they are independent values
+    # and the checkout step uses inputs.branch directly.
+    if: >-
+      ${{
+        github.event_name == 'workflow_dispatch' &&
+        github.ref != 'refs/heads/changeset-release/main' &&
+        github.event.inputs.branch != 'changeset-release/main' &&
+        github.event.inputs.branch != 'refs/heads/changeset-release/main'
+      }}
+    name: Publish Snapshots
     permissions:
       contents: write
       id-token: write

--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,4 @@ GEMINI.md
 
 .claude/worktrees
 .claude/settings.local.json
+.opensource

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "build": "nx sync && nx affected --target=build",
     "changeset": "changeset",
-    "ci:release": "pnpm nx run-many -t build --no-agents && pnpm publish -r --no-git-checks && changeset tag",
+    "ci:release": "pnpm nx run-many -t build --no-agents --skip-nx-cache && pnpm publish -r --no-git-checks && changeset tag",
     "ci:version": "changeset version && pnpm install --no-frozen-lockfile && pnpm nx format:write --uncommitted",
     "circular-dep-check": "madge --circular .",
     "clean": "shx rm -rf ./{coverage,dist,docs,node_modules,tmp}/ ./{packages,e2e}/*/{dist,node_modules}/ ./e2e/node_modules/ && git clean -fX -e \"!.env*,nx-cloud.env\" -e \"!**/GEMINI.md\"",


### PR DESCRIPTION
# JIRA Ticket
https://pingidentity.atlassian.net/browse/SDKS-4858

## Description

Due to unforeseen issues, we want to guard the job against the changesets release branch.

Additionally add steps to force no agents (no distributed build tasks) and no nx cache when running build in publish steps


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI publishing workflows updated to run fresh, uncached builds before package publish steps.
  * Snapshot publishing now includes an extra guard to avoid running on the release branch/ref selected for releases and clearer snapshot job naming.
  * Release scripts adjusted so release runs perform non-cached builds, reducing stale artifacts and ensuring published packages reflect the latest build output.
  * .gitignore updated to include new entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->