### PR TITLE
feat(davinci-client): add polling support (SDKS-4687)

### DIFF
--- a/.changeset/lucky-parts-own.md
+++ b/.changeset/lucky-parts-own.md
@@ -1,0 +1,6 @@
+---
+'@forgerock/sdk-request-middleware': minor
+'@forgerock/davinci-client': minor
+---
+
+Support both challenge polling and continue polling in DaVinci

--- a/e2e/davinci-app/components/polling.ts
+++ b/e2e/davinci-app/components/polling.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+import {
+  PollingCollector,
+  PollingStatus,
+  InternalErrorResponse,
+  Updater,
+} from '@forgerock/davinci-client/types';
+
+export default function pollingComponent(
+  formEl: HTMLFormElement,
+  collector: PollingCollector,
+  poll: (collector: PollingCollector) => Promise<PollingStatus | InternalErrorResponse>,
+  updater: Updater<PollingCollector>,
+  submitForm: () => Promise<void>,
+) {
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.value = collector.output.key;
+  button.innerHTML = 'Start polling';
+  formEl.appendChild(button);
+
+  button.onclick = async () => {
+    const p = document.createElement('p');
+    p.innerText = 'Polling...';
+    formEl?.appendChild(p);
+
+    const status = await poll(collector);
+    if (typeof status !== 'string' && 'error' in status) {
+      console.error(status.error.message);
+      return;
+    }
+
+    const result = updater(status);
+    if (result && 'error' in result) {
+      console.error(result.error.message);
+      return;
+    }
+
+    const resultEl = document.createElement('p');
+    resultEl.innerText = 'Polling result: ' + JSON.stringify(status, null, 2);
+    formEl?.appendChild(resultEl);
+
+    await submitForm();
+  };
+}

--- a/e2e/davinci-app/components/polling.ts
+++ b/e2e/davinci-app/components/polling.ts
@@ -4,17 +4,12 @@
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
  */
-import type {
-  PollingCollector,
-  PollingStatus,
-  InternalErrorResponse,
-  Updater,
-} from '@forgerock/davinci-client/types';
+import type { PollingCollector, Poller, Updater } from '@forgerock/davinci-client/types';
 
 export default function pollingComponent(
   formEl: HTMLFormElement,
   collector: PollingCollector,
-  poll: (collector: PollingCollector) => Promise<PollingStatus | InternalErrorResponse>,
+  poll: Poller,
   updater: Updater<PollingCollector>,
   submitForm: () => Promise<void>,
 ) {
@@ -25,11 +20,13 @@ export default function pollingComponent(
   formEl.appendChild(button);
 
   button.onclick = async () => {
+    button.disabled = true;
+
     const p = document.createElement('p');
     p.innerText = 'Polling...';
     formEl?.appendChild(p);
 
-    const status = await poll(collector);
+    const status = await poll();
     if (typeof status !== 'string' && 'error' in status) {
       console.error(status.error?.message);
 
@@ -54,5 +51,7 @@ export default function pollingComponent(
     formEl?.appendChild(resultEl);
 
     await submitForm();
+
+    button.disabled = false;
   };
 }

--- a/e2e/davinci-app/components/polling.ts
+++ b/e2e/davinci-app/components/polling.ts
@@ -4,7 +4,7 @@
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
  */
-import {
+import type {
   PollingCollector,
   PollingStatus,
   InternalErrorResponse,
@@ -31,13 +31,21 @@ export default function pollingComponent(
 
     const status = await poll(collector);
     if (typeof status !== 'string' && 'error' in status) {
-      console.error(status.error.message);
+      console.error(status.error?.message);
+
+      const errEl = document.createElement('p');
+      errEl.innerText = 'Polling error: ' + status.error?.message;
+      formEl?.appendChild(errEl);
       return;
     }
 
     const result = updater(status);
     if (result && 'error' in result) {
       console.error(result.error.message);
+
+      const errEl = document.createElement('p');
+      errEl.innerText = 'Polling error: ' + result.error.message;
+      formEl?.appendChild(errEl);
       return;
     }
 

--- a/e2e/davinci-app/main.ts
+++ b/e2e/davinci-app/main.ts
@@ -33,6 +33,7 @@ import labelComponent from './components/label.js';
 import objectValueComponent from './components/object-value.js';
 import fidoComponent from './components/fido.js';
 import qrCodeComponent from './components/qr-code.js';
+import pollingComponent from './components/polling.js';
 
 const loggerFn = {
   error: () => {
@@ -262,6 +263,14 @@ const urlParams = new URLSearchParams(window.location.search);
         fidoComponent(
           formEl, // You can ignore this; it's just for rendering
           collector, // This is the plain object of the collector
+          davinciClient.update(collector), // Returns an update function for this collector
+          submitForm,
+        );
+      } else if (collector.type === 'PollingCollector') {
+        pollingComponent(
+          formEl, // You can ignore this; it's just for rendering
+          collector, // This is the plain object of the collector
+          davinciClient.poll, // Returns a poll function
           davinciClient.update(collector), // Returns an update function for this collector
           submitForm,
         );

--- a/e2e/davinci-app/main.ts
+++ b/e2e/davinci-app/main.ts
@@ -270,7 +270,7 @@ const urlParams = new URLSearchParams(window.location.search);
         pollingComponent(
           formEl, // You can ignore this; it's just for rendering
           collector, // This is the plain object of the collector
-          davinciClient.poll, // Returns a poll function
+          davinciClient.poll(collector), // Returns a poll function
           davinciClient.update(collector), // Returns an update function for this collector
           submitForm,
         );

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "author": "ForgeRock",
   "scripts": {
-    "build": "nx affected --target=build",
+    "build": "nx sync && nx affected --target=build",
     "changeset": "changeset",
     "ci:release": "pnpm nx run-many -t build --no-agents && pnpm publish -r --no-git-checks && changeset tag",
     "ci:version": "changeset version && pnpm install --no-frozen-lockfile && pnpm nx format:write --uncommitted",

--- a/packages/davinci-client/package.json
+++ b/packages/davinci-client/package.json
@@ -34,6 +34,7 @@
     "immer": "catalog:"
   },
   "devDependencies": {
+    "@effect/vitest": "catalog:effect",
     "vitest": "catalog:vitest"
   },
   "publishConfig": {

--- a/packages/davinci-client/src/lib/client.store.effects.test.ts
+++ b/packages/davinci-client/src/lib/client.store.effects.test.ts
@@ -1,0 +1,282 @@
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+import { Micro } from 'effect';
+import { describe, expect, vi } from 'vitest';
+import { it } from '@effect/vitest';
+
+import {
+  buildChallengeEndpoint,
+  isChallengeStillPending,
+  interpretChallengeResponse,
+  getPollingModeµ,
+} from './client.store.effects.js';
+import type { PollDispatchResult } from './client.store.effects.js';
+import type { PollingCollector } from './collector.types.js';
+
+const mockLog = {
+  debug: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn(),
+} as any;
+
+// ---------------------------------------------------------------------------
+// buildChallengeEndpoint
+// ---------------------------------------------------------------------------
+
+describe('buildChallengeEndpoint', () => {
+  it('returns a constructed URL string for a valid self link', () => {
+    const selfHref =
+      'https://auth.pingone.ca/3b2b0d54-99f9-4c28-b57e-d4e66e8e72c2/davinci/orchestrate';
+    const challenge = 'abc123';
+
+    const result = buildChallengeEndpoint(selfHref, challenge);
+
+    expect(result).toBe(
+      'https://auth.pingone.ca/3b2b0d54-99f9-4c28-b57e-d4e66e8e72c2/davinci/user/credentials/challenge/abc123/status',
+    );
+  });
+
+  it('returns InternalErrorResponse when envId is missing from URL path', () => {
+    // pathname is just '/' → split gives ['', ''] → envId is empty string → falsy
+    const selfHref = 'https://auth.pingone.ca/';
+    const challenge = 'abc123';
+
+    const result = buildChallengeEndpoint(selfHref, challenge);
+
+    expect(typeof result).toBe('object');
+    expect((result as any).type).toBe('internal_error');
+  });
+
+  it('returns InternalErrorResponse for a completely invalid URL', () => {
+    const result = buildChallengeEndpoint('not-a-url', 'abc123');
+
+    expect(typeof result).toBe('object');
+    expect((result as any).type).toBe('internal_error');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isChallengeStillPending
+// ---------------------------------------------------------------------------
+
+describe('isChallengeStillPending', () => {
+  it('returns false when response has an error', () => {
+    const response: PollDispatchResult = { error: { status: 400, data: {} } };
+    expect(isChallengeStillPending(response)).toBe(false);
+  });
+
+  it('returns false when isChallengeComplete is true', () => {
+    const response: PollDispatchResult = {
+      data: { isChallengeComplete: true, status: 'approved' },
+    };
+    expect(isChallengeStillPending(response)).toBe(false);
+  });
+
+  it('returns true when challenge is still pending', () => {
+    const response: PollDispatchResult = { data: { isChallengeComplete: false } };
+    expect(isChallengeStillPending(response)).toBe(true);
+  });
+
+  it('returns true when data has no isChallengeComplete field', () => {
+    const response: PollDispatchResult = { data: { someOtherField: 'value' } };
+    expect(isChallengeStillPending(response)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// interpretChallengeResponse
+// ---------------------------------------------------------------------------
+
+describe('interpretChallengeResponse', () => {
+  it("returns 'expired' for a 400 error with serviceName 'challengeExpired'", () => {
+    const response: PollDispatchResult = {
+      error: { status: 400, data: { serviceName: 'challengeExpired' } },
+    };
+
+    const result = interpretChallengeResponse(response, mockLog);
+
+    expect(result).toBe('expired');
+  });
+
+  it("returns 'error' for other HTTP errors (status 500)", () => {
+    const response: PollDispatchResult = {
+      error: { status: 500, data: { message: 'Server Error' } },
+    };
+
+    const result = interpretChallengeResponse(response, mockLog);
+
+    expect(result).toBe('error');
+  });
+
+  it('returns InternalErrorResponse for a SerializedError (has message, no status)', () => {
+    const response: PollDispatchResult = {
+      error: { name: 'SerializedError', message: 'Network failure' },
+    };
+
+    const result = interpretChallengeResponse(response, mockLog);
+
+    expect(typeof result).toBe('object');
+    expect((result as any).type).toBe('internal_error');
+    expect((result as any).error.message).toBe('Network failure');
+  });
+
+  it("returns 'error' for non-object data", () => {
+    const response: PollDispatchResult = { data: 'just a string' };
+
+    const result = interpretChallengeResponse(response, mockLog);
+
+    expect(result).toBe('error');
+  });
+
+  it('returns the status from a completed challenge', () => {
+    const response: PollDispatchResult = {
+      data: { isChallengeComplete: true, status: 'approved' },
+    };
+
+    const result = interpretChallengeResponse(response, mockLog);
+
+    expect(result).toBe('approved');
+  });
+
+  it("returns 'error' when challenge is complete but status is missing", () => {
+    const response: PollDispatchResult = {
+      data: { isChallengeComplete: true },
+    };
+
+    const result = interpretChallengeResponse(response, mockLog);
+
+    expect(result).toBe('error');
+  });
+
+  it("returns 'timedOut' for an incomplete challenge when the schedule is exhausted", () => {
+    const response: PollDispatchResult = {
+      data: { isChallengeComplete: false },
+    };
+
+    const result = interpretChallengeResponse(response, mockLog);
+
+    expect(result).toBe('timedOut');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getPollingModeµ
+// ---------------------------------------------------------------------------
+
+describe('getPollingModeµ', () => {
+  const basePollingCollector: PollingCollector = {
+    category: 'SingleValueAutoCollector',
+    error: null,
+    type: 'PollingCollector',
+    id: 'polling-0',
+    name: 'polling',
+    input: { key: 'polling', value: '', type: 'POLLING' },
+    output: {
+      key: 'polling',
+      type: 'POLLING',
+      config: { pollInterval: 2000, pollRetries: 5, retriesRemaining: 5 },
+    },
+  };
+
+  it.effect('succeeds with challenge mode when challenge and pollChallengeStatus are set', () =>
+    Micro.gen(function* () {
+      const collector: PollingCollector = {
+        ...basePollingCollector,
+        output: {
+          ...basePollingCollector.output,
+          config: {
+            pollInterval: 2000,
+            pollRetries: 5,
+            pollChallengeStatus: true,
+            challenge: 'test-challenge',
+          },
+        },
+      };
+
+      const result = yield* getPollingModeµ(collector);
+
+      expect(result).toStrictEqual({ _tag: 'challenge', challenge: 'test-challenge' });
+    }),
+  );
+
+  it.effect('succeeds with continue mode when no challenge is present', () =>
+    Micro.gen(function* () {
+      const result = yield* getPollingModeµ(basePollingCollector);
+
+      expect(result).toStrictEqual({
+        _tag: 'continue',
+        retriesRemaining: 5,
+        pollInterval: 2000,
+      });
+    }),
+  );
+
+  it.effect('succeeds with unknown mode for ambiguous configuration', () =>
+    Micro.gen(function* () {
+      const collector: PollingCollector = {
+        ...basePollingCollector,
+        output: {
+          ...basePollingCollector.output,
+          config: {
+            pollInterval: 2000,
+            pollRetries: 5,
+            challenge: 'test-challenge',
+            // pollChallengeStatus is absent — ambiguous
+          },
+        },
+      };
+
+      const result = yield* getPollingModeµ(collector);
+
+      expect(result).toStrictEqual({ _tag: 'unknown' });
+    }),
+  );
+
+  it.effect('fails when collector type is not PollingCollector', () =>
+    Micro.gen(function* () {
+      const badCollector = { ...basePollingCollector, type: 'TextCollector' } as any;
+
+      const result = yield* Micro.exit(getPollingModeµ(badCollector));
+
+      expect(result).toStrictEqual(
+        Micro.exitFail({
+          error: {
+            message: 'Collector provided to poll is not a PollingCollector',
+            type: 'argument_error',
+          },
+          type: 'internal_error',
+        }),
+      );
+    }),
+  );
+
+  it.effect('fails when retriesRemaining is undefined in continue mode', () =>
+    Micro.gen(function* () {
+      const collector: PollingCollector = {
+        ...basePollingCollector,
+        output: {
+          ...basePollingCollector.output,
+          config: { pollInterval: 2000, pollRetries: 5 },
+        },
+      };
+
+      const result = yield* Micro.exit(getPollingModeµ(collector));
+
+      expect(result).toStrictEqual(
+        Micro.exitFail({
+          error: {
+            message: 'No retries found on PollingCollector',
+            type: 'argument_error',
+          },
+          type: 'internal_error',
+        }),
+      );
+    }),
+  );
+});

--- a/packages/davinci-client/src/lib/client.store.effects.ts
+++ b/packages/davinci-client/src/lib/client.store.effects.ts
@@ -1,0 +1,312 @@
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+import { Micro } from 'effect';
+import { SerializedError } from '@reduxjs/toolkit/react';
+import { FetchBaseQueryError } from '@reduxjs/toolkit/query/react';
+
+import type { logger as loggerFn } from '@forgerock/sdk-logger';
+
+import type { ClientStore, RootState } from './client.store.utils.js';
+import type { PollingStatus, InternalErrorResponse } from './client.types.js';
+import type { PollingCollector } from './collector.types.js';
+
+import { createInternalError, isInternalError } from './client.store.utils.js';
+import { davinciApi } from './davinci.api.js';
+import { nodeSlice } from './node.slice.js';
+
+/**
+ * Shape returned by RTK Query's dispatch for the poll endpoint.
+ */
+export interface PollDispatchResult {
+  data?: unknown;
+  error?: FetchBaseQueryError | SerializedError;
+}
+
+/**
+ * Validated prerequisites needed to initiate challenge polling.
+ */
+interface PollingPrerequisites {
+  interactionId: string;
+  challengeEndpoint: string;
+}
+
+/**
+ * Discriminated union representing the validated polling mode.
+ */
+export type PollingMode =
+  | { _tag: 'challenge'; challenge: string }
+  | { _tag: 'continue'; retriesRemaining: number; pollInterval: number }
+  | { _tag: 'unknown' };
+
+/**
+ * Type guard: determines if a value is a plain object (Record<string, unknown>).
+ */
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+/**
+ * Determines the polling mode for a given PollingCollector.
+ * Succeeds with a discriminated PollingMode, or fails with InternalErrorResponse.
+ */
+export function getPollingModeµ(
+  collector: PollingCollector,
+): Micro.Micro<PollingMode, InternalErrorResponse> {
+  if (collector.type !== 'PollingCollector') {
+    return Micro.fail(
+      createInternalError('Collector provided to poll is not a PollingCollector', 'argument_error'),
+    );
+  }
+
+  const { pollChallengeStatus, challenge, retriesRemaining, pollInterval } =
+    collector.output.config;
+
+  if (challenge && pollChallengeStatus === true) {
+    return Micro.succeed({ _tag: 'challenge', challenge });
+  }
+
+  if (!challenge && !pollChallengeStatus) {
+    if (retriesRemaining === undefined) {
+      return Micro.fail(
+        createInternalError('No retries found on PollingCollector', 'argument_error'),
+      );
+    }
+    return Micro.succeed({
+      _tag: 'continue',
+      retriesRemaining,
+      pollInterval: pollInterval ?? 2000,
+    });
+  }
+
+  return Micro.succeed({ _tag: 'unknown' });
+}
+
+/**
+ * Constructs the challenge polling endpoint from a self link URL.
+ * Returns InternalErrorResponse if URL cannot be parsed, instead of throwing.
+ */
+export function buildChallengeEndpoint(
+  selfHref: string,
+  challenge: string,
+): string | InternalErrorResponse {
+  try {
+    const url = new URL(selfHref);
+    const envId = url.pathname.split('/')[1];
+
+    if (!url.origin || !envId) {
+      return createInternalError(
+        'Failed to construct challenge polling endpoint. Requires host and environment ID.',
+        'parse_error',
+      );
+    }
+
+    return `${url.origin}/${envId}/davinci/user/credentials/challenge/${challenge}/status`;
+  } catch {
+    return createInternalError(
+      'Failed to construct challenge polling endpoint. Requires host and environment ID.',
+      'parse_error',
+    );
+  }
+}
+
+/**
+ * Lifts a selector result with { error, state } shape into a Micro.
+ * Succeeds with state when error is null, fails with InternalErrorResponse otherwise.
+ */
+function fromSelectorµ<T>(result: {
+  error: { message: string } | null;
+  state: T;
+}): Micro.Micro<NonNullable<T>, InternalErrorResponse> {
+  return result.error
+    ? Micro.fail(createInternalError(result.error.message, 'state_error'))
+    : Micro.succeed(result.state as NonNullable<T>);
+}
+
+/**
+ * Validates all prerequisites for challenge polling and constructs the endpoint URL.
+ * validate challenge → select server → select self link → build endpoint → assemble
+ */
+export function validatePollingPrerequisitesµ(
+  rootState: RootState,
+  challenge: string,
+): Micro.Micro<PollingPrerequisites, InternalErrorResponse> {
+  if (!challenge) {
+    return Micro.fail(
+      createInternalError('No challenge found on collector for poll operation', 'state_error'),
+    );
+  }
+
+  return fromSelectorµ(nodeSlice.selectors.selectContinueServer(rootState)).pipe(
+    Micro.filterOrFail(
+      (server) => !!server.interactionId,
+      () =>
+        createInternalError(
+          'Missing interactionId in server info for challenge polling',
+          'state_error',
+        ),
+    ),
+    Micro.flatMap((server) =>
+      fromSelectorµ(nodeSlice.selectors.selectSelfLink(rootState)).pipe(
+        Micro.map((selfLink) => ({ server, selfLink })),
+      ),
+    ),
+    Micro.flatMap(({ server, selfLink }) => {
+      const endpoint = buildChallengeEndpoint(selfLink, challenge);
+      return typeof endpoint === 'string'
+        ? Micro.succeed({
+            interactionId: server.interactionId!,
+            challengeEndpoint: endpoint,
+          })
+        : Micro.fail(endpoint);
+    }),
+  );
+}
+
+/**
+ * Pure predicate: determines if challenge polling should continue.
+ * Returns true when the challenge has not yet completed and no error occurred.
+ */
+export function isChallengeStillPending(response: PollDispatchResult): boolean {
+  if (response.error) return false;
+
+  const data = isRecord(response.data) ? response.data : undefined;
+  if (data?.['isChallengeComplete']) return false;
+
+  return true;
+}
+
+export function interpretChallengeResponse(
+  response: PollDispatchResult,
+  log: ReturnType<typeof loggerFn>,
+): PollingStatus | InternalErrorResponse {
+  const { data, error } = response;
+
+  if (error) {
+    // FetchBaseQueryError — has status field
+    if ('status' in error) {
+      const errorDetails = isRecord(error.data) ? error.data : undefined;
+      const serviceName = errorDetails?.['serviceName'];
+
+      // Expired challenge is an expected polling outcome, not a failure
+      if (error.status === 400 && serviceName === 'challengeExpired') {
+        log.debug('Challenge expired for polling');
+        return 'expired';
+      }
+
+      // Other HTTP errors are also expected outcomes (e.g. bad challenge returning 400 with code 4019)
+      log.debug('Unknown error occurred during polling');
+      return 'error';
+    }
+
+    // SerializedError — has message field
+    const message =
+      'message' in error && error.message
+        ? error.message
+        : 'An unknown error occurred while challenge polling';
+
+    return createInternalError(message, 'unknown_error');
+  }
+
+  if (!isRecord(data)) {
+    log.debug('Unable to parse polling response');
+    return 'error';
+  }
+
+  // Challenge completed — extract status
+  if (data['isChallengeComplete'] === true) {
+    const pollStatus = data['status'];
+    return pollStatus ? (pollStatus as PollingStatus) : 'error';
+  }
+
+  // If we reach here, Micro.repeat exhausted its schedule without the challenge completing
+  log.debug('Challenge polling timed out');
+  return 'timedOut';
+}
+
+/**
+ * Builds a Micro effect for the challenge polling branch.
+ * validate → dispatch → repeat → interpret → lift errors
+ */
+function challengePollingµ({
+  collector,
+  challenge,
+  store,
+  log,
+}: {
+  collector: PollingCollector;
+  challenge: string;
+  store: ReturnType<ClientStore>;
+  log: ReturnType<typeof loggerFn>;
+}): Micro.Micro<PollingStatus, InternalErrorResponse> {
+  const maxRetries = collector.output.config.pollRetries ?? 60;
+  const pollInterval = collector.output.config.pollInterval ?? 2000;
+
+  return validatePollingPrerequisitesµ(store.getState(), challenge).pipe(
+    Micro.flatMap(({ interactionId, challengeEndpoint }) =>
+      Micro.promise(() =>
+        store.dispatch(
+          davinciApi.endpoints.poll.initiate({
+            endpoint: challengeEndpoint,
+            interactionId,
+          }),
+        ),
+      ),
+    ),
+    Micro.repeat({
+      while: isChallengeStillPending,
+      // `times` tracks repetitions after the initial attempt, so decrement by one
+      times: maxRetries - 1,
+      schedule: Micro.scheduleSpaced(pollInterval),
+    }),
+    Micro.map((response) => interpretChallengeResponse(response, log)),
+    Micro.flatMap((result) =>
+      isInternalError(result) ? Micro.fail(result) : Micro.succeed(result),
+    ),
+  );
+}
+
+/**
+ * Builds a Micro effect for the continue polling branch.
+ * If retries remain, delays by pollInterval then returns 'continue'.
+ * If retries are exhausted, returns 'timedOut' immediately.
+ */
+function continuePollingµ(
+  mode: Extract<PollingMode, { _tag: 'continue' }>,
+): Micro.Micro<PollingStatus, InternalErrorResponse> {
+  if (mode.retriesRemaining <= 0) {
+    return Micro.succeed('timedOut' as PollingStatus);
+  }
+  return Micro.sleep(mode.pollInterval).pipe(Micro.map(() => 'continue'));
+}
+
+/**
+ * Routes a validated PollingMode to the appropriate polling effect.
+ * This is the single entry point — the caller lifts getPollingMode into Micro, pipes through this.
+ */
+export function pollingµ({
+  mode,
+  collector,
+  store,
+  log,
+}: {
+  mode: PollingMode;
+  collector: PollingCollector;
+  store: ReturnType<ClientStore>;
+  log: ReturnType<typeof loggerFn>;
+}): Micro.Micro<PollingStatus, InternalErrorResponse> {
+  if (mode._tag === 'challenge') {
+    return challengePollingµ({ collector, challenge: mode.challenge, store, log });
+  }
+
+  if (mode._tag === 'continue') {
+    return continuePollingµ(mode);
+  }
+
+  return Micro.fail(
+    createInternalError('Invalid polling collector configuration', 'argument_error'),
+  );
+}

--- a/packages/davinci-client/src/lib/client.store.ts
+++ b/packages/davinci-client/src/lib/client.store.ts
@@ -5,7 +5,8 @@
  * of the MIT license. See the LICENSE file for details.
  */
 import { Micro } from 'effect';
-import { CustomLogger, logger as loggerFn, LogLevel } from '@forgerock/sdk-logger';
+import { exitIsFail, exitIsSuccess } from 'effect/Micro';
+import { type CustomLogger, logger as loggerFn, type LogLevel } from '@forgerock/sdk-logger';
 import { createStorage } from '@forgerock/storage';
 import { isGenericError, createWellknownError } from '@forgerock/sdk-utilities';
 
@@ -14,10 +15,11 @@ import { isGenericError, createWellknownError } from '@forgerock/sdk-utilities';
  */
 import {
   createClientStore,
-  handleChallengePolling,
+  createInternalError,
   handleUpdateValidateError,
-  RootState,
+  type RootState,
 } from './client.store.utils.js';
+import { pollingµ, getPollingModeµ } from './client.store.effects.js';
 import { nodeSlice } from './node.slice.js';
 import { davinciApi } from './davinci.api.js';
 import { configSlice } from './config.slice.js';
@@ -51,7 +53,7 @@ import type {
   NodeStates,
   Updater,
   Validator,
-  PollingStatus,
+  Poller,
 } from './client.types.js';
 import { returnValidator } from './collector.utils.js';
 import type { ContinueNode, StartNode } from './node.types.js';
@@ -417,78 +419,27 @@ export async function davinci<ActionType extends ActionTypes = ActionTypes>({
      * @param {PollingCollector} collector - the polling collector
      * @returns {Promise<PollingStatus | InternalErrorResponse>} - Returns a promise that resolves to a polling status or error
      */
-    poll: async (collector: PollingCollector): Promise<PollingStatus | InternalErrorResponse> => {
-      try {
-        if (collector.type !== 'PollingCollector') {
-          log.error('Collector provided to poll is not a PollingCollector');
-          return {
-            error: {
-              message: 'Collector provided to poll is not a PollingCollector',
-              type: 'argument_error',
-            },
-            type: 'internal_error',
-          };
+    poll: (collector: PollingCollector): Poller => {
+      return async () => {
+        const result = await getPollingModeµ(collector).pipe(
+          Micro.flatMap((mode) => pollingµ({ mode, collector, store, log })),
+          Micro.tapError((err) => Micro.sync(() => log.error(err.error.message))),
+          Micro.runPromiseExit,
+        );
+
+        if (exitIsSuccess(result)) {
+          return result.value;
         }
 
-        const pollChallengeStatus = collector.output.config.pollChallengeStatus;
-        const challenge = collector.output.config.challenge;
-
-        if (challenge && pollChallengeStatus === true) {
-          // Challenge Polling
-          return await handleChallengePolling({
-            collector,
-            challenge,
-            store,
-            log,
-          });
-        } else if (!challenge && !pollChallengeStatus) {
-          // Continue polling
-          const retriesLeft = collector.output.config.retriesRemaining;
-          const pollInterval = collector.output.config.pollInterval ?? 2000; // miliseconds
-
-          if (retriesLeft === undefined) {
-            log.error('No retries found on PollingCollector');
-            return {
-              error: {
-                message: 'No retries found on PollingCollector',
-                type: 'argument_error',
-              },
-              type: 'internal_error',
-            };
-          }
-
-          if (retriesLeft > 0) {
-            const getStatusµ = Micro.sync(() => 'continue' as PollingStatus).pipe(
-              Micro.delay(pollInterval),
-            );
-            const status: PollingStatus = await Micro.runPromise(getStatusµ);
-            return status;
-          } else {
-            // Retries exhausted
-            return 'timedOut' as PollingStatus;
-          }
-        } else {
-          // Error if polling type can't be determined from configuration
-          log.error('Invalid polling collector configuration');
-          return {
-            error: {
-              message: 'Invalid polling collector configuration',
-              type: 'internal_error',
-            },
-            type: 'internal_error',
-          };
+        if (exitIsFail(result)) {
+          return result.cause.error;
         }
-      } catch (err) {
-        const errorMessage = err instanceof Error ? err.message : String(err);
-        log.error(errorMessage);
-        return {
-          error: {
-            message: errorMessage || 'An unexpected error occurred during poll operation',
-            type: 'internal_error',
-          },
-          type: 'internal_error',
-        };
-      }
+
+        return createInternalError(
+          'An unexpected error occurred during poll operation',
+          'unknown_error',
+        );
+      };
     },
 
     /**

--- a/packages/davinci-client/src/lib/client.store.ts
+++ b/packages/davinci-client/src/lib/client.store.ts
@@ -11,7 +11,12 @@ import { CustomLogger, logger as loggerFn, LogLevel } from '@forgerock/sdk-logge
 import { createStorage } from '@forgerock/storage';
 import { isGenericError, createWellknownError } from '@forgerock/sdk-utilities';
 
-import { createClientStore, handleUpdateValidateError, RootState } from './client.store.utils.js';
+import {
+  createClientStore,
+  handleChallengePolling,
+  handleUpdateValidateError,
+  RootState,
+} from './client.store.utils.js';
 import { nodeSlice } from './node.slice.js';
 import { davinciApi } from './davinci.api.js';
 import { configSlice } from './config.slice.js';
@@ -34,6 +39,7 @@ import type {
   ObjectValueCollectors,
   PhoneNumberInputValue,
   AutoCollectors,
+  PollingCollector,
   MultiValueCollectors,
   FidoRegistrationInputValue,
   FidoAuthenticationInputValue,
@@ -44,6 +50,7 @@ import type {
   NodeStates,
   Updater,
   Validator,
+  PollingStatus,
 } from './client.types.js';
 import { returnValidator } from './collector.utils.js';
 import type { ContinueNode, StartNode } from './node.types.js';
@@ -402,6 +409,49 @@ export async function davinci<ActionType extends ActionTypes = ActionTypes>({
       }
 
       return returnValidator(collectorToUpdate);
+    },
+
+    /**
+     * @method: poll - Poll for updates for a polling collector
+     */
+    poll: async (collector: PollingCollector): Promise<PollingStatus | InternalErrorResponse> => {
+      try {
+        if (collector.type !== 'PollingCollector') {
+          log.error('Collector provided to poll is not a PollingCollector');
+          return {
+            error: {
+              message: 'Collector provided to poll is not a PollingCollector',
+              type: 'argument_error',
+            },
+            type: 'internal_error',
+          };
+        }
+
+        const challenge = collector.output.config.challenge;
+
+        // Challenge Polling
+        if (challenge) {
+          return await handleChallengePolling({
+            collector,
+            challenge,
+            store,
+            log,
+          });
+        } else {
+          // TODO: Handle continue polling
+          return 'error' as PollingStatus;
+        }
+      } catch (err) {
+        const errorMessage = err instanceof Error ? err.message : String(err);
+        log.error(errorMessage);
+        return {
+          error: {
+            message: errorMessage || 'An unexpected error occurred during poll operation',
+            type: 'internal_error',
+          },
+          type: 'internal_error',
+        };
+      }
     },
 
     /**

--- a/packages/davinci-client/src/lib/client.store.ts
+++ b/packages/davinci-client/src/lib/client.store.ts
@@ -4,13 +4,14 @@
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
  */
-/**
- * Import RTK slices and api
- */
+import { Micro } from 'effect';
 import { CustomLogger, logger as loggerFn, LogLevel } from '@forgerock/sdk-logger';
 import { createStorage } from '@forgerock/storage';
 import { isGenericError, createWellknownError } from '@forgerock/sdk-utilities';
 
+/**
+ * Import RTK slices and api
+ */
 import {
   createClientStore,
   handleChallengePolling,
@@ -412,7 +413,9 @@ export async function davinci<ActionType extends ActionTypes = ActionTypes>({
     },
 
     /**
-     * @method: poll - Poll for updates for a polling collector
+     * @method poll - Perform challenge polling or continue polling
+     * @param {PollingCollector} collector - the polling collector
+     * @returns {Promise<PollingStatus | InternalErrorResponse>} - Returns a promise that resolves to a polling status or error
      */
     poll: async (collector: PollingCollector): Promise<PollingStatus | InternalErrorResponse> => {
       try {
@@ -427,19 +430,53 @@ export async function davinci<ActionType extends ActionTypes = ActionTypes>({
           };
         }
 
+        const pollChallengeStatus = collector.output.config.pollChallengeStatus;
         const challenge = collector.output.config.challenge;
 
-        // Challenge Polling
-        if (challenge) {
+        if (challenge && pollChallengeStatus === true) {
+          // Challenge Polling
           return await handleChallengePolling({
             collector,
             challenge,
             store,
             log,
           });
+        } else if (!challenge && !pollChallengeStatus) {
+          // Continue polling
+          const retriesLeft = collector.output.config.retriesRemaining;
+          const pollInterval = collector.output.config.pollInterval ?? 2000; // miliseconds
+
+          if (retriesLeft === undefined) {
+            log.error('No retries found on PollingCollector');
+            return {
+              error: {
+                message: 'No retries found on PollingCollector',
+                type: 'argument_error',
+              },
+              type: 'internal_error',
+            };
+          }
+
+          if (retriesLeft > 0) {
+            const getStatusµ = Micro.sync(() => 'continue' as PollingStatus).pipe(
+              Micro.delay(pollInterval),
+            );
+            const status: PollingStatus = await Micro.runPromise(getStatusµ);
+            return status;
+          } else {
+            // Retries exhausted
+            return 'timedOut' as PollingStatus;
+          }
         } else {
-          // TODO: Handle continue polling
-          return 'error' as PollingStatus;
+          // Error if polling type can't be determined from configuration
+          log.error('Invalid polling collector configuration');
+          return {
+            error: {
+              message: 'Invalid polling collector configuration',
+              type: 'internal_error',
+            },
+            type: 'internal_error',
+          };
         }
       } catch (err) {
         const errorMessage = err instanceof Error ? err.message : String(err);

--- a/packages/davinci-client/src/lib/client.store.utils.ts
+++ b/packages/davinci-client/src/lib/client.store.utils.ts
@@ -5,20 +5,18 @@
  * of the MIT license. See the LICENSE file for details.
  */
 import { configureStore } from '@reduxjs/toolkit';
-import { Micro } from 'effect';
-import { exitIsSuccess, exitIsFail } from 'effect/Micro';
 
 import type { ActionTypes, RequestMiddleware } from '@forgerock/sdk-request-middleware';
 import type { logger as loggerFn } from '@forgerock/sdk-logger';
-import { isGenericError } from '@forgerock/sdk-utilities';
+import type { GenericError } from '@forgerock/sdk-types';
+
+import type { ErrorNode, ContinueNode, StartNode, SuccessNode } from '../types.js';
+import type { InternalErrorResponse } from './client.types.js';
 
 import { configSlice } from './config.slice.js';
 import { nodeSlice } from './node.slice.js';
 import { davinciApi } from './davinci.api.js';
-import { ErrorNode, ContinueNode, StartNode, SuccessNode } from '../types.js';
 import { wellknownApi } from './wellknown.api.js';
-import type { InternalErrorResponse, PollingStatus } from './client.types.js';
-import { PollingCollector } from './collector.types.js';
 
 export function createClientStore<ActionType extends ActionTypes>({
   requestMiddleware,
@@ -69,7 +67,7 @@ export function handleUpdateValidateError(
   };
 }
 
-type ClientStore = typeof createClientStore;
+export type ClientStore = typeof createClientStore;
 
 export type RootState = ReturnType<ReturnType<ClientStore>['getState']>;
 
@@ -80,195 +78,28 @@ export interface RootStateWithNode<T extends ErrorNode | ContinueNode | StartNod
 
 export type AppDispatch = ReturnType<ReturnType<ClientStore>['dispatch']>;
 
-export async function handleChallengePolling({
-  collector,
-  challenge,
-  store,
-  log,
-}: {
-  collector: PollingCollector;
-  challenge: string;
-  store: ReturnType<ClientStore>;
-  log: ReturnType<typeof loggerFn>;
-}): Promise<PollingStatus | InternalErrorResponse> {
-  if (!challenge) {
-    log.error('No challenge found on collector for poll operation');
-    return {
-      error: {
-        message: 'No challenge found on collector for poll operation',
-        type: 'state_error',
-      },
-      type: 'internal_error',
-    };
-  }
+/**
+ * @function createInternalError
+ * @description - Creates an InternalErrorResponse object
+ * @param message - The error message
+ * @param type - The error type
+ * @returns - An InternalErrorResponse object
+ */
+export function createInternalError(
+  message: string,
+  type: GenericError['type'] = 'internal_error',
+): InternalErrorResponse {
+  return { error: { message, type }, type: 'internal_error' };
+}
 
-  const rootState: RootState = store.getState();
-  const serverSlice = nodeSlice.selectors.selectServer(rootState);
-
-  if (serverSlice === null) {
-    log.error('No server info found for poll operation');
-    return {
-      error: {
-        message: 'No server info found for poll operation',
-        type: 'state_error',
-      },
-      type: 'internal_error',
-    };
-  }
-
-  if (isGenericError(serverSlice)) {
-    log.error(serverSlice.message ?? serverSlice.error);
-    return {
-      error: {
-        message: serverSlice.message ?? 'Failed to retrieve server info for poll operation',
-        type: 'internal_error',
-      },
-      type: 'internal_error',
-    };
-  }
-
-  if (serverSlice.status !== 'continue') {
-    return {
-      error: {
-        message: 'Not in a continue node state, must be in a continue node to use poll method',
-        type: 'state_error',
-      },
-    } as InternalErrorResponse;
-  }
-
-  // Construct the challenge polling endpoint
-  const links = serverSlice._links;
-  if (!links || !('self' in links) || !('href' in links['self']) || !links['self'].href) {
-    return {
-      error: {
-        message: 'No self link found in server info for challenge polling operation',
-        type: 'internal_error',
-      },
-    } as InternalErrorResponse;
-  }
-
-  const selfUrl = links['self'].href;
-  const url = new URL(selfUrl);
-  const baseUrl = url.origin;
-  const paths = url.pathname.split('/');
-  const envId = paths[1];
-
-  if (!baseUrl || !envId) {
-    return {
-      error: {
-        message:
-          'Failed to construct challenge polling endpoint. Requires host and environment ID.',
-        type: 'parse_error',
-      },
-    } as InternalErrorResponse;
-  }
-
-  const interactionId = serverSlice.interactionId;
-  if (!interactionId) {
-    return {
-      error: {
-        message: 'Missing interactionId in server info for challenge polling',
-        type: 'internal_error',
-      },
-    } as InternalErrorResponse;
-  }
-
-  const challengeEndpoint = `${baseUrl}/${envId}/davinci/user/credentials/challenge/${challenge}/status`;
-
-  // Start challenge polling
-  let retriesLeft = collector.output.config.pollRetries ?? 60;
-  const pollInterval = collector.output.config.pollInterval ?? 2000; // miliseconds
-
-  const queryµ = Micro.promise(() => {
-    retriesLeft--;
-    return store.dispatch(
-      davinciApi.endpoints.poll.initiate({
-        endpoint: challengeEndpoint,
-        interactionId,
-      }),
-    );
-  });
-
-  const challengePollµ = Micro.repeat(queryµ, {
-    while: ({ data, error }) =>
-      retriesLeft > 0 && !error && !(data as Record<string, unknown>)['isChallengeComplete'],
-    schedule: Micro.scheduleSpaced(pollInterval),
-  }).pipe(
-    Micro.flatMap(({ data, error }) => {
-      const pollResponse = data as Record<string, unknown>;
-
-      // Check for any errors and return the appropriate status
-      if (error) {
-        // SerializedError
-        let message = 'An unknown error occurred while challenge polling';
-        if ('message' in error && error.message) {
-          message = error.message;
-          return Micro.fail({
-            error: {
-              message,
-              type: 'unknown_error',
-            },
-            type: 'internal_error',
-          } as InternalErrorResponse);
-        }
-
-        // FetchBaseQueryError
-        let status: number | string = 'unknown';
-        if ('status' in error) {
-          status = error.status;
-
-          const errorDetails = error.data as Record<string, unknown>;
-          const serviceName = errorDetails['serviceName'];
-
-          // Check for an expired challenge
-          if (status === 400 && serviceName && serviceName === 'challengeExpired') {
-            log.debug('Challenge expired for polling');
-            return Micro.succeed('expired' as PollingStatus);
-          } else {
-            // If we're here there is some other type of network error and status != 200
-            // e.g. A bad challenge can return a httpStatus of 400 with code 4019
-            log.debug('Network error occurred during polling');
-            return Micro.succeed('error' as PollingStatus);
-          }
-        }
-      }
-
-      // If a successful response is recieved it can be either a timeout or true success
-      if (pollResponse['isChallengeComplete'] === true) {
-        const pollStatus = pollResponse['status'];
-        if (!pollStatus) {
-          return Micro.succeed('error' as PollingStatus);
-        } else {
-          return Micro.succeed(pollStatus as PollingStatus);
-        }
-      } else if (retriesLeft <= 0 && !pollResponse['isChallengeComplete']) {
-        return Micro.succeed('timedOut' as PollingStatus);
-      }
-
-      // Just in case no polling status was determined
-      return Micro.fail({
-        error: {
-          message: 'Unknown error occurred during polling',
-          type: 'unknown_error',
-        },
-        type: 'internal_error',
-      } as InternalErrorResponse);
-    }),
+/**
+ * Type guard: checks if a value is an InternalErrorResponse.
+ */
+export function isInternalError(value: unknown): value is InternalErrorResponse {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'type' in value &&
+    (value as Record<string, unknown>)['type'] === 'internal_error'
   );
-
-  const result = await Micro.runPromiseExit(challengePollµ);
-
-  if (exitIsSuccess(result)) {
-    return result.value;
-  } else if (exitIsFail(result)) {
-    return result.cause.error;
-  } else {
-    return {
-      error: {
-        message: result.cause.message,
-        type: 'unknown_error',
-      },
-      type: 'internal_error',
-    };
-  }
 }

--- a/packages/davinci-client/src/lib/client.store.utils.ts
+++ b/packages/davinci-client/src/lib/client.store.utils.ts
@@ -5,16 +5,20 @@
  * of the MIT license. See the LICENSE file for details.
  */
 import { configureStore } from '@reduxjs/toolkit';
+import { Micro } from 'effect';
+import { exitIsSuccess, exitIsFail } from 'effect/Micro';
 
 import type { ActionTypes, RequestMiddleware } from '@forgerock/sdk-request-middleware';
 import type { logger as loggerFn } from '@forgerock/sdk-logger';
+import { isGenericError } from '@forgerock/sdk-utilities';
 
 import { configSlice } from './config.slice.js';
 import { nodeSlice } from './node.slice.js';
 import { davinciApi } from './davinci.api.js';
 import { ErrorNode, ContinueNode, StartNode, SuccessNode } from '../types.js';
 import { wellknownApi } from './wellknown.api.js';
-import { InternalErrorResponse } from './client.types.js';
+import type { InternalErrorResponse, PollingStatus } from './client.types.js';
+import { PollingCollector } from './collector.types.js';
 
 export function createClientStore<ActionType extends ActionTypes>({
   requestMiddleware,
@@ -75,3 +79,196 @@ export interface RootStateWithNode<T extends ErrorNode | ContinueNode | StartNod
 }
 
 export type AppDispatch = ReturnType<ReturnType<ClientStore>['dispatch']>;
+
+export async function handleChallengePolling({
+  collector,
+  challenge,
+  store,
+  log,
+}: {
+  collector: PollingCollector;
+  challenge: string;
+  store: ReturnType<ClientStore>;
+  log: ReturnType<typeof loggerFn>;
+}): Promise<PollingStatus | InternalErrorResponse> {
+  if (!challenge) {
+    log.error('No challenge found on collector for poll operation');
+    return {
+      error: {
+        message: 'No challenge found on collector for poll operation',
+        type: 'state_error',
+      },
+      type: 'internal_error',
+    };
+  }
+
+  const rootState: RootState = store.getState();
+  const serverSlice = nodeSlice.selectors.selectServer(rootState);
+
+  if (serverSlice === null) {
+    log.error('No server info found for poll operation');
+    return {
+      error: {
+        message: 'No server info found for poll operation',
+        type: 'state_error',
+      },
+      type: 'internal_error',
+    };
+  }
+
+  if (isGenericError(serverSlice)) {
+    log.error(serverSlice.message ?? serverSlice.error);
+    return {
+      error: {
+        message: serverSlice.message ?? 'Failed to retrieve server info for poll operation',
+        type: 'internal_error',
+      },
+      type: 'internal_error',
+    };
+  }
+
+  if (serverSlice.status !== 'continue') {
+    return {
+      error: {
+        message: 'Not in a continue node state, must be in a continue node to use poll method',
+        type: 'state_error',
+      },
+    } as InternalErrorResponse;
+  }
+
+  // Construct the challenge polling endpoint
+  const links = serverSlice._links;
+  if (!links || !('self' in links) || !('href' in links['self']) || !links['self'].href) {
+    return {
+      error: {
+        message: 'No self link found in server info for challenge polling operation',
+        type: 'internal_error',
+      },
+    } as InternalErrorResponse;
+  }
+
+  const selfUrl = links['self'].href;
+  const url = new URL(selfUrl);
+  const baseUrl = url.origin;
+  const paths = url.pathname.split('/');
+  const envId = paths[1];
+
+  if (!baseUrl || !envId) {
+    return {
+      error: {
+        message:
+          'Failed to construct challenge polling endpoint. Requires host and environment ID.',
+        type: 'parse_error',
+      },
+    } as InternalErrorResponse;
+  }
+
+  const interactionId = serverSlice.interactionId;
+  if (!interactionId) {
+    return {
+      error: {
+        message: 'Missing interactionId in server info for challenge polling',
+        type: 'internal_error',
+      },
+    } as InternalErrorResponse;
+  }
+
+  const challengeEndpoint = `${baseUrl}/${envId}/davinci/user/credentials/challenge/${challenge}/status`;
+
+  // Start challenge polling
+  let retriesLeft = collector.output.config.pollRetries ?? 60;
+  const pollInterval = collector.output.config.pollInterval ?? 2000; // miliseconds
+
+  const queryµ = Micro.promise(() => {
+    retriesLeft--;
+    return store.dispatch(
+      davinciApi.endpoints.poll.initiate({
+        challengeEndpoint,
+        interactionId,
+      }),
+    );
+  });
+
+  const challengePollµ = Micro.repeat(queryµ, {
+    while: ({ data, error }) =>
+      retriesLeft > 0 && !error && !(data as Record<string, unknown>)['isChallengeComplete'],
+    schedule: Micro.scheduleSpaced(pollInterval),
+  }).pipe(
+    Micro.flatMap(({ data, error }) => {
+      const pollResponse = data as Record<string, unknown>;
+
+      // Check for any errors and return the appropriate status
+      if (error) {
+        // SerializedError
+        let message = 'An unknown error occurred while challenge polling';
+        if ('message' in error && error.message) {
+          message = error.message;
+          return Micro.fail({
+            error: {
+              message,
+              type: 'unknown_error',
+            },
+            type: 'internal_error',
+          } as InternalErrorResponse);
+        }
+
+        // FetchBaseQueryError
+        let status: number | string = 'unknown';
+        if ('status' in error) {
+          status = error.status;
+
+          const errorDetails = error.data as Record<string, unknown>;
+          const serviceName = errorDetails['serviceName'];
+
+          // Check for an expired challenge
+          if (status === 400 && serviceName && serviceName === 'challengeExpired') {
+            log.debug('Challenge expired for polling');
+            return Micro.succeed('expired' as PollingStatus);
+          } else {
+            // If we're here there is some other type of network error and status != 200
+            // e.g. A bad challenge can return a httpStatus of 400 with code 4019
+            log.debug('Network error occurred during polling');
+            return Micro.succeed('error' as PollingStatus);
+          }
+        }
+      }
+
+      // If a successful response is recieved it can be either a timeout or true success
+      if (pollResponse['isChallengeComplete'] === true) {
+        const pollStatus = pollResponse['status'];
+        if (!pollStatus) {
+          return Micro.succeed('error' as PollingStatus);
+        } else {
+          return Micro.succeed(pollStatus as PollingStatus);
+        }
+      } else if (retriesLeft <= 0 && !pollResponse['isChallengeComplete']) {
+        return Micro.succeed('timedOut' as PollingStatus);
+      }
+
+      // Just in case no polling status was determined
+      return Micro.fail({
+        error: {
+          message: 'Unknown error occurred during polling',
+          type: 'unknown_error',
+        },
+        type: 'internal_error',
+      } as InternalErrorResponse);
+    }),
+  );
+
+  const result = await Micro.runPromiseExit(challengePollµ);
+
+  if (exitIsSuccess(result)) {
+    return result.value;
+  } else if (exitIsFail(result)) {
+    return result.cause.error;
+  } else {
+    return {
+      error: {
+        message: result.cause.message,
+        type: 'unknown_error',
+      },
+      type: 'internal_error',
+    };
+  }
+}

--- a/packages/davinci-client/src/lib/client.store.utils.ts
+++ b/packages/davinci-client/src/lib/client.store.utils.ts
@@ -183,7 +183,7 @@ export async function handleChallengePolling({
     retriesLeft--;
     return store.dispatch(
       davinciApi.endpoints.poll.initiate({
-        challengeEndpoint,
+        endpoint: challengeEndpoint,
         interactionId,
       }),
     );

--- a/packages/davinci-client/src/lib/client.types.ts
+++ b/packages/davinci-client/src/lib/client.types.ts
@@ -92,5 +92,11 @@ export type Validator = (value: string) =>
 
 export type NodeStates = StartNode | ContinueNode | ErrorNode | SuccessNode | FailureNode;
 
-export type PollingStatusComplete = 'approved' | 'denied' | 'continue' | string;
-export type PollingStatus = PollingStatusComplete | 'expired' | 'timedOut' | 'error';
+export type PollingStatusChallengeComplete = 'approved' | 'denied' | 'continue' | string;
+export type PollingStatusChallenge =
+  | PollingStatusChallengeComplete
+  | 'expired'
+  | 'timedOut'
+  | 'error';
+export type PollingStatusContinue = 'continue' | 'timedOut';
+export type PollingStatus = PollingStatusContinue | PollingStatusChallenge;

--- a/packages/davinci-client/src/lib/client.types.ts
+++ b/packages/davinci-client/src/lib/client.types.ts
@@ -91,3 +91,6 @@ export type Validator = (value: string) =>
     };
 
 export type NodeStates = StartNode | ContinueNode | ErrorNode | SuccessNode | FailureNode;
+
+export type PollingStatusComplete = 'approved' | 'denied' | 'continue' | string;
+export type PollingStatus = PollingStatusComplete | 'expired' | 'timedOut' | 'error';

--- a/packages/davinci-client/src/lib/client.types.ts
+++ b/packages/davinci-client/src/lib/client.types.ts
@@ -89,10 +89,19 @@ export type Validator = (value: string) =>
       };
       type: string;
     };
+export type Poller = () => Promise<PollingStatus | InternalErrorResponse>;
 
 export type NodeStates = StartNode | ContinueNode | ErrorNode | SuccessNode | FailureNode;
 
-export type PollingStatusChallengeComplete = 'approved' | 'denied' | 'continue' | string;
+/**
+ * Polling status type for handling custom statuses. Resolves to any string.
+ */
+export type CustomPollingStatus = string & {};
+export type PollingStatusChallengeComplete =
+  | 'approved'
+  | 'denied'
+  | 'continue'
+  | CustomPollingStatus;
 export type PollingStatusChallenge =
   | PollingStatusChallengeComplete
   | 'expired'

--- a/packages/davinci-client/src/lib/collector.types.ts
+++ b/packages/davinci-client/src/lib/collector.types.ts
@@ -607,6 +607,7 @@ export interface PollingOutputValue {
   pollRetries: number;
   pollChallengeStatus?: boolean;
   challenge?: string;
+  retriesRemaining?: number;
 }
 
 export type AutoCollectorCategories = 'SingleValueAutoCollector' | 'ObjectValueAutoCollector';

--- a/packages/davinci-client/src/lib/collector.types.ts
+++ b/packages/davinci-client/src/lib/collector.types.ts
@@ -602,8 +602,18 @@ export interface FidoAuthenticationOutputValue {
   trigger: string;
 }
 
+export interface PollingOutputValue {
+  pollInterval: number;
+  pollRetries: number;
+  pollChallengeStatus?: boolean;
+  challenge?: string;
+}
+
 export type AutoCollectorCategories = 'SingleValueAutoCollector' | 'ObjectValueAutoCollector';
-export type SingleValueAutoCollectorTypes = 'SingleValueAutoCollector' | 'ProtectCollector';
+export type SingleValueAutoCollectorTypes =
+  | 'SingleValueAutoCollector'
+  | 'ProtectCollector'
+  | 'PollingCollector';
 export type ObjectValueAutoCollectorTypes =
   | 'ObjectValueAutoCollector'
   | 'FidoRegistrationCollector'
@@ -652,6 +662,12 @@ export type FidoAuthenticationCollector = AutoCollector<
   FidoAuthenticationInputValue,
   FidoAuthenticationOutputValue
 >;
+export type PollingCollector = AutoCollector<
+  'SingleValueAutoCollector',
+  'PollingCollector',
+  string,
+  PollingOutputValue
+>;
 export type SingleValueAutoCollector = AutoCollector<
   'SingleValueAutoCollector',
   'SingleValueAutoCollector',
@@ -667,6 +683,7 @@ export type AutoCollectors =
   | ProtectCollector
   | FidoRegistrationCollector
   | FidoAuthenticationCollector
+  | PollingCollector
   | SingleValueAutoCollector
   | ObjectValueAutoCollector;
 
@@ -679,14 +696,16 @@ export type AutoCollectors =
  */
 export type InferAutoCollectorType<T extends AutoCollectorTypes> = T extends 'ProtectCollector'
   ? ProtectCollector
-  : T extends 'FidoRegistrationCollector'
-    ? FidoRegistrationCollector
-    : T extends 'FidoAuthenticationCollector'
-      ? FidoAuthenticationCollector
-      : T extends 'ObjectValueAutoCollector'
-        ? ObjectValueAutoCollector
-        : /**
-           * At this point, we have not passed in a collector type
-           * so we can return a SingleValueAutoCollector
-           **/
-          SingleValueAutoCollector;
+  : T extends 'PollingCollector'
+    ? PollingCollector
+    : T extends 'FidoRegistrationCollector'
+      ? FidoRegistrationCollector
+      : T extends 'FidoAuthenticationCollector'
+        ? FidoAuthenticationCollector
+        : T extends 'ObjectValueAutoCollector'
+          ? ObjectValueAutoCollector
+          : /**
+             * At this point, we have not passed in a collector type
+             * so we can return a SingleValueAutoCollector
+             **/
+            SingleValueAutoCollector;

--- a/packages/davinci-client/src/lib/collector.utils.test.ts
+++ b/packages/davinci-client/src/lib/collector.utils.test.ts
@@ -33,6 +33,7 @@ import type {
   PhoneNumberField,
   ProtectField,
   QrCodeField,
+  PollingField,
   ReadOnlyField,
   RedirectField,
   StandardField,
@@ -908,6 +909,40 @@ describe('returnSingleValueAutoCollector', () => {
         config: {
           behavioralDataCollection: mockField.behavioralDataCollection,
           universalDeviceIdentification: mockField.universalDeviceIdentification,
+        },
+      },
+    });
+  });
+
+  it('should create a valid PollingCollector', () => {
+    const mockField: PollingField = {
+      type: 'POLLING',
+      key: 'polling-key',
+      pollInterval: 2000,
+      pollRetries: 20,
+      pollChallengeStatus: true,
+      challenge: 'hlMtnk2RsPtnlYs2n1IiS9qhTZQLK-AOHNAo8-F3eY0',
+    };
+    const result = returnSingleValueAutoCollector(mockField, 1, 'PollingCollector');
+    expect(result).toEqual({
+      category: 'SingleValueAutoCollector',
+      error: null,
+      type: 'PollingCollector',
+      id: 'polling-key-1',
+      name: 'polling-key',
+      input: {
+        key: mockField.key,
+        value: '',
+        type: mockField.type,
+      },
+      output: {
+        key: mockField.key,
+        type: mockField.type,
+        config: {
+          pollInterval: 2000,
+          pollRetries: 20,
+          pollChallengeStatus: true,
+          challenge: 'hlMtnk2RsPtnlYs2n1IiS9qhTZQLK-AOHNAo8-F3eY0',
         },
       },
     });

--- a/packages/davinci-client/src/lib/collector.utils.ts
+++ b/packages/davinci-client/src/lib/collector.utils.ts
@@ -40,6 +40,7 @@ import type {
   PhoneNumberField,
   ProtectField,
   QrCodeField,
+  PollingField,
   ReadOnlyField,
   RedirectField,
   SingleSelectField,
@@ -273,7 +274,7 @@ export function returnSingleValueCollector<
  * @returns {AutoCollector} The constructed AutoCollector object.
  */
 export function returnSingleValueAutoCollector<
-  Field extends ProtectField,
+  Field extends ProtectField | PollingField,
   CollectorType extends SingleValueAutoCollectorTypes = 'SingleValueAutoCollector',
 >(field: Field, idx: number, collectorType: CollectorType) {
   let error = '';
@@ -284,7 +285,7 @@ export function returnSingleValueAutoCollector<
     error = `${error}Type is not found in the field object. `;
   }
 
-  if (collectorType === 'ProtectCollector') {
+  if (collectorType === 'ProtectCollector' && field.type === 'PROTECT') {
     return {
       category: 'SingleValueAutoCollector',
       error: error || null,
@@ -305,6 +306,31 @@ export function returnSingleValueAutoCollector<
         },
       },
     } as InferAutoCollectorType<'ProtectCollector'>;
+  } else if (collectorType === 'PollingCollector' && field.type === 'POLLING') {
+    return {
+      category: 'SingleValueAutoCollector',
+      error: error || null,
+      type: collectorType,
+      id: `${field?.key}-${idx}`,
+      name: field.key,
+      input: {
+        key: field.key,
+        value: '',
+        type: field.type,
+      },
+      output: {
+        key: field.key,
+        type: field.type,
+        config: {
+          pollInterval: field.pollInterval,
+          pollRetries: field.pollRetries,
+          ...(field.pollChallengeStatus !== undefined && {
+            pollChallengeStatus: field.pollChallengeStatus,
+          }),
+          ...(field.challenge && { challenge: field.challenge }),
+        },
+      },
+    } as InferAutoCollectorType<'PollingCollector'>;
   } else {
     return {
       category: 'SingleValueAutoCollector',
@@ -440,6 +466,16 @@ export function returnSingleSelectCollector(field: SingleSelectField, idx: numbe
  */
 export function returnProtectCollector(field: ProtectField, idx: number) {
   return returnSingleValueAutoCollector(field, idx, 'ProtectCollector');
+}
+
+/**
+ * @function returnPollingCollector - Creates a PollingCollector object based on the provided field and index.
+ * @param {DaVinciField} field - The field object containing key, label, type, and links.
+ * @param {number} idx - The index to be used in the id of the PollingCollector.
+ * @returns {PollingCollector} The constructed PollingCollector object.
+ */
+export function returnPollingCollector(field: PollingField, idx: number) {
+  return returnSingleValueAutoCollector(field, idx, 'PollingCollector');
 }
 
 /**

--- a/packages/davinci-client/src/lib/collector.utils.ts
+++ b/packages/davinci-client/src/lib/collector.utils.ts
@@ -328,6 +328,7 @@ export function returnSingleValueAutoCollector<
             pollChallengeStatus: field.pollChallengeStatus,
           }),
           ...(field.challenge && { challenge: field.challenge }),
+          ...(!field.challenge && { retriesRemaining: field.pollRetries }),
         },
       },
     } as InferAutoCollectorType<'PollingCollector'>;

--- a/packages/davinci-client/src/lib/davinci.api.ts
+++ b/packages/davinci-client/src/lib/davinci.api.ts
@@ -430,19 +430,19 @@ export const davinciApi = createApi({
     }),
 
     /**
-     * @method poll - method for polling in a DaVinci flow
+     * @method poll - method for challenge polling in a DaVinci flow
      */
     /**
      * The poll endpoint differs from others in that it does not use onQueryStarted. This allows
-     * us to use the response from onQueryFn, while avoiding updating the node state with the poll
+     * us to use the response from queryFn, while avoiding updating the node state with the poll
      * response which causes the node to lose the initial collectors state when polling started.
      */
-    poll: builder.mutation<unknown, { challengeEndpoint: string; interactionId: string }>({
-      async queryFn({ challengeEndpoint, interactionId }, api, _c, baseQuery) {
+    poll: builder.mutation<unknown, { endpoint: string; interactionId: string }>({
+      async queryFn({ endpoint, interactionId }, api, _c, baseQuery) {
         const { requestMiddleware, logger } = api.extra as Extras;
 
         const request: FetchArgs = {
-          url: challengeEndpoint,
+          url: endpoint,
           credentials: 'include',
           method: 'POST',
           headers: {

--- a/packages/davinci-client/src/lib/davinci.api.ts
+++ b/packages/davinci-client/src/lib/davinci.api.ts
@@ -58,10 +58,12 @@ export const davinciApi = createApi({
   reducerPath: 'davinci',
   // TODO: implement extraOptions for request interceptors: https://stackoverflow.com/a/77569083 & https://stackoverflow.com/a/65129117
   baseQuery: fetchBaseQuery({
-    prepareHeaders: (headers) => {
+    prepareHeaders: (headers, { endpoint }) => {
       headers.set('Accept', 'application/json');
-      headers.set('x-requested-with', 'ping-sdk');
-      headers.set('x-requested-platform', 'javascript');
+      if (endpoint !== 'poll') {
+        headers.set('x-requested-with', 'ping-sdk');
+        headers.set('x-requested-platform', 'javascript');
+      }
       return headers;
     },
   }),
@@ -348,6 +350,10 @@ export const davinciApi = createApi({
         handleResponse(cacheEntry, api.dispatch, response?.status || 0, logger);
       },
     }),
+
+    /**
+     * @method resume - method for resuming a social login DaVinci flow
+     */
     resume: builder.query<unknown, { serverInfo: ContinueNode['server']; continueToken: string }>({
       async queryFn({ serverInfo, continueToken }, api, _c, baseQuery) {
         const { requestMiddleware, logger } = api.extra as Extras;
@@ -420,6 +426,38 @@ export const davinciApi = createApi({
         logger.debug('Davinci API response', cacheEntry);
 
         handleResponse(cacheEntry, api.dispatch, response?.status || 0, logger);
+      },
+    }),
+
+    /**
+     * @method poll - method for polling in a DaVinci flow
+     */
+    /**
+     * The poll endpoint differs from others in that it does not use onQueryStarted. This allows
+     * us to use the response from onQueryFn, while avoiding updating the node state with the poll
+     * response which causes the node to lose the initial collectors state when polling started.
+     */
+    poll: builder.mutation<unknown, { challengeEndpoint: string; interactionId: string }>({
+      async queryFn({ challengeEndpoint, interactionId }, api, _c, baseQuery) {
+        const { requestMiddleware, logger } = api.extra as Extras;
+
+        const request: FetchArgs = {
+          url: challengeEndpoint,
+          credentials: 'include',
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            interactionId,
+          },
+          body: JSON.stringify({}),
+        };
+
+        logger.debug('Davinci API request', request);
+        const response: BaseQueryResponse = initQuery(request, 'poll')
+          .applyMiddleware(requestMiddleware)
+          .applyQuery(async (req: FetchArgs) => await baseQuery(req));
+
+        return response;
       },
     }),
   }),

--- a/packages/davinci-client/src/lib/davinci.types.ts
+++ b/packages/davinci-client/src/lib/davinci.types.ts
@@ -272,6 +272,17 @@ export interface DaVinciNextResponse extends DaVinciBaseResponse {
 }
 
 /**
+ * Continue Polling Response DaVinci API
+ */
+
+export interface DaVinciPollResponse extends DaVinciBaseResponse {
+  // Optional properties
+  eventName?: string;
+  success?: boolean;
+  _links?: Links;
+}
+
+/**
  * Error Response from DaVinci API
  */
 

--- a/packages/davinci-client/src/lib/davinci.types.ts
+++ b/packages/davinci-client/src/lib/davinci.types.ts
@@ -19,7 +19,7 @@ export interface DaVinciRequest {
   eventName: string;
   interactionId: string;
   parameters: {
-    eventType: 'submit' | 'action';
+    eventType: 'submit' | 'action' | 'polling';
     data: {
       actionKey: string;
       formData?: Record<string, unknown>;
@@ -219,6 +219,15 @@ export type FidoAuthenticationField = {
   required: boolean;
 };
 
+export type PollingField = {
+  type: 'POLLING';
+  key: string;
+  pollInterval: number;
+  pollRetries: number;
+  pollChallengeStatus: boolean;
+  challenge: string;
+};
+
 export type UnknownField = Record<string, unknown>;
 
 export type ComplexValueFields =
@@ -226,7 +235,8 @@ export type ComplexValueFields =
   | DeviceRegistrationField
   | PhoneNumberField
   | FidoRegistrationField
-  | FidoAuthenticationField;
+  | FidoAuthenticationField
+  | PollingField;
 export type MultiValueFields = MultiSelectField;
 export type ReadOnlyFields = ReadOnlyField | QrCodeField;
 export type RedirectFields = RedirectField;

--- a/packages/davinci-client/src/lib/davinci.types.ts
+++ b/packages/davinci-client/src/lib/davinci.types.ts
@@ -224,8 +224,8 @@ export type PollingField = {
   key: string;
   pollInterval: number;
   pollRetries: number;
-  pollChallengeStatus: boolean;
-  challenge: string;
+  pollChallengeStatus?: boolean;
+  challenge?: string;
 };
 
 export type UnknownField = Record<string, unknown>;

--- a/packages/davinci-client/src/lib/davinci.utils.test.ts
+++ b/packages/davinci-client/src/lib/davinci.utils.test.ts
@@ -114,6 +114,102 @@ describe('transformSubmitRequest', () => {
     const result = transformSubmitRequest(node, logger({ level: 'none' }));
     expect(result).toEqual(expectedRequest);
   });
+
+  it('should set eventType to "submit" when PollingCollector exists but has no payload', () => {
+    const node: ContinueNode = {
+      cache: {
+        key: '123',
+      },
+      client: {
+        action: 'SIGNON',
+        collectors: [
+          {
+            category: 'SingleValueAutoCollector',
+            error: null,
+            type: 'PollingCollector',
+            id: 'polling-field-2',
+            name: 'polling-field',
+            input: {
+              key: 'polling-field',
+              value: '',
+              type: 'POLLING',
+            },
+            output: {
+              key: 'polling-field',
+              type: 'POLLING',
+              config: {
+                pollInterval: 2000,
+                pollRetries: 20,
+                pollChallengeStatus: true,
+                challenge: '123_456-7890',
+              },
+            },
+          },
+        ],
+        status: 'continue',
+      },
+      error: null,
+      httpStatus: 200,
+      server: {
+        id: '123',
+        eventName: 'login',
+        interactionId: '456',
+        status: 'continue',
+      },
+      status: 'continue',
+    };
+
+    const result = transformSubmitRequest(node, logger({ level: 'none' }));
+    expect(result.parameters.eventType).toBe('submit');
+  });
+
+  it('should set eventType to "polling" when PollingCollector has populated payload', () => {
+    const node: ContinueNode = {
+      cache: {
+        key: '123',
+      },
+      client: {
+        action: 'SIGNON',
+        collectors: [
+          {
+            category: 'SingleValueAutoCollector',
+            error: null,
+            type: 'PollingCollector',
+            id: 'polling-field-2',
+            name: 'polling-field',
+            input: {
+              key: 'polling-field',
+              value: 'complete',
+              type: 'POLLING',
+            },
+            output: {
+              key: 'polling-field',
+              type: 'POLLING',
+              config: {
+                pollInterval: 2000,
+                pollRetries: 20,
+                pollChallengeStatus: true,
+                challenge: '123_456-7890',
+              },
+            },
+          },
+        ],
+        status: 'continue',
+      },
+      error: null,
+      httpStatus: 200,
+      server: {
+        id: '123',
+        eventName: 'login',
+        interactionId: '456',
+        status: 'continue',
+      },
+      status: 'continue',
+    };
+
+    const result = transformSubmitRequest(node, logger({ level: 'none' }));
+    expect(result.parameters.eventType).toBe('polling');
+  });
 });
 
 describe('transformActionRequest', () => {

--- a/packages/davinci-client/src/lib/davinci.utils.ts
+++ b/packages/davinci-client/src/lib/davinci.utils.ts
@@ -230,6 +230,7 @@ export function handleResponse(
    */
   if (cacheEntry.isSuccess) {
     const requestId = cacheEntry.requestId;
+
     const hasNextUrl = () => {
       const data = cacheEntry.data;
 
@@ -243,9 +244,19 @@ export function handleResponse(
       return false;
     };
 
+    const isContinuePollingEvent = () => {
+      const data = cacheEntry.data;
+      return (
+        'eventName' in data &&
+        ['rewindStateToLastRenderedUI', 'rewindStateToSpecificRenderedUI'].includes(data.eventName)
+      );
+    };
+
     if ('session' in cacheEntry.data || 'authorizeResponse' in cacheEntry.data) {
       const data = cacheEntry.data as DaVinciSuccessResponse;
       dispatch(nodeSlice.actions.success({ data, requestId, httpStatus: status }));
+    } else if (isContinuePollingEvent()) {
+      dispatch(nodeSlice.actions.poll({ requestId }));
     } else if (hasNextUrl()) {
       const data = cacheEntry.data as DaVinciNextResponse;
       dispatch(nodeSlice.actions.next({ data, requestId, httpStatus: status }));

--- a/packages/davinci-client/src/lib/davinci.utils.ts
+++ b/packages/davinci-client/src/lib/davinci.utils.ts
@@ -31,6 +31,7 @@ import {
 /**
  * @function transformSubmitRequest - Transforms a NextNode into a DaVinciRequest for form submissions
  * @param {ContinueNode} node - The node to transform into a DaVinciRequest
+ * @param {ReturnType<typeof loggerFn>} logger - Logger instance
  * @returns {DaVinciRequest} - The transformed request object
  */
 export function transformSubmitRequest(
@@ -63,10 +64,14 @@ export function transformSubmitRequest(
     return acc;
   }, {});
 
-  // Set eventType based on PollingCollector presence
-  const eventType = collectors?.some((collector) => collector.type === 'PollingCollector')
-    ? 'polling'
-    : 'submit';
+  // Determine eventType: check if there's a PollingCollector with a non-empty string value
+  const hasPollingWithPayload = collectors?.some(
+    (collector) =>
+      collector.type === 'PollingCollector' &&
+      typeof collector.input.value === 'string' &&
+      collector.input.value,
+  );
+  const eventType = hasPollingWithPayload ? 'polling' : 'submit';
 
   logger.debug('Transforming submit request', { node, formData });
 

--- a/packages/davinci-client/src/lib/davinci.utils.ts
+++ b/packages/davinci-client/src/lib/davinci.utils.ts
@@ -62,6 +62,12 @@ export function transformSubmitRequest(
     acc[collector.input.key] = collector.input.value;
     return acc;
   }, {});
+
+  // Set eventType based on PollingCollector presence
+  const eventType = collectors?.some((collector) => collector.type === 'PollingCollector')
+    ? 'polling'
+    : 'submit';
+
   logger.debug('Transforming submit request', { node, formData });
 
   return {
@@ -69,7 +75,7 @@ export function transformSubmitRequest(
     eventName: node.server.eventName || '',
     interactionId: node.server.interactionId || '',
     parameters: {
-      eventType: 'submit',
+      eventType,
       data: {
         actionKey: node.client?.action || '',
         formData: formData || {},

--- a/packages/davinci-client/src/lib/mock-data/node.poll.mock.ts
+++ b/packages/davinci-client/src/lib/mock-data/node.poll.mock.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+/**
+ * A DaVinci response with a POLLING field (continue polling).
+ */
+export const continuePolling = {
+  interactionId: 'poll-interaction-id',
+  interactionToken: 'poll-token',
+  _links: { next: { href: 'https://auth.pingone.ca/connections/poll' } },
+  eventName: 'continue',
+  id: 'poll-node-id',
+  form: {
+    name: 'Polling Form',
+    description: '',
+    category: 'CUSTOM_HTML',
+    components: {
+      fields: [
+        {
+          type: 'POLLING',
+          key: 'polling',
+          pollInterval: 2000,
+          pollRetries: 5,
+        },
+      ],
+    },
+  },
+};
+
+/**
+ * A DaVinci response with a POLLING field (challenge polling).
+ */
+export const challengePolling = {
+  ...continuePolling,
+  form: {
+    ...continuePolling.form,
+    components: {
+      fields: [
+        {
+          type: 'POLLING',
+          key: 'polling',
+          pollInterval: 2000,
+          pollRetries: 5,
+          pollChallengeStatus: true,
+          challenge: 'test-challenge-value',
+        },
+      ],
+    },
+  },
+};

--- a/packages/davinci-client/src/lib/node.reducer.test.ts
+++ b/packages/davinci-client/src/lib/node.reducer.test.ts
@@ -14,6 +14,7 @@ import type {
   FidoRegistrationCollector,
   MultiSelectCollector,
   PhoneNumberCollector,
+  PollingCollector,
   ProtectCollector,
   QrCodeCollector,
   SubmitCollector,
@@ -1058,6 +1059,134 @@ describe('The node collector reducer with FidoRegistrationFieldValue', () => {
         },
       },
     ]);
+  });
+});
+
+describe('The node collector reducer with pollCollectorValues', () => {
+  const basePollingCollector: PollingCollector = {
+    category: 'SingleValueAutoCollector',
+    error: null,
+    type: 'PollingCollector',
+    id: 'polling-0',
+    name: 'polling',
+    input: {
+      key: 'polling',
+      value: '',
+      type: 'POLLING',
+    },
+    output: {
+      key: 'polling',
+      type: 'POLLING',
+      config: {
+        pollInterval: 2000,
+        pollRetries: 5,
+        retriesRemaining: 5,
+      },
+    },
+  };
+
+  it('should decrement retriesRemaining on each poll', () => {
+    const action = { type: 'node/poll' };
+    const result = nodeCollectorReducer([basePollingCollector], action);
+    expect((result[0] as PollingCollector).output.config.retriesRemaining).toBe(4);
+  });
+
+  it('should decrement retriesRemaining from 1 to 0', () => {
+    const action = { type: 'node/poll' };
+    const state: PollingCollector[] = [
+      {
+        ...basePollingCollector,
+        output: {
+          ...basePollingCollector.output,
+          config: { ...basePollingCollector.output.config, retriesRemaining: 1 },
+        },
+      },
+    ];
+    const result = nodeCollectorReducer(state, action);
+    expect((result[0] as PollingCollector).output.config.retriesRemaining).toBe(0);
+  });
+
+  it('should return state unchanged when no PollingCollector exists', () => {
+    const action = { type: 'node/poll' };
+    const state: TextCollector[] = [
+      {
+        category: 'SingleValueCollector',
+        error: null,
+        type: 'TextCollector',
+        id: 'username-0',
+        name: 'username',
+        input: { key: 'username', value: '', type: 'TEXT' },
+        output: { key: 'username', label: 'Username', type: 'TEXT', value: '' },
+      },
+    ];
+    const result = nodeCollectorReducer(state, action);
+    expect(result).toEqual(state);
+  });
+
+  it('should return state unchanged when state is empty', () => {
+    const action = { type: 'node/poll' };
+    const result = nodeCollectorReducer([], action);
+    expect(result).toEqual([]);
+  });
+
+  it('should set error when retriesRemaining is undefined', () => {
+    const action = { type: 'node/poll' };
+    const state: PollingCollector[] = [
+      {
+        ...basePollingCollector,
+        output: {
+          ...basePollingCollector.output,
+          config: { pollInterval: 2000, pollRetries: 5 },
+        },
+      },
+    ];
+    const result = nodeCollectorReducer(state, action);
+    expect((result[0] as PollingCollector).error).toBe(
+      'Polling collector does not track retriesRemaining',
+    );
+  });
+
+  it('should set error when retriesRemaining is 0', () => {
+    const action = { type: 'node/poll' };
+    const state: PollingCollector[] = [
+      {
+        ...basePollingCollector,
+        output: {
+          ...basePollingCollector.output,
+          config: { ...basePollingCollector.output.config, retriesRemaining: 0 },
+        },
+      },
+    ];
+    const result = nodeCollectorReducer(state, action);
+    expect((result[0] as PollingCollector).error).toBe('No poll retries left');
+  });
+
+  it('should set error when retriesRemaining is negative', () => {
+    const action = { type: 'node/poll' };
+    const state: PollingCollector[] = [
+      {
+        ...basePollingCollector,
+        output: {
+          ...basePollingCollector.output,
+          config: { ...basePollingCollector.output.config, retriesRemaining: -1 },
+        },
+      },
+    ];
+    const result = nodeCollectorReducer(state, action);
+    expect((result[0] as PollingCollector).error).toBe('No poll retries left');
+  });
+
+  it('should clear error on successful decrement', () => {
+    const action = { type: 'node/poll' };
+    const state: PollingCollector[] = [
+      {
+        ...basePollingCollector,
+        error: 'previous error',
+      },
+    ];
+    const result = nodeCollectorReducer(state, action);
+    expect((result[0] as PollingCollector).error).toBeNull();
+    expect((result[0] as PollingCollector).output.config.retriesRemaining).toBe(4);
   });
 });
 

--- a/packages/davinci-client/src/lib/node.reducer.ts
+++ b/packages/davinci-client/src/lib/node.reducer.ts
@@ -344,13 +344,24 @@ export const nodeCollectorReducer = createReducer(initialCollectorValues, (build
      * transformed to `'node/poll'` for the action type.
      */
     .addCase(pollCollectorValues, (state) => {
-      // For challenge polling, track and decrement retries when this reducer is called
+      // For continue polling, track and decrement retries when this reducer is called
       const pollCollector = state.find((collector) => collector.type === 'PollingCollector');
 
-      if (!pollCollector?.output.config.retriesRemaining) {
-        throw new Error('No poll collector found to update');
+      if (!pollCollector) {
+        return;
       }
 
+      if (pollCollector.output.config.retriesRemaining === undefined) {
+        pollCollector.error = 'Polling collector does not track retriesRemaining';
+        return;
+      }
+
+      if (pollCollector.output.config.retriesRemaining <= 0) {
+        pollCollector.error = 'No poll retries left';
+        return;
+      }
+
+      pollCollector.error = null;
       pollCollector.output.config.retriesRemaining--;
     });
 });

--- a/packages/davinci-client/src/lib/node.reducer.ts
+++ b/packages/davinci-client/src/lib/node.reducer.ts
@@ -25,6 +25,7 @@ import {
   returnObjectSelectCollector,
   returnObjectValueCollector,
   returnProtectCollector,
+  returnPollingCollector,
   returnUnknownCollector,
   returnFidoRegistrationCollector,
   returnFidoAuthenticationCollector,
@@ -50,6 +51,7 @@ import type {
   PhoneNumberOutputValue,
   UnknownCollector,
   ProtectCollector,
+  PollingCollector,
   FidoRegistrationCollector,
   FidoAuthenticationCollector,
   FidoAuthenticationInputValue,
@@ -98,6 +100,7 @@ const initialCollectorValues: (
   | ValidatedTextCollector
   | UnknownCollector
   | ProtectCollector
+  | PollingCollector
   | FidoRegistrationCollector
   | FidoAuthenticationCollector
   | QrCodeCollector
@@ -186,6 +189,10 @@ export const nodeCollectorReducer = createReducer(initialCollectorValues, (build
               case 'PROTECT': {
                 return returnProtectCollector(field, idx);
               }
+              case 'POLLING': {
+                // No data to send
+                return returnPollingCollector(field, idx);
+              }
               case 'FIDO2': {
                 if (field.action === 'REGISTER') {
                   return returnFidoRegistrationCollector(field, idx);
@@ -232,7 +239,7 @@ export const nodeCollectorReducer = createReducer(initialCollectorValues, (build
       if (
         collector.category === 'SingleValueCollector' ||
         collector.category === 'ValidatedSingleValueCollector' ||
-        collector.type === 'ProtectCollector'
+        collector.category === 'SingleValueAutoCollector'
       ) {
         if (typeof action.payload.value !== 'string') {
           throw new Error('Value argument must be a string');

--- a/packages/davinci-client/src/lib/node.reducer.ts
+++ b/packages/davinci-client/src/lib/node.reducer.ts
@@ -79,6 +79,7 @@ export const updateCollectorValues = createAction<{
     | FidoAuthenticationInputValue;
   index?: number;
 }>('node/update');
+export const pollCollectorValues = createAction('node/poll');
 
 /**
  * @const initialCollectorValues - Initial state for the collector values
@@ -336,5 +337,20 @@ export const nodeCollectorReducer = createReducer(initialCollectorValues, (build
         }
         collector.input.value = action.payload.value;
       }
+    })
+    /**
+     * Using the `pollCollectorValues` const (e.g. `'node/poll'`) to add the case
+     * 'node/poll' is essentially derived `createSlice` below. `node.poll()` is
+     * transformed to `'node/poll'` for the action type.
+     */
+    .addCase(pollCollectorValues, (state) => {
+      // For challenge polling, track and decrement retries when this reducer is called
+      const pollCollector = state.find((collector) => collector.type === 'PollingCollector');
+
+      if (!pollCollector?.output.config.retriesRemaining) {
+        throw new Error('No poll collector found to update');
+      }
+
+      pollCollector.output.config.retriesRemaining--;
     });
 });

--- a/packages/davinci-client/src/lib/node.slice.test.ts
+++ b/packages/davinci-client/src/lib/node.slice.test.ts
@@ -12,6 +12,8 @@ import { nodeNext0 } from './mock-data/node.next.mock.js';
 import { success0, success1 } from './mock-data/davinci.success.mock.js';
 import { nodeSuccess0, nodeSuccess1 } from './mock-data/node.success.mock.js';
 import { error0a, error2b, error3 } from './mock-data/davinci.error.mock.js';
+import { continuePolling } from './mock-data/node.poll.mock.js';
+import type { ContinueNode } from './node.types.js';
 
 describe('The node slice reducers', () => {
   it('should return the initial state', () => {
@@ -249,5 +251,101 @@ describe('The node slice reducers', () => {
       },
       status: 'failure',
     });
+  });
+
+  it('should decrement retriesRemaining and update cache key on poll', () => {
+    // Build a continue state from a node that contains a PollingCollector.
+    const continueState = nodeSlice.reducer(undefined, {
+      type: 'node/next',
+      payload: { data: continuePolling, requestId: '1234', httpStatus: 200 },
+    });
+
+    // Dispatch a single poll action with a new requestId
+    const result = nodeSlice.reducer(continueState, {
+      type: 'node/poll',
+      payload: { requestId: '5678' },
+    });
+
+    // Cache key must reflect the latest requestId
+    expect(result.cache).toEqual({ key: '5678' });
+    // Node must remain in the continue state — poll does not change the node type
+    expect(result.status).toBe('continue');
+
+    // retriesRemaining must have decreased by 1 (5 → 4)
+    const pollingCollector = (result as ContinueNode).client.collectors.find(
+      (c) => c.type === 'PollingCollector',
+    );
+    expect(pollingCollector?.output.config.retriesRemaining).toBe(4);
+  });
+});
+
+describe('nodeSlice.selectors.selectContinueServer', () => {
+  const continueState: ContinueNode = {
+    cache: { key: 'test-key' },
+    client: { action: 'test', collectors: [], status: 'continue' },
+    error: null,
+    httpStatus: 200,
+    server: {
+      _links: { self: { href: 'https://auth.pingone.ca/envId/davinci/connections/abc' } },
+      interactionId: 'interaction-123',
+      status: 'continue',
+    },
+    status: 'continue',
+  };
+
+  it('returns the server when node is in continue state', () => {
+    const result = nodeSlice.selectors.selectContinueServer({ node: continueState });
+    expect(result).toEqual({ error: null, state: continueState.server });
+  });
+
+  it('returns an error when node is not in continue state (initial start state)', () => {
+    const result = nodeSlice.selectors.selectContinueServer({ node: nodeSlice.getInitialState() });
+    expect(result.error).not.toBeNull();
+    expect(result.error?.type).toBe('state_error');
+    expect(result.state).toBeNull();
+  });
+});
+
+describe('nodeSlice.selectors.selectSelfLink', () => {
+  const continueState: ContinueNode = {
+    cache: { key: 'test-key' },
+    client: { action: 'test', collectors: [], status: 'continue' },
+    error: null,
+    httpStatus: 200,
+    server: {
+      _links: { self: { href: 'https://auth.pingone.ca/envId/davinci/connections/abc' } },
+      interactionId: 'interaction-123',
+      status: 'continue',
+    },
+    status: 'continue',
+  };
+
+  it('returns the self link href when in continue state with self link present', () => {
+    const result = nodeSlice.selectors.selectSelfLink({ node: continueState });
+    expect(result).toEqual({
+      error: null,
+      state: 'https://auth.pingone.ca/envId/davinci/connections/abc',
+    });
+  });
+
+  it('returns an error when not in continue state', () => {
+    const result = nodeSlice.selectors.selectSelfLink({ node: nodeSlice.getInitialState() });
+    expect(result.error).not.toBeNull();
+    expect(result.error?.type).toBe('state_error');
+    expect(result.state).toBeNull();
+  });
+
+  it('returns an error when in continue state but self link is missing', () => {
+    const stateWithoutSelfLink: ContinueNode = {
+      ...continueState,
+      server: {
+        ...continueState.server,
+        _links: { other: { href: 'https://example.com' } },
+      },
+    };
+    const result = nodeSlice.selectors.selectSelfLink({ node: stateWithoutSelfLink });
+    expect(result.error).not.toBeNull();
+    expect(result.error?.type).toBe('state_error');
+    expect(result.state).toBeNull();
   });
 });

--- a/packages/davinci-client/src/lib/node.slice.ts
+++ b/packages/davinci-client/src/lib/node.slice.ts
@@ -364,5 +364,44 @@ export const nodeSlice = createSlice({
     selectServer: (state) => {
       return state.server;
     },
+    selectContinueServer: (state) => {
+      if (state.status !== 'continue') {
+        return {
+          error: {
+            code: 'unknown',
+            type: 'state_error',
+            message: 'Not in a continue node state, must be in a continue node to use poll method',
+          } as const,
+          state: null,
+        };
+      }
+      return { error: null, state: state.server };
+    },
+    selectSelfLink: (state) => {
+      if (state.status !== 'continue') {
+        return {
+          error: {
+            code: 'unknown',
+            type: 'state_error',
+            message: 'Not in a continue node state, must be in a continue node for self link',
+          } as const,
+          state: null,
+        };
+      }
+
+      const links = state.server._links;
+      if (!links || !('self' in links) || !('href' in links['self']) || !links['self'].href) {
+        return {
+          error: {
+            code: 'unknown',
+            type: 'state_error',
+            message: 'No self link found in server info for challenge polling operation',
+          } as const,
+          state: null,
+        };
+      }
+
+      return { error: null, state: links['self'].href };
+    },
   },
 });

--- a/packages/davinci-client/src/lib/node.slice.ts
+++ b/packages/davinci-client/src/lib/node.slice.ts
@@ -222,10 +222,11 @@ export const nodeSlice = createSlice({
 
       return newState;
     },
+
     /**
-     * @method start - Method for creating a start node
+     * @method success - Method for creating a success node
      * @param {Object} state - The current state of the slice
-     * @returns {StartNode} - The start node
+     * @returns {SuccessNode} - The success node
      */
     success(
       state,
@@ -264,6 +265,7 @@ export const nodeSlice = createSlice({
 
       return newState;
     },
+
     /**
      * @method update - Method for updating collector values with the node
      * @param {Object} state - The current state of the slice
@@ -275,6 +277,32 @@ export const nodeSlice = createSlice({
 
       newState.client.collectors = nodeCollectorReducer(newState.client.collectors, action);
 
+      return newState;
+    },
+
+    /**
+     * @method poll - Method for creating the next node after continue polling
+     * @param {Object} state - The current state of the slice
+     * @param {PayloadAction} action - The action to be dispatched
+     * @returns {ContinueNode} - The next node
+     */
+    poll(
+      state,
+      action: PayloadAction<{
+        requestId: string;
+      }>,
+    ) {
+      const newState = state as Draft<ContinueNode>;
+
+      // Update retries remaining in poll collector
+      newState.client.collectors = nodeCollectorReducer(newState.client.collectors, action);
+
+      // Update cache key
+      newState.cache = {
+        key: action.payload.requestId,
+      };
+
+      // Return the previous continue node with updated retries and cache key
       return newState;
     },
   },

--- a/packages/davinci-client/src/lib/node.slice.ts
+++ b/packages/davinci-client/src/lib/node.slice.ts
@@ -110,10 +110,10 @@ export const nodeSlice = createSlice({
     },
 
     /**
-     * @method failure - Method for creating an error node
+     * @method failure - Method for creating a failure node
      * @param {Object} state - The current state of the slice
      * @param {PayloadAction<DaVinciFailureResponse>} action - The action to be dispatched
-     * @returns {FailureNode} - The error node
+     * @returns {FailureNode} - The failure node
      */
     failure(
       state,

--- a/packages/davinci-client/src/lib/node.types.test-d.ts
+++ b/packages/davinci-client/src/lib/node.types.test-d.ts
@@ -33,6 +33,7 @@ import {
   PhoneNumberCollector,
   UnknownCollector,
   ProtectCollector,
+  PollingCollector,
   FidoRegistrationCollector,
   FidoAuthenticationCollector,
   QrCodeCollector,
@@ -235,6 +236,7 @@ describe('Node Types', () => {
         | SingleSelectCollector
         | ValidatedTextCollector
         | ProtectCollector
+        | PollingCollector
         | FidoRegistrationCollector
         | FidoAuthenticationCollector
         | QrCodeCollector

--- a/packages/davinci-client/src/lib/node.types.ts
+++ b/packages/davinci-client/src/lib/node.types.ts
@@ -22,6 +22,7 @@ import type {
   ValidatedTextCollector,
   PhoneNumberCollector,
   ProtectCollector,
+  PollingCollector,
   UnknownCollector,
   FidoRegistrationCollector,
   FidoAuthenticationCollector,
@@ -45,6 +46,7 @@ export type Collectors =
   | ReadOnlyCollector
   | ValidatedTextCollector
   | ProtectCollector
+  | PollingCollector
   | FidoRegistrationCollector
   | FidoAuthenticationCollector
   | QrCodeCollector

--- a/packages/davinci-client/src/types.ts
+++ b/packages/davinci-client/src/types.ts
@@ -56,6 +56,7 @@ export type FidoAuthenticationCollector = collectors.FidoAuthenticationCollector
 export type QrCodeCollector = collectors.QrCodeCollector;
 
 export type PollingStatus = client.PollingStatus;
+export type Poller = client.Poller;
 
 export type InternalErrorResponse = client.InternalErrorResponse;
 export type { RequestMiddleware, ActionTypes } from '@forgerock/sdk-request-middleware';

--- a/packages/davinci-client/src/types.ts
+++ b/packages/davinci-client/src/types.ts
@@ -55,7 +55,6 @@ export type FidoRegistrationCollector = collectors.FidoRegistrationCollector;
 export type FidoAuthenticationCollector = collectors.FidoAuthenticationCollector;
 export type QrCodeCollector = collectors.QrCodeCollector;
 
-export type PollingStatusComplete = client.PollingStatusComplete;
 export type PollingStatus = client.PollingStatus;
 
 export type InternalErrorResponse = client.InternalErrorResponse;

--- a/packages/davinci-client/src/types.ts
+++ b/packages/davinci-client/src/types.ts
@@ -50,9 +50,13 @@ export type DeviceRegistrationCollector = collectors.DeviceRegistrationCollector
 export type DeviceAuthenticationCollector = collectors.DeviceAuthenticationCollector;
 export type PhoneNumberCollector = collectors.PhoneNumberCollector;
 export type ProtectCollector = collectors.ProtectCollector;
+export type PollingCollector = collectors.PollingCollector;
 export type FidoRegistrationCollector = collectors.FidoRegistrationCollector;
 export type FidoAuthenticationCollector = collectors.FidoAuthenticationCollector;
 export type QrCodeCollector = collectors.QrCodeCollector;
+
+export type PollingStatusComplete = client.PollingStatusComplete;
+export type PollingStatus = client.PollingStatus;
 
 export type InternalErrorResponse = client.InternalErrorResponse;
 export type { RequestMiddleware, ActionTypes } from '@forgerock/sdk-request-middleware';

--- a/packages/davinci-client/tsconfig.json
+++ b/packages/davinci-client/tsconfig.json
@@ -7,7 +7,8 @@
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "skipLibCheck": true
   },
   "references": [
     {

--- a/packages/sdk-effects/sdk-request-middleware/src/lib/request-mware.derived.ts
+++ b/packages/sdk-effects/sdk-request-middleware/src/lib/request-mware.derived.ts
@@ -19,6 +19,7 @@ export const actionTypes = {
   error: 'DAVINCI_ERROR',
   failure: 'DAVINCI_FAILURE',
   resume: 'DAVINCI_RESUME',
+  poll: 'DAVINCI_POLL',
 
   // OIDC
   authorize: 'AUTHORIZE',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -440,6 +440,9 @@ importers:
         specifier: 'catalog:'
         version: 10.2.0
     devDependencies:
+      '@effect/vitest':
+        specifier: catalog:effect
+        version: 0.27.0(effect@3.21.0)(vitest@3.2.4)
       vitest:
         specifier: catalog:vitest
         version: 3.2.4(@types/node@24.9.2)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@27.1.0)(msw@2.12.1(@types/node@24.9.2)(typescript@5.9.3))(terser@5.46.0)(tsx@4.20.6)(yaml@2.8.1)


### PR DESCRIPTION
# JIRA Ticket

https://pingidentity.atlassian.net/browse/SDKS-4687

## Description

- Adds polling collectors and new `poll()` method on `davinciClient`
- Handles challenge polling
- Handles continue polling
- Automated e2e tests are blocked until we can create more flows in our env. https://pingidentity.atlassian.net/browse/SDKS-4929


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added challenge and continue polling support for long-running flows.
  * Added a polling UI component showing "Start polling", live status, results, and error messages.
  * Configurable polling intervals, retry limits, automatic timeout detection, and submission on successful polling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->