### PR TITLE
feat: SSR compatibility PoC for journey-client and oidc-client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,13 @@ test-output
 .cursor/rules/nx-rules.mdc
 .github/instructions/nx.instructions.md
 
+# SvelteKit
+.svelte-kit
+
+# Gemini local knowledge base files
+GEMINI.md
+**/GEMINI.md
+
 .claude/worktrees
 .claude/settings.local.json
 .claude/skills

--- a/e2e/oidc-app/src/utils/oidc-app.ts
+++ b/e2e/oidc-app/src/utils/oidc-app.ts
@@ -130,15 +130,15 @@ export async function oidcApp({
   });
 
   document.getElementById('login-redirect')?.addEventListener('click', async () => {
-    const authorizeUrl = await oidcClient.authorize?.url();
-    if (!authorizeUrl) return;
-    if (typeof authorizeUrl !== 'string' && 'error' in authorizeUrl) {
-      console.error('Authorization URL Error:', authorizeUrl);
-      displayError(authorizeUrl);
+    const authorizeResult = await oidcClient.authorize?.url();
+    if (!authorizeResult) return;
+    if ('error' in authorizeResult) {
+      console.error('Authorization URL Error:', authorizeResult);
+      displayError(authorizeResult);
       return;
     } else {
-      console.log('Authorization URL:', authorizeUrl);
-      window.location.assign(authorizeUrl);
+      console.log('Authorization URL:', authorizeResult.url);
+      window.location.assign(authorizeResult.url);
     }
   });
 

--- a/e2e/svelte-app/package.json
+++ b/e2e/svelte-app/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@forgerock/svelte-app",
+  "version": "1.0.0",
+  "private": true,
+  "description": "SvelteKit SSR proof of concept for Journey Client",
+  "type": "module",
+  "scripts": {
+    "dev": "vite dev",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@forgerock/journey-client": "workspace:*",
+    "@forgerock/oidc-client": "workspace:*"
+  },
+  "devDependencies": {
+    "@sveltejs/adapter-auto": "^6.0.0",
+    "@sveltejs/kit": "^2.21.0",
+    "@sveltejs/vite-plugin-svelte": "^5.0.0",
+    "svelte": "^5.0.0",
+    "vite": "catalog:vite"
+  },
+  "nx": {
+    "tags": ["scope:e2e"]
+  }
+}

--- a/e2e/svelte-app/src/app.html
+++ b/e2e/svelte-app/src/app.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Journey Client SSR PoC</title>
+    %sveltekit.head%
+  </head>
+  <body>
+    <div id="app">%sveltekit.body%</div>
+  </body>
+</html>

--- a/e2e/svelte-app/src/lib/config.ts
+++ b/e2e/svelte-app/src/lib/config.ts
@@ -1,0 +1,17 @@
+/**
+ * Server configuration for the SSR proof of concept.
+ * Points at the AM mock API running on localhost:9443.
+ */
+export const WELLKNOWN_URL =
+  'http://localhost:9443/am/oauth2/realms/root/.well-known/openid-configuration';
+
+export const CLIENT_ID = 'SvelteSSRClient';
+export const REDIRECT_URI = 'http://localhost:5174/callback';
+export const SCOPE = 'openid profile';
+
+/** No-op storage adapter for server-side usage where browser storage is unavailable. */
+export const noopStorage = {
+  get: async () => null,
+  set: async () => {},
+  remove: async () => {},
+};

--- a/e2e/svelte-app/src/routes/+layout.svelte
+++ b/e2e/svelte-app/src/routes/+layout.svelte
@@ -1,0 +1,15 @@
+<script>
+  let { children } = $props();
+</script>
+
+<main>
+  {@render children()}
+</main>
+
+<style>
+  main {
+    max-width: 480px;
+    margin: 2rem auto;
+    font-family: system-ui, sans-serif;
+  }
+</style>

--- a/e2e/svelte-app/src/routes/+page.server.ts
+++ b/e2e/svelte-app/src/routes/+page.server.ts
@@ -1,0 +1,92 @@
+import { redirect } from '@sveltejs/kit';
+import { journey } from '@forgerock/journey-client';
+import { oidc } from '@forgerock/oidc-client';
+import { WELLKNOWN_URL, CLIENT_ID, REDIRECT_URI, SCOPE, noopStorage } from '$lib/config.js';
+import type { PageServerLoad, Actions } from './$types';
+
+/**
+ * Server-side load function.
+ *
+ * Initializes the journey client with noop storage (no sessionStorage on server)
+ * and calls start() to fetch the first authentication step. The raw step payload
+ * is serialized and passed to the client for SSR rendering.
+ */
+export const load: PageServerLoad = async () => {
+  try {
+    const client = await journey({
+      config: {
+        serverConfig: { wellknown: WELLKNOWN_URL },
+        storage: { type: 'custom', name: 'journey-step', custom: noopStorage },
+      },
+    });
+
+    const result = await client.start();
+
+    if ('payload' in result) {
+      return {
+        stepPayload: result.payload,
+        error: null,
+      };
+    }
+
+    return {
+      stepPayload: null,
+      error: 'error' in result ? result : { error: 'unexpected', message: 'Unexpected result' },
+    };
+  } catch (e) {
+    return {
+      stepPayload: null,
+      error: {
+        error: 'server_init_failed',
+        message: e instanceof Error ? e.message : 'Failed to initialize journey client on server',
+      },
+    };
+  }
+};
+
+/**
+ * Form actions — the authorize action generates a PKCE authorize URL on the server,
+ * stores the verifier in a cookie, and redirects the browser to the authorize endpoint.
+ */
+export const actions: Actions = {
+  authorize: async ({ cookies }) => {
+    const client = await oidc({
+      config: {
+        serverConfig: { wellknown: WELLKNOWN_URL },
+        clientId: CLIENT_ID,
+        redirectUri: REDIRECT_URI,
+        scope: SCOPE,
+        responseType: 'code',
+      },
+      storage: { type: 'custom', name: CLIENT_ID, custom: noopStorage },
+    });
+
+    if (!client || 'error' in client) {
+      return { error: 'Failed to initialize OIDC client' };
+    }
+
+    // Generate authorize URL with PKCE — returns { url, verifier, state }
+    const result = await client.authorize.url();
+
+    if ('error' in result) {
+      return { error: result.error };
+    }
+
+    // Store PKCE verifier + state in an httpOnly cookie for the callback route
+    cookies.set('pkce_verifier', result.verifier, {
+      path: '/',
+      httpOnly: true,
+      sameSite: 'lax',
+      maxAge: 300, // 5 minutes
+    });
+    cookies.set('pkce_state', result.state, {
+      path: '/',
+      httpOnly: true,
+      sameSite: 'lax',
+      maxAge: 300,
+    });
+
+    // Redirect browser to authorization endpoint
+    redirect(303, result.url);
+  },
+};

--- a/e2e/svelte-app/src/routes/+page.svelte
+++ b/e2e/svelte-app/src/routes/+page.svelte
@@ -1,0 +1,219 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { journey, createJourneyObject, callbackType } from '@forgerock/journey-client';
+  import { WELLKNOWN_URL } from '$lib/config.js';
+
+  import type { JourneyClient } from '@forgerock/journey-client';
+  import type { Step } from '@forgerock/journey-client/types';
+
+  let { data } = $props();
+
+  // Reactive state — initialized from server data, updated client-side
+  let stepPayload = $state<Step | null>(data?.stepPayload ?? null);
+  let serverError = $state(data?.error ?? null);
+  let client = $state<JourneyClient | null>(null);
+  let submitting = $state(false);
+  let success = $state(false);
+  let failure = $state<string | null>(null);
+
+  /**
+   * On mount, initialize the journey client with real browser storage.
+   * This is where the browser-only setup happens — safe because onMount
+   * only runs in the browser after hydration.
+   */
+  onMount(async () => {
+    try {
+      client = await journey({
+        config: {
+          serverConfig: { wellknown: WELLKNOWN_URL },
+        },
+      });
+    } catch (e) {
+      serverError = {
+        error: 'client_init_failed',
+        message: e instanceof Error ? e.message : 'Failed to initialize client',
+      };
+    }
+  });
+
+  function getPrompt(cb: Step['callbacks'][number]): string {
+    const prompt = cb.output?.find((o) => o.name === 'prompt');
+    return prompt?.value ?? cb.type;
+  }
+
+  function isTextInput(cb: Step['callbacks'][number]): boolean {
+    return cb.type === callbackType.NameCallback || cb.type === callbackType.TextInputCallback;
+  }
+
+  function isPassword(cb: Step['callbacks'][number]): boolean {
+    return cb.type === callbackType.PasswordCallback;
+  }
+
+  /**
+   * Submit the current step. Reconstitutes the step with methods via
+   * createJourneyObject, sets input values, and calls client.next().
+   */
+  async function handleSubmit(event: SubmitEvent) {
+    event.preventDefault();
+    if (!client || !stepPayload) return;
+
+    submitting = true;
+    failure = null;
+
+    const formData = new FormData(event.target as HTMLFormElement);
+    const step = createJourneyObject(stepPayload);
+
+    if ('callbacks' in step && step.callbacks) {
+      for (const cb of step.callbacks) {
+        const inputName = `callback_${cb.payload._id}`;
+        const value = formData.get(inputName);
+        if (value !== null) {
+          cb.setInputValue(String(value));
+        }
+      }
+    }
+
+    try {
+      const result = await client.next(step);
+
+      if ('payload' in result && result.type === 'Step') {
+        stepPayload = result.payload;
+      } else if ('type' in result && result.type === 'LoginSuccess') {
+        success = true;
+        stepPayload = null;
+      } else if ('type' in result && result.type === 'LoginFailure') {
+        failure = 'message' in result ? String(result.message) : 'Authentication failed';
+        const restart = await client.start({});
+        if ('payload' in restart) {
+          stepPayload = restart.payload;
+        }
+      } else if ('error' in result) {
+        failure = result.message ?? 'Unknown error';
+      }
+    } catch (e) {
+      failure = e instanceof Error ? e.message : 'Submission failed';
+    } finally {
+      submitting = false;
+    }
+  }
+</script>
+
+<h1>Journey Client SSR PoC</h1>
+
+{#if serverError}
+  <div class="error">
+    <p><strong>Error:</strong> {serverError.message}</p>
+    <p><em>This is expected if the AM mock API is not running on port 9443.</em></p>
+  </div>
+{:else if success}
+  <div class="success">
+    <h2>Journey complete!</h2>
+    <p>Authentication succeeded. Now exchange for tokens via server-side PKCE:</p>
+    <form method="POST" action="?/authorize">
+      <button type="submit">Get Tokens (Server-Side PKCE)</button>
+    </form>
+  </div>
+{:else if failure}
+  <div class="error">
+    <p>{failure}</p>
+  </div>
+{/if}
+
+{#if stepPayload?.callbacks}
+  <form onsubmit={handleSubmit}>
+    <h2>{stepPayload.header ?? 'Sign In'}</h2>
+    {#if stepPayload.description}
+      <p>{stepPayload.description}</p>
+    {/if}
+
+    {#each stepPayload.callbacks as cb (cb._id)}
+      {#if isTextInput(cb)}
+        <label>
+          {getPrompt(cb)}
+          <input
+            type="text"
+            name={`callback_${cb._id}`}
+            value={cb.input?.[0]?.value ?? ''}
+            required
+          />
+        </label>
+      {:else if isPassword(cb)}
+        <label>
+          {getPrompt(cb)}
+          <input
+            type="password"
+            name={`callback_${cb._id}`}
+            value=""
+            required
+          />
+        </label>
+      {:else}
+        <p class="unsupported">Unsupported callback: {cb.type}</p>
+      {/if}
+    {/each}
+
+    <button type="submit" disabled={submitting || !client}>
+      {#if submitting}
+        Submitting...
+      {:else if !client}
+        Initializing...
+      {:else}
+        Next
+      {/if}
+    </button>
+  </form>
+{:else if !serverError && !success}
+  <p>Loading...</p>
+{/if}
+
+<style>
+  label {
+    display: block;
+    margin-bottom: 1rem;
+  }
+
+  input {
+    display: block;
+    width: 100%;
+    padding: 0.5rem;
+    margin-top: 0.25rem;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    box-sizing: border-box;
+  }
+
+  button {
+    padding: 0.5rem 1.5rem;
+    background: #0066cc;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    margin-top: 0.5rem;
+  }
+
+  button:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+
+  .error {
+    padding: 1rem;
+    background: #fee;
+    border: 1px solid #fcc;
+    border-radius: 4px;
+    margin-bottom: 1rem;
+  }
+
+  .success {
+    padding: 1rem;
+    background: #efe;
+    border: 1px solid #cfc;
+    border-radius: 4px;
+  }
+
+  .unsupported {
+    color: #999;
+    font-style: italic;
+  }
+</style>

--- a/e2e/svelte-app/src/routes/callback/+page.server.ts
+++ b/e2e/svelte-app/src/routes/callback/+page.server.ts
@@ -1,0 +1,105 @@
+import { oidc } from '@forgerock/oidc-client';
+import { WELLKNOWN_URL, CLIENT_ID, REDIRECT_URI, SCOPE, noopStorage } from '$lib/config.js';
+import type { PageServerLoad } from './$types';
+
+/**
+ * Callback route — handles the redirect from the authorization server.
+ *
+ * Reads the authorization code and state from the URL, retrieves the PKCE
+ * verifier from the cookie (set during authorize), and exchanges for tokens
+ * entirely on the server. The browser never sees the verifier or tokens directly.
+ */
+export const load: PageServerLoad = async ({ url, cookies }) => {
+  const code = url.searchParams.get('code');
+  const state = url.searchParams.get('state');
+  const error = url.searchParams.get('error');
+  const errorDescription = url.searchParams.get('error_description');
+
+  if (error) {
+    return {
+      tokens: null,
+      error: { error, message: errorDescription ?? 'Authorization failed' },
+    };
+  }
+
+  if (!code || !state) {
+    return {
+      tokens: null,
+      error: { error: 'missing_params', message: 'Missing code or state in callback URL' },
+    };
+  }
+
+  // Retrieve PKCE values from httpOnly cookies
+  const verifier = cookies.get('pkce_verifier');
+  const pkceState = cookies.get('pkce_state');
+
+  // Clean up cookies
+  cookies.delete('pkce_verifier', { path: '/' });
+  cookies.delete('pkce_state', { path: '/' });
+
+  if (!verifier || !pkceState) {
+    return {
+      tokens: null,
+      error: { error: 'missing_pkce', message: 'PKCE verifier or state not found in cookies' },
+    };
+  }
+
+  if (pkceState !== state) {
+    return {
+      tokens: null,
+      error: { error: 'state_mismatch', message: 'State parameter does not match' },
+    };
+  }
+
+  try {
+    const client = await oidc({
+      config: {
+        serverConfig: { wellknown: WELLKNOWN_URL },
+        clientId: CLIENT_ID,
+        redirectUri: REDIRECT_URI,
+        scope: SCOPE,
+        responseType: 'code',
+      },
+      storage: { type: 'custom', name: CLIENT_ID, custom: noopStorage },
+    });
+
+    if (!client || 'error' in client) {
+      return {
+        tokens: null,
+        error: { error: 'oidc_init_failed', message: 'Failed to initialize OIDC client' },
+      };
+    }
+
+    // Exchange code for tokens, providing PKCE values directly (no sessionStorage)
+    const tokens = await client.token.exchange(code, state, {
+      pkceValues: { verifier, state: pkceState },
+    });
+
+    if ('error' in tokens) {
+      return {
+        tokens: null,
+        error: {
+          error: tokens.error,
+          message: 'message' in tokens ? tokens.message : 'Token exchange failed',
+        },
+      };
+    }
+
+    return {
+      tokens: {
+        accessToken: tokens.accessToken,
+        idToken: tokens.idToken,
+        ...(tokens.refreshToken && { refreshToken: tokens.refreshToken }),
+      },
+      error: null,
+    };
+  } catch (e) {
+    return {
+      tokens: null,
+      error: {
+        error: 'exchange_failed',
+        message: e instanceof Error ? e.message : 'Token exchange failed',
+      },
+    };
+  }
+};

--- a/e2e/svelte-app/src/routes/callback/+page.svelte
+++ b/e2e/svelte-app/src/routes/callback/+page.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+  let { data } = $props();
+</script>
+
+<h1>OIDC Callback</h1>
+
+{#if data.error}
+  <div class="error">
+    <h2>Error</h2>
+    <p><strong>{data.error.error}:</strong> {data.error.message}</p>
+    <a href="/">Back to login</a>
+  </div>
+{:else if data.tokens}
+  <div class="success">
+    <h2>Tokens received!</h2>
+    <dl>
+      <dt>Access Token</dt>
+      <dd>{data.tokens.accessToken.slice(0, 20)}...</dd>
+      <dt>ID Token</dt>
+      <dd>{data.tokens.idToken.slice(0, 20)}...</dd>
+      {#if data.tokens.refreshToken}
+        <dt>Refresh Token</dt>
+        <dd>{data.tokens.refreshToken.slice(0, 20)}...</dd>
+      {/if}
+    </dl>
+    <a href="/">Back to login</a>
+  </div>
+{:else}
+  <p>Processing...</p>
+{/if}
+
+<style>
+  .error {
+    padding: 1rem;
+    background: #fee;
+    border: 1px solid #fcc;
+    border-radius: 4px;
+  }
+
+  .success {
+    padding: 1rem;
+    background: #efe;
+    border: 1px solid #cfc;
+    border-radius: 4px;
+  }
+
+  dt {
+    font-weight: bold;
+    margin-top: 0.5rem;
+  }
+
+  dd {
+    font-family: monospace;
+    margin-left: 0;
+    color: #666;
+  }
+
+  a {
+    display: inline-block;
+    margin-top: 1rem;
+    color: #0066cc;
+  }
+</style>

--- a/e2e/svelte-app/svelte.config.js
+++ b/e2e/svelte-app/svelte.config.js
@@ -1,0 +1,10 @@
+import adapter from '@sveltejs/adapter-auto';
+
+/** @type {import('@sveltejs/kit').Config} */
+const config = {
+  kit: {
+    adapter: adapter(),
+  },
+};
+
+export default config;

--- a/e2e/svelte-app/tsconfig.json
+++ b/e2e/svelte-app/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "extends": "./.svelte-kit/tsconfig.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "moduleResolution": "bundler"
+  },
+  "references": [
+    {
+      "path": "../../packages/oidc-client"
+    },
+    {
+      "path": "../../packages/journey-client"
+    }
+  ]
+}

--- a/e2e/svelte-app/vite.config.ts
+++ b/e2e/svelte-app/vite.config.ts
@@ -1,0 +1,6 @@
+import { sveltekit } from '@sveltejs/kit/vite';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  plugins: [sveltekit()],
+});

--- a/nx.json
+++ b/nx.json
@@ -132,7 +132,8 @@
         "buildDepsTargetName": "vite:build-deps",
         "watchDepsTargetName": "vite:watch-deps"
       },
-      "include": ["packages/**/**/*", "e2e/**/**/*", "tools/**/**/*"]
+      "include": ["packages/**/**/*", "e2e/**/**/*", "tools/**/**/*"],
+      "exclude": ["e2e/svelte-app/**/*"]
     },
     {
       "plugin": "@nx/js/typescript",
@@ -152,7 +153,8 @@
       "options": {
         "testTargetName": "nxTest"
       },
-      "include": ["packages/**/**/*", "e2e/**/**/*", "tools/**/**/*"]
+      "include": ["packages/**/**/*", "e2e/**/**/*", "tools/**/**/*"],
+      "exclude": ["e2e/svelte-app/**/*"]
     }
   ],
   "parallel": 1,

--- a/packages/davinci-client/src/lib/davinci.api.ts
+++ b/packages/davinci-client/src/lib/davinci.api.ts
@@ -289,7 +289,7 @@ export const davinciApi = createApi({
         }
 
         try {
-          const authorizeUrl = await createAuthorizeUrl(authorizeEndpoint, {
+          const authorizeResult = await createAuthorizeUrl(authorizeEndpoint, {
             clientId: state?.config?.clientId,
             login: 'redirect', // TODO: improve this in SDK to be more semantic
             redirectUri: state?.config?.redirectUri,
@@ -297,7 +297,7 @@ export const davinciApi = createApi({
             responseMode: 'pi.flow',
             scope: state?.config?.scope,
           });
-          const url = new URL(authorizeUrl);
+          const url = new URL(authorizeResult.url);
           const existingParams = url.searchParams;
 
           if (options?.query) {

--- a/packages/journey-client/src/index.ts
+++ b/packages/journey-client/src/index.ts
@@ -7,6 +7,7 @@
 
 export * from './lib/client.store.js';
 export * from './types.js';
+export { createJourneyObject } from './lib/journey.utils.js';
 
 // Re-export types from internal packages that consumers need
 export { callbackType } from '@forgerock/sdk-types';

--- a/packages/journey-client/src/lib/client.store.ts
+++ b/packages/journey-client/src/lib/client.store.ts
@@ -148,10 +148,9 @@ export async function journey<ActionType extends ActionTypes = ActionTypes>({
     throw new Error(message);
   }
 
-  const stepStorage = createStorage<{ step: Step }>({
-    type: 'sessionStorage',
-    name: 'journey-step',
-  });
+  const stepStorage = createStorage<{ step: Step }>(
+    config.storage ?? { type: 'sessionStorage', name: 'journey-step' },
+  );
 
   const self: JourneyClient = {
     subscribe: store.subscribe,
@@ -191,6 +190,11 @@ export async function journey<ActionType extends ActionTypes = ActionTypes>({
       const err = await stepStorage.set({ step: step.payload });
       if (isGenericError(err)) {
         log.warn('Failed to persist step before redirect', err);
+      }
+      if (typeof window === 'undefined') {
+        throw new Error(
+          'redirect() requires a browser environment. Extract the redirect URL from the RedirectCallback for server-side redirection.',
+        );
       }
       window.location.assign(redirectUrl);
     },

--- a/packages/journey-client/src/lib/config.types.ts
+++ b/packages/journey-client/src/lib/config.types.ts
@@ -5,10 +5,45 @@
  * of the MIT license. See the LICENSE file for details.
  */
 
-import type { GenericError } from '@forgerock/sdk-types';
+import type { AsyncLegacyConfigOptions, GenericError } from '@forgerock/sdk-types';
+import type { StorageConfig } from '@forgerock/storage';
 import type { ResolvedServerConfig } from './wellknown.utils.js';
 
-export type { JourneyServerConfig, JourneyClientConfig } from '@forgerock/sdk-types';
+/**
+ * Server configuration for journey-client.
+ *
+ * Only the OIDC discovery endpoint URL is required. All other configuration
+ * (baseUrl, paths) is automatically derived from the well-known response.
+ */
+export interface JourneyServerConfig {
+  /** Required OIDC discovery endpoint URL */
+  wellknown: string;
+  /** Optional request timeout in milliseconds. Included for config-sharing compatibility with other clients. */
+  timeout?: number;
+}
+
+/**
+ * Configuration for creating a journey client instance.
+ *
+ * Extends {@link AsyncLegacyConfigOptions} so that the same config object can
+ * be shared across journey-client, davinci-client, and oidc-client. Properties
+ * like `clientId`, `scope`, and `redirectUri` are accepted but not used by
+ * journey-client — a warning is logged when they are provided.
+ *
+ * @example
+ * ```typescript
+ * const config: JourneyClientConfig = {
+ *   serverConfig: {
+ *     wellknown: 'https://am.example.com/am/oauth2/alpha/.well-known/openid-configuration',
+ *   },
+ * };
+ * ```
+ */
+export interface JourneyClientConfig extends AsyncLegacyConfigOptions {
+  serverConfig: JourneyServerConfig;
+  /** Storage configuration for step persistence during redirects. Defaults to sessionStorage in browsers. */
+  storage?: StorageConfig;
+}
 
 /**
  * Internal configuration after wellknown discovery and path resolution.

--- a/packages/oidc-client/src/lib/authorize.request.utils.ts
+++ b/packages/oidc-client/src/lib/authorize.request.utils.ts
@@ -4,11 +4,16 @@
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
  */
-import type { SerializedError } from '@reduxjs/toolkit';
-import type { FetchBaseQueryError } from '@reduxjs/toolkit/query';
+import { createAuthorizeUrl, type AuthorizeUrlResult } from '@forgerock/sdk-oidc';
+import { Micro } from 'effect';
+
 import type { WellknownResponse, GetAuthorizationUrlOptions } from '@forgerock/sdk-types';
 import type { AuthPromptValue } from '@forgerock/sdk-utilities';
-import type { AuthorizationError, OptionalAuthorizeOptions } from './authorize.request.types.js';
+import type {
+  AuthorizationError,
+  AuthorizationSuccess,
+  OptionalAuthorizeOptions,
+} from './authorize.request.types.js';
 import type { OidcConfig } from './config.types.js';
 
 export type ParUrlParams = {
@@ -46,49 +51,115 @@ export function buildAuthorizeOptions(
 }
 
 /**
- * Type guard for RTK FetchBaseQueryError vs SerializedError.
- * FetchBaseQueryError always carries a `status` field; SerializedError does not.
+ * @function createAuthorizeErrorµ
+ * @description Creates an error response with new Authorize URL for the authorization request.
+ * @param { error: string; error_description: string } res - The error response from the authorization request.
+ * @param {WellknownResponse} wellknown- The well-known configuration for the OIDC server.
+ * @param { GetAuthorizationUrlOptions } options- Optional parameters for the authorization request.
+ * @returns { Micro.Micro<never, AuthorizationError, never> }
  */
-export function isFetchBaseQueryError(
-  error: FetchBaseQueryError | SerializedError,
-): error is FetchBaseQueryError {
-  return 'status' in error;
-}
-
-const KNOWN_ERROR_TYPES = new Set([
-  'auth_error',
-  'argument_error',
-  'network_error',
-  'unknown_error',
-  'wellknown_error',
-] as const);
-
-function isKnownErrorType(value: unknown): value is AuthorizationError['type'] {
-  return typeof value === 'string' && KNOWN_ERROR_TYPES.has(value as AuthorizationError['type']);
+export function createAuthorizeErrorµ(
+  res: { error: string; error_description: string },
+  wellknown: WellknownResponse,
+  options: GetAuthorizationUrlOptions,
+): Micro.Micro<never, AuthorizationError, never> {
+  return Micro.tryPromise({
+    try: () =>
+      createAuthorizeUrl(wellknown.authorization_endpoint, {
+        ...options,
+      }),
+    catch: (error) => {
+      let message = 'Error creating authorization URL';
+      if (error instanceof Error) {
+        message = error.message;
+      }
+      return {
+        error: 'AuthorizationUrlError',
+        error_description: message,
+        type: 'auth_error',
+      } as const;
+    },
+  }).pipe(
+    Micro.flatMap((result) => {
+      return Micro.fail({
+        error: res.error,
+        error_description: res.error_description,
+        type: 'auth_error',
+        redirectUrl: result.url,
+      } as const);
+    }),
+  );
 }
 
 /**
- * Safely narrows an unknown value to AuthorizationError shape.
- * Validates that the data has the required 'error' string field, otherwise returns
- * a default unknown error response.
+ * @function createAuthorizeUrlµ
+ * @description Creates an authorization URL and related options/config for the Authorize request.
+ *              Stores PKCE values in sessionStorage for the background authorize flow.
+ * @param {string} path - The path to the authorization endpoint.
+ * @param { GetAuthorizationUrlOptions } options - Optional parameters for the authorization request.
+ * @returns { Micro.Micro<[string, GetAuthorizationUrlOptions], AuthorizationError, never> }
  */
-export function toAuthorizationError(data: unknown): AuthorizationError {
-  if (isStringRecord(data)) {
-    if (typeof data['error'] === 'string') {
+export function createAuthorizeUrlµ(
+  path: string,
+  options: GetAuthorizationUrlOptions,
+): Micro.Micro<[string, GetAuthorizationUrlOptions], AuthorizationError, never> {
+  return Micro.tryPromise({
+    try: async (): Promise<[string, GetAuthorizationUrlOptions]> => {
+      const result = await createAuthorizeUrl(path, {
+        ...options,
+        prompt: 'none',
+      });
+
+      // For the background flow, persist PKCE values in sessionStorage
+      // so the token exchange can retrieve them after the iframe redirect.
+      storePkceValues(options.clientId, result, options);
+
+      return [result.url, options];
+    },
+    catch: (error) => {
+      let message = 'Error creating authorization URL';
+      if (error instanceof Error) {
+        message = error.message;
+      }
       return {
-        error: data['error'],
-        error_description:
-          typeof data['error_description'] === 'string' ? data['error_description'] : '',
-        type: isKnownErrorType(data['type']) ? data['type'] : 'unknown_error',
-        ...(typeof data['redirectUrl'] === 'string' && { redirectUrl: data['redirectUrl'] }),
-      };
-    }
+        error: 'AuthorizationUrlError',
+        error_description: message,
+        type: 'auth_error',
+      } as const;
+    },
+  });
+}
+
+/**
+ * Store PKCE values in sessionStorage for the background authorize flow.
+ * This is the browser-only path — server-side callers handle storage themselves.
+ */
+function storePkceValues(
+  clientId: string,
+  result: AuthorizeUrlResult,
+  options: GetAuthorizationUrlOptions,
+): void {
+  const storageKey = `FR-SDK-authflow-${clientId}`;
+  globalThis.sessionStorage.setItem(
+    storageKey,
+    JSON.stringify({
+      ...options,
+      state: result.state,
+      verifier: result.verifier,
+    }),
+  );
+}
+
+export function handleResponseµ(
+  response: AuthorizationSuccess | AuthorizationError,
+  wellknown: WellknownResponse,
+  options: GetAuthorizationUrlOptions,
+): Micro.Micro<AuthorizationSuccess, AuthorizationError, never> {
+  if ('code' in response) {
+    return Micro.sync(() => response);
+  } else {
+    return createAuthorizeErrorµ(response, wellknown, options);
   }
-  return {
-    error: 'Unknown_Error',
-    error_description: 'Unexpected error response shape',
-    type: 'unknown_error',
-  };
 }
 
 /**
@@ -107,21 +178,4 @@ export function buildParAuthorizeUrl({
   url.searchParams.set('request_uri', requestUri);
   if (prompt) url.searchParams.set('prompt', prompt);
   return url.toString();
-}
-
-/**
- * Converts an RTK Query dispatch error to a typed AuthorizationError.
- * oidc.api.ts normalizes all FetchBaseQueryErrors so that error.data always
- * contains { error, error_description, type }. SerializedErrors fall back to
- * their code/message fields.
- */
-export function toDispatchError(error: FetchBaseQueryError | SerializedError): AuthorizationError {
-  if (!isFetchBaseQueryError(error)) {
-    return {
-      error: error.code ?? 'Unknown_Error',
-      error_description: error.message ?? 'An unknown error occurred during authorization',
-      type: 'unknown_error',
-    };
-  }
-  return toAuthorizationError(error.data);
 }

--- a/packages/oidc-client/src/lib/client.store.ts
+++ b/packages/oidc-client/src/lib/client.store.ts
@@ -5,7 +5,7 @@
  * of the MIT license. See the LICENSE file for details.
  */
 import { logger as loggerFn } from '@forgerock/sdk-logger';
-import { createAuthorizeUrl } from '@forgerock/sdk-oidc';
+import { createAuthorizeUrl, type AuthorizeUrlResult } from '@forgerock/sdk-oidc';
 import { createStorage } from '@forgerock/storage';
 import { Micro } from 'effect';
 import { causeIsDie, exitIsFail, exitIsSuccess } from 'effect/Micro';
@@ -33,6 +33,7 @@ import type {
   RevokeSuccessResult,
   UserInfoResponse,
 } from './client.types.js';
+import type { PkceValues } from './exchange.utils.js';
 import type { OauthTokens, OidcConfig } from './config.types.js';
 import type { AuthorizationError, AuthorizationSuccess } from './authorize.request.types.js';
 import type { TokenExchangeErrorResponse } from './exchange.types.js';
@@ -128,7 +129,9 @@ export async function oidc<ActionType extends ActionTypes = ActionTypes>({
        * @param {GetAuthorizationUrlOptions} options - Optional parameters to customize the authorization URL.
        * @returns {Promise<string | GenericError>} - Returns a promise that resolves to the authorization URL or an error.
        */
-      url: async (options?: GetAuthorizationUrlOptions): Promise<string | GenericError> => {
+      url: async (
+        options?: GetAuthorizationUrlOptions,
+      ): Promise<AuthorizeUrlResult | GenericError> => {
         const state = store.getState();
         const wellknown = wellknownSelector(wellknownUrl, state);
 
@@ -249,7 +252,7 @@ export async function oidc<ActionType extends ActionTypes = ActionTypes>({
       exchange: async (
         code: string,
         state: string,
-        options?: Partial<StorageConfig>,
+        options?: Partial<StorageConfig> & { pkceValues?: PkceValues },
       ): Promise<OauthTokens | TokenExchangeErrorResponse | GenericError> => {
         const storeState = store.getState();
         const wellknown = wellknownSelector(wellknownUrl, storeState);
@@ -269,6 +272,7 @@ export async function oidc<ActionType extends ActionTypes = ActionTypes>({
           endpoint: wellknown.token_endpoint,
           store,
           options,
+          pkceValues: options?.pkceValues,
         }).pipe(
           Micro.tap(async (tokens) => {
             await storageClient.set(tokens);

--- a/packages/oidc-client/src/lib/exchange.request.ts
+++ b/packages/oidc-client/src/lib/exchange.request.ts
@@ -8,7 +8,12 @@ import { Micro } from 'effect';
 
 import { logger } from '@forgerock/sdk-logger';
 
-import { createValuesµ, handleTokenResponseµ, validateValuesµ } from './exchange.utils.js';
+import {
+  createValuesµ,
+  handleTokenResponseµ,
+  validateValuesµ,
+  type PkceValues,
+} from './exchange.utils.js';
 import { oidcApi } from './oidc.api.js';
 
 import type { ClientStore } from './client.types.js';
@@ -24,6 +29,8 @@ interface BuildTokenExchangeµParams {
   state: string;
   store: ClientStore;
   options?: Partial<StorageConfig>;
+  /** Provide PKCE values directly (SSR) instead of reading from sessionStorage. */
+  pkceValues?: PkceValues;
 }
 
 export function buildTokenExchangeµ({
@@ -34,8 +41,9 @@ export function buildTokenExchangeµ({
   state,
   store,
   options,
+  pkceValues,
 }: BuildTokenExchangeµParams): Micro.Micro<OauthTokens, TokenExchangeErrorResponse, never> {
-  return createValuesµ(code, config, state, endpoint, options).pipe(
+  return createValuesµ(code, config, state, endpoint, options, pkceValues).pipe(
     Micro.flatMap((options) => validateValuesµ(options)),
     Micro.tap((options) => log.debug('Token exchange values created', options)),
     Micro.tapError((options) =>

--- a/packages/oidc-client/src/lib/exchange.utils.ts
+++ b/packages/oidc-client/src/lib/exchange.utils.ts
@@ -16,15 +16,32 @@ import type { TokenExchangeResponse, TokenRequestOptions } from './exchange.type
 import type { TokenExchangeErrorResponse } from './exchange.types.js';
 import type { OidcConfig } from './config.types.js';
 
+/** Options for providing PKCE values directly instead of reading sessionStorage. */
+export interface PkceValues {
+  verifier: string;
+  state: string;
+}
+
 export function createValuesµ(
   code: string,
   config: OidcConfig,
   state: string,
   endpoint: string,
   options?: Partial<StorageConfig>,
+  pkceValues?: PkceValues,
 ) {
   return Micro.sync(() => {
-    const storedValues = getStoredAuthUrlValues(config.clientId, options?.prefix);
+    // If PKCE values are provided directly, use them (SSR path).
+    // Otherwise, fall back to reading from sessionStorage (browser path).
+    const storedValues: GetAuthorizationUrlOptions = pkceValues
+      ? {
+          ...pkceValues,
+          clientId: config.clientId,
+          redirectUri: config.redirectUri,
+          responseType: 'code',
+          scope: config.scope || 'openid',
+        }
+      : getStoredAuthUrlValues(config.clientId, options?.prefix);
 
     return {
       code,

--- a/packages/oidc-client/src/types.ts
+++ b/packages/oidc-client/src/types.ts
@@ -23,3 +23,5 @@ export type { StorageConfig } from '@forgerock/storage';
 // Re-export functions needed to resolve OidcClient and ClientStore type aliases
 export { oidc } from './lib/client.store.js';
 export { createClientStore } from './lib/client.store.utils.js';
+export type { AuthorizeUrlResult } from '@forgerock/sdk-oidc';
+export type { PkceValues } from './lib/exchange.utils.js';

--- a/packages/sdk-effects/oidc/src/lib/authorize.effects.ts
+++ b/packages/sdk-effects/oidc/src/lib/authorize.effects.ts
@@ -10,27 +10,35 @@
  */
 import { createChallenge } from '@forgerock/sdk-utilities';
 
-import { generateAndStoreAuthUrlValues } from './state-pkce.effects.js';
+import { generateAuthUrlValues } from './state-pkce.effects.js';
 import { buildAuthorizeParams } from './authorize.utils.js';
 
 import type { GetAuthorizationUrlOptions } from '@forgerock/sdk-types';
 
+/** Result of creating an authorization URL with PKCE. */
+export interface AuthorizeUrlResult {
+  /** The fully-formed authorization URL to redirect to. */
+  url: string;
+  /** The PKCE verifier — caller must persist this for token exchange. */
+  verifier: string;
+  /** The state parameter — caller must persist this for CSRF validation. */
+  state: string;
+}
+
 /**
- * @function createAuthorizeUrl - Create authorization URL for initial call to DaVinci
- * @param baseUrl {string}
- * @param options {GetAuthorizationUrlOptions}
- * @returns {Promise<string>} - the authorization URL
+ * Creates an authorization URL with PKCE parameters.
+ *
+ * Returns the URL along with the verifier and state values. The caller is
+ * responsible for persisting verifier/state (in sessionStorage, a cookie,
+ * a server-side session, etc.) so they can be provided during token exchange.
  */
 export async function createAuthorizeUrl(
   authorizeUrl: string,
   options: GetAuthorizationUrlOptions,
-): Promise<string> {
-  /**
-   * Generate state and verifier for PKCE
-   */
+): Promise<AuthorizeUrlResult> {
   const baseUrl = new URL(authorizeUrl).origin;
 
-  const [authorizeUrlOptions, storeOptions] = generateAndStoreAuthUrlValues({
+  const authorizeUrlOptions = generateAuthUrlValues({
     clientId: options.clientId,
     serverConfig: { baseUrl },
     responseType: options.responseType,
@@ -48,7 +56,9 @@ export async function createAuthorizeUrl(
 
   const url = new URL(`${authorizeUrl}?${requestParams.toString()}`);
 
-  storeOptions();
-
-  return url.toString();
+  return {
+    url: url.toString(),
+    verifier: authorizeUrlOptions.verifier,
+    state: authorizeUrlOptions.state,
+  };
 }

--- a/packages/sdk-effects/oidc/src/lib/authorize.test.ts
+++ b/packages/sdk-effects/oidc/src/lib/authorize.test.ts
@@ -9,7 +9,6 @@ import type { GenerateAndStoreAuthUrlValues } from '@forgerock/sdk-types';
 import { describe, expect, it, beforeEach } from 'vitest';
 import { createAuthorizeUrl } from './authorize.effects.js';
 import { buildAuthorizeParams } from './authorize.utils.js';
-import { getStorageKey } from './state-pkce.effects.js';
 
 const mockSessionStorage = (() => {
   let store: { [key: string]: string } = {};
@@ -46,8 +45,8 @@ describe('createAuthorizeUrl', () => {
   const baseUrl = 'https://auth.example.com/authorize';
 
   it('should create a valid authorization URL with all required parameters', async () => {
-    const url = await createAuthorizeUrl(baseUrl, mockOptions);
-    const parsedUrl = new URL(url);
+    const result = await createAuthorizeUrl(baseUrl, mockOptions);
+    const parsedUrl = new URL(result.url);
 
     // Check the base URL
     expect(parsedUrl.origin + parsedUrl.pathname).toBe(baseUrl);
@@ -68,6 +67,21 @@ describe('createAuthorizeUrl', () => {
     expect(params.code_challenge).toBeDefined();
   });
 
+  it('should return verifier and state alongside the URL', async () => {
+    const result = await createAuthorizeUrl(baseUrl, mockOptions);
+
+    expect(result.verifier).toBeDefined();
+    expect(result.state).toBeDefined();
+    expect(typeof result.verifier).toBe('string');
+    expect(typeof result.state).toBe('string');
+    expect(result.verifier.length).toBeGreaterThan(0);
+    expect(result.state.length).toBeGreaterThan(0);
+
+    // State in URL should match the returned state
+    const parsedUrl = new URL(result.url);
+    expect(parsedUrl.searchParams.get('state')).toBe(result.state);
+  });
+
   it('should include optional parameters when provided', async () => {
     const prompt = 'login';
     const responseMode = 'pi.flow';
@@ -77,8 +91,8 @@ describe('createAuthorizeUrl', () => {
       responseMode,
     };
 
-    const url = await createAuthorizeUrl(baseUrl, optionsWithOptionals);
-    const params = new URL(url).searchParams;
+    const result = await createAuthorizeUrl(baseUrl, optionsWithOptionals);
+    const params = new URL(result.url).searchParams;
 
     expect(params.get('prompt')).toBe(prompt);
     expect(params.get('response_mode')).toBe(responseMode);
@@ -95,8 +109,8 @@ describe('createAuthorizeUrl', () => {
       },
     };
 
-    const url = await createAuthorizeUrl(baseUrl, optionsWithOptionals);
-    const params = new URL(url).searchParams;
+    const result = await createAuthorizeUrl(baseUrl, optionsWithOptionals);
+    const params = new URL(result.url).searchParams;
 
     expect(params.get('queryA')).toBe(queryA);
     expect(params.get('queryB')).toBe(queryB);
@@ -111,8 +125,8 @@ describe('createAuthorizeUrl', () => {
       },
     };
 
-    const url = await createAuthorizeUrl(baseUrl, optionsWithConflict);
-    const params = new URL(url).searchParams;
+    const result = await createAuthorizeUrl(baseUrl, optionsWithConflict);
+    const params = new URL(result.url).searchParams;
 
     // Standard param should override query param
     expect(params.get('client_id')).toBe(mockOptions.clientId);
@@ -120,21 +134,10 @@ describe('createAuthorizeUrl', () => {
     expect(params.get('custom_param')).toBe('value');
   });
 
-  it('should store the authorize options in session storage', async () => {
+  it('should NOT store values in session storage (caller responsibility)', async () => {
     await createAuthorizeUrl(baseUrl, mockOptions);
-    const storageKey = getStorageKey(mockOptions.clientId);
-    const storedData = sessionStorage.getItem(storageKey);
-
-    const parsedOptions = JSON.parse(storedData as string);
-    const serverUrl = new URL(baseUrl).origin;
-
-    expect(storedData).toBeDefined();
-    expect(parsedOptions).toMatchObject({
-      ...mockOptions,
-      serverConfig: { baseUrl: serverUrl },
-    });
-    expect(parsedOptions).toHaveProperty('state');
-    expect(parsedOptions).toHaveProperty('verifier');
+    // createAuthorizeUrl no longer writes to sessionStorage — that's the caller's job
+    expect(sessionStorage.getItem(`FR-SDK-authflow-${mockOptions.clientId}`)).toBeNull();
   });
 });
 

--- a/packages/sdk-effects/oidc/src/lib/state-pkce.effects.ts
+++ b/packages/sdk-effects/oidc/src/lib/state-pkce.effects.ts
@@ -16,44 +16,55 @@ export function getStorageKey(clientId: string, prefix?: string) {
   return `${prefix || 'FR-SDK'}-authflow-${clientId}`;
 }
 
-/**
- * Generate and store PKCE values for later use
- * @param { string } storageKey - Key to store authorization options in sessionStorage
- * @param {GenerateAndStoreAuthUrlValues} options - Options for generating PKCE values
- * @returns { state: string, verifier: string, GetAuthorizationUrlOptions }
- */
+/** The PKCE + state values generated for an authorization request. */
+export interface AuthUrlValues extends GetAuthorizationUrlOptions {
+  state: string;
+  verifier: string;
+}
 
-export function generateAndStoreAuthUrlValues(
-  options: GenerateAndStoreAuthUrlValues,
-): readonly [GetAuthorizationUrlOptions & { state: string; verifier: string }, () => void] {
+/**
+ * Pure PKCE generation — no storage side effects.
+ * Returns the authorize URL options with generated state and verifier.
+ * The caller is responsible for persisting these values for token exchange.
+ */
+export function generateAuthUrlValues(options: GenerateAndStoreAuthUrlValues): AuthUrlValues {
   const verifier = createVerifier();
   const state = createState();
-  const storageKey = getStorageKey(options.clientId, options.prefix);
 
-  const authorizeUrlOptions = {
+  return {
     ...options,
     state,
     verifier,
   };
+}
+
+/**
+ * @deprecated Use `generateAuthUrlValues` and handle storage yourself.
+ * Generate PKCE values and return a closure to store them in sessionStorage.
+ */
+export function generateAndStoreAuthUrlValues(
+  options: GenerateAndStoreAuthUrlValues,
+): readonly [AuthUrlValues, () => void] {
+  const authorizeUrlOptions = generateAuthUrlValues(options);
+  const storageKey = getStorageKey(options.clientId, options.prefix);
 
   return [
     authorizeUrlOptions,
-    () => sessionStorage.setItem(storageKey, JSON.stringify(authorizeUrlOptions)),
+    () => globalThis.sessionStorage.setItem(storageKey, JSON.stringify(authorizeUrlOptions)),
   ] as const;
 }
 
 /**
- * @function getStoredAuthUrlValues - Retrieve stored authorization options from sessionStorage
- * @param { string } storageKey - Key to retrieve stored values from sessionStorage
- * @returns { GetAuthorizationUrlOptions }
+ * @deprecated Use caller-provided stored values instead.
+ * Retrieve stored authorization options from sessionStorage.
  */
 export function getStoredAuthUrlValues(
   clientId: string,
   prefix?: string,
 ): GetAuthorizationUrlOptions {
   const storageKey = getStorageKey(clientId, prefix);
-  const storedString = sessionStorage.getItem(storageKey);
-  sessionStorage.removeItem(storageKey);
+  const storedString = globalThis.sessionStorage.getItem(storageKey);
+  globalThis.sessionStorage.removeItem(storageKey);
 
   try {
     return JSON.parse(storedString as string);

--- a/packages/sdk-effects/storage/src/lib/storage.effects.ts
+++ b/packages/sdk-effects/storage/src/lib/storage.effects.ts
@@ -27,6 +27,21 @@ export interface CustomStorageConfig {
   custom: CustomStorageObject;
 }
 
+/**
+ * Lazily access browser storage globals. Using `globalThis` property access
+ * instead of bare `sessionStorage`/`localStorage` avoids ReferenceError
+ * in Node.js/SSR environments — property access returns `undefined` rather than throwing.
+ */
+function getBrowserStorage(type: 'localStorage' | 'sessionStorage'): Storage {
+  const storage = type === 'localStorage' ? globalThis.localStorage : globalThis.sessionStorage;
+  if (!storage) {
+    throw new Error(
+      `${type} is not available in this environment. Use type: 'custom' for server-side usage.`,
+    );
+  }
+  return storage;
+}
+
 function createStorageError(
   storeType: 'localStorage' | 'sessionStorage' | 'custom',
   action: 'Storing' | 'Retrieving' | 'Removing' | 'Parsing',
@@ -56,10 +71,6 @@ function createStorageError(
 export function createStorage<Value>(config: StorageConfig): StorageClient<Value> {
   const { type: storeType, prefix = 'pic', name } = config;
   const key = `${prefix}-${name}`;
-  const storageTypes = {
-    sessionStorage,
-    localStorage,
-  };
 
   if (storeType === 'custom' && !('custom' in config)) {
     throw new Error('Custom storage configuration must include a custom storage object');
@@ -89,7 +100,7 @@ export function createStorage<Value>(config: StorageConfig): StorageClient<Value
 
       let value: string | null;
       try {
-        value = await storageTypes[storeType].getItem(key);
+        value = await getBrowserStorage(storeType).getItem(key);
         if (value === null) {
           return value;
         }
@@ -116,7 +127,7 @@ export function createStorage<Value>(config: StorageConfig): StorageClient<Value
       }
 
       try {
-        await storageTypes[storeType].setItem(key, valueToStore);
+        await getBrowserStorage(storeType).setItem(key, valueToStore);
         return Promise.resolve(null);
       } catch {
         return createStorageError(storeType, 'Storing');
@@ -133,7 +144,7 @@ export function createStorage<Value>(config: StorageConfig): StorageClient<Value
       }
 
       try {
-        await storageTypes[storeType].removeItem(key);
+        await getBrowserStorage(storeType).removeItem(key);
         return Promise.resolve(null);
       } catch {
         return createStorageError(storeType, 'Removing');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -440,6 +440,31 @@ importers:
         specifier: workspace:*
         version: link:../../packages/recognize
 
+  e2e/svelte-app:
+    dependencies:
+      '@forgerock/journey-client':
+        specifier: workspace:*
+        version: link:../../packages/journey-client
+      '@forgerock/oidc-client':
+        specifier: workspace:*
+        version: link:../../packages/oidc-client
+    devDependencies:
+      '@sveltejs/adapter-auto':
+        specifier: ^6.0.0
+        version: 6.1.1(@sveltejs/kit@2.57.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.2)(vite@7.3.6(@types/node@24.9.2)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.55.2)(typescript@5.9.3)(vite@7.3.6(@types/node@24.9.2)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)))
+      '@sveltejs/kit':
+        specifier: ^2.21.0
+        version: 2.57.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.2)(vite@7.3.6(@types/node@24.9.2)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.55.2)(typescript@5.9.3)(vite@7.3.6(@types/node@24.9.2)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@sveltejs/vite-plugin-svelte':
+        specifier: ^5.0.0
+        version: 5.1.1(svelte@5.55.2)(vite@7.3.6(@types/node@24.9.2)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+      svelte:
+        specifier: ^5.0.0
+        version: 5.55.2
+      vite:
+        specifier: catalog:vite
+        version: 7.3.6(@types/node@24.9.2)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+
   packages/davinci-client:
     dependencies:
       '@forgerock/sdk-logger':
@@ -2991,6 +3016,47 @@ packages:
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
+  '@sveltejs/acorn-typescript@1.0.9':
+    resolution: {integrity: sha512-lVJX6qEgs/4DOcRTpo56tmKzVPtoWAaVbL4hfO7t7NVwl9AAXzQR6cihesW1BmNMPl+bK6dreu2sOKBP2Q9CIA==}
+    peerDependencies:
+      acorn: ^8.9.0
+
+  '@sveltejs/adapter-auto@6.1.1':
+    resolution: {integrity: sha512-cBNt4jgH4KuaNO5gRSB2CZKkGtz+OCZ8lPjRQGjhvVUD4akotnj2weUia6imLl2v07K3IgsQRyM36909miSwoQ==}
+    peerDependencies:
+      '@sveltejs/kit': ^2.0.0
+
+  '@sveltejs/kit@2.57.0':
+    resolution: {integrity: sha512-TMiqCTy9ZW4KBHvmTgeWU/hF6jcFpeMgR+9ekE06uhhGnbUZ7wpIY6l1Uk4ThRzlWYJnCVfzmtVNaHaDjaSiSg==}
+    engines: {node: '>=18.13'}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+      '@sveltejs/vite-plugin-svelte': ^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0 || ^7.0.0
+      svelte: ^4.0.0 || ^5.0.0-next.0
+      typescript: ^5.3.3 || ^6.0.0
+      vite: ^5.0.3 || ^6.0.0 || ^7.0.0-beta.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      typescript:
+        optional: true
+
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1':
+    resolution: {integrity: sha512-J/Nmb2Q2y7mck2hyCX4ckVHcR5tu2J+MtBEQqpDrrgELZ2uvraQcK/ioCV61AqkdXFgriksOKIceDcQmqnGhVw==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22}
+    peerDependencies:
+      '@sveltejs/vite-plugin-svelte': ^5.0.0
+      svelte: ^5.0.0
+      vite: ^6.0.0
+
+  '@sveltejs/vite-plugin-svelte@5.1.1':
+    resolution: {integrity: sha512-Y1Cs7hhTc+a5E9Va/xwKlAJoariQyHY+5zBgCZg4PFWNYQ1nMN9sjK1zhw1gK69DuqVP++sht/1GZg1aRwmAXQ==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22}
+    peerDependencies:
+      svelte: ^5.0.0
+      vite: ^6.0.0
+
   '@swc-node/core@1.14.1':
     resolution: {integrity: sha512-jrt5GUaZUU6cmMS+WTJEvGvaB6j1YNKPHPzC2PUi2BjaFbtxURHj6641Az6xN7b665hNniAIdvjxWcRml5yCnw==}
     engines: {node: '>= 10'}
@@ -3182,6 +3248,9 @@ packages:
 
   '@types/conventional-commits-parser@5.0.2':
     resolution: {integrity: sha512-BgT2szDXnVypgpNxOK8aL5SGjUdaQbC++WZNjF1Qge3Og2+zhHj+RWhmehLhYyvQwqAmvezruVfOf8+3m74W+g==}
+
+  '@types/cookie@0.6.0':
+    resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
@@ -3836,6 +3905,10 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  aria-query@5.3.1:
+    resolution: {integrity: sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==}
+    engines: {node: '>= 0.4'}
+
   array-buffer-byte-length@1.0.2:
     resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
     engines: {node: '>= 0.4'}
@@ -3921,6 +3994,10 @@ packages:
 
   axios@1.16.0:
     resolution: {integrity: sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==}
+
+  axobject-query@4.1.0:
+    resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
+    engines: {node: '>= 0.4'}
 
   b4a@1.7.3:
     resolution: {integrity: sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==}
@@ -4245,6 +4322,10 @@ packages:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
     engines: {node: '>=0.8'}
 
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
   co@4.6.0:
     resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
     engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
@@ -4383,13 +4464,13 @@ packages:
     resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
     engines: {node: '>=6.6.0'}
 
+  cookie@0.6.0:
+    resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
+    engines: {node: '>= 0.6'}
+
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
-
-  cookie@1.0.2:
-    resolution: {integrity: sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==}
-    engines: {node: '>=18'}
 
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
@@ -4700,6 +4781,9 @@ packages:
     peerDependencies:
       typescript: ^5.4.4
 
+  devalue@5.7.1:
+    resolution: {integrity: sha512-MUbZ586EgQqdRnC4yDrlod3BEdyvE4TapGYHMW2CiaW+KkkFmWEFqBUaLltEZCGi0iFXCEjRF0OjF0DV2QHjOA==}
+
   dezalgo@1.0.4:
     resolution: {integrity: sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==}
 
@@ -4995,6 +5079,9 @@ packages:
       jiti:
         optional: true
 
+  esm-env@1.2.2:
+    resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
+
   espree@10.4.0:
     resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -5011,6 +5098,9 @@ packages:
   esquery@1.7.0:
     resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
     engines: {node: '>=0.10'}
+
+  esrap@2.2.4:
+    resolution: {integrity: sha512-suICpxAmZ9A8bzJjEl/+rLJiDKC0X4gYWUxT6URAWBLvlXmtbZd5ySMu/N2ZGEtMCAmflUDPSehrP9BQcsGcSg==}
 
   esrecurse@4.3.0:
     resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
@@ -5830,6 +5920,9 @@ packages:
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
+  is-reference@3.0.3:
+    resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
+
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
@@ -6190,6 +6283,10 @@ packages:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
     engines: {node: '>=0.10.0'}
 
+  kleur@4.1.5:
+    resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
+    engines: {node: '>=6'}
+
   leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
     engines: {node: '>=6'}
@@ -6220,6 +6317,9 @@ packages:
   loader-runner@4.3.2:
     resolution: {integrity: sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==}
     engines: {node: '>=6.11.5'}
+
+  locate-character@3.0.0:
+    resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
 
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
@@ -7405,6 +7505,9 @@ packages:
   set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
 
+  set-cookie-parser@3.1.0:
+    resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
+
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
     engines: {node: '>= 0.4'}
@@ -7713,6 +7816,10 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  svelte@5.55.2:
+    resolution: {integrity: sha512-z41M/hi0ZPTzrwVKLvB/R1/Oo08gL1uIib8HZ+FncqxxtY9MLb01emg2fqk+WLZ/lNrrtNDFh7BZLDxAHvMgLw==}
+    engines: {node: '>=18'}
 
   swc-loader@0.2.7:
     resolution: {integrity: sha512-nwYWw3Fh9ame3Rtm7StS9SBLpHRRnYcK7bnpF3UKZmesAK0gw2/ADvlURFAINmPvKtDLzp+GBiP9yLoEjg6S9w==}
@@ -8305,6 +8412,14 @@ packages:
       yaml:
         optional: true
 
+  vitefu@1.1.3:
+    resolution: {integrity: sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==}
+    peerDependencies:
+      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      vite:
+        optional: true
+
   vitest-canvas-mock@1.1.3:
     resolution: {integrity: sha512-zlKJR776Qgd+bcACPh0Pq5MG3xWq+CdkACKY/wX4Jyija0BSz8LH3aCCgwFKYFwtm565+050YFEGG9Ki0gE/Hw==}
     peerDependencies:
@@ -8544,6 +8659,9 @@ packages:
   yoctocolors@2.1.2:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
     engines: {node: '>=18'}
+
+  zimmerframe@1.1.4:
+    resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
 
   zod-package-json@1.2.0:
     resolution: {integrity: sha512-tamtgPM3MkP+obfO2dLr/G+nYoYkpJKmuHdYEy6IXRKfLybruoJ5NUj0lM0LxwOpC9PpoGLbll1ecoeyj43Wsg==}
@@ -11267,6 +11385,57 @@ snapshots:
 
   '@standard-schema/utils@0.3.0': {}
 
+  '@sveltejs/acorn-typescript@1.0.9(acorn@8.17.0)':
+    dependencies:
+      acorn: 8.17.0
+
+  '@sveltejs/adapter-auto@6.1.1(@sveltejs/kit@2.57.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.2)(vite@7.3.6(@types/node@24.9.2)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.55.2)(typescript@5.9.3)(vite@7.3.6(@types/node@24.9.2)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)))':
+    dependencies:
+      '@sveltejs/kit': 2.57.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.2)(vite@7.3.6(@types/node@24.9.2)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.55.2)(typescript@5.9.3)(vite@7.3.6(@types/node@24.9.2)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+
+  '@sveltejs/kit@2.57.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.2)(vite@7.3.6(@types/node@24.9.2)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.55.2)(typescript@5.9.3)(vite@7.3.6(@types/node@24.9.2)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@sveltejs/acorn-typescript': 1.0.9(acorn@8.17.0)
+      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.55.2)(vite@7.3.6(@types/node@24.9.2)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@types/cookie': 0.6.0
+      acorn: 8.17.0
+      cookie: 0.6.0
+      devalue: 5.7.1
+      esm-env: 1.2.2
+      kleur: 4.1.5
+      magic-string: 0.30.21
+      mrmime: 2.0.1
+      set-cookie-parser: 3.1.0
+      sirv: 3.0.2
+      svelte: 5.55.2
+      vite: 7.3.6(@types/node@24.9.2)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      typescript: 5.9.3
+
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.2)(vite@7.3.6(@types/node@24.9.2)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.55.2)(vite@7.3.6(@types/node@24.9.2)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
+    dependencies:
+      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.55.2)(vite@7.3.6(@types/node@24.9.2)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+      debug: 4.4.3
+      svelte: 5.55.2
+      vite: 7.3.6(@types/node@24.9.2)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.2)(vite@7.3.6(@types/node@24.9.2)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
+    dependencies:
+      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.2)(vite@7.3.6(@types/node@24.9.2)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.55.2)(vite@7.3.6(@types/node@24.9.2)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+      debug: 4.4.3
+      deepmerge: 4.3.1
+      kleur: 4.1.5
+      magic-string: 0.30.21
+      svelte: 5.55.2
+      vite: 7.3.6(@types/node@24.9.2)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+      vitefu: 1.1.3(vite@7.3.6(@types/node@24.9.2)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - supports-color
+
   '@swc-node/core@1.14.1(@swc/core@1.15.30(@swc/helpers@0.5.21))(@swc/types@0.1.26)':
     dependencies:
       '@swc/core': 1.15.30(@swc/helpers@0.5.21)
@@ -11467,6 +11636,8 @@ snapshots:
   '@types/conventional-commits-parser@5.0.2':
     dependencies:
       '@types/node': 24.9.2
+
+  '@types/cookie@0.6.0': {}
 
   '@types/deep-eql@4.0.2': {}
 
@@ -12229,7 +12400,7 @@ snapshots:
 
   acorn-walk@8.3.4:
     dependencies:
-      acorn: 8.16.0
+      acorn: 8.17.0
 
   acorn@8.16.0: {}
 
@@ -12333,6 +12504,8 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  aria-query@5.3.1: {}
+
   array-buffer-byte-length@1.0.2:
     dependencies:
       call-bound: 1.0.4
@@ -12432,6 +12605,8 @@ snapshots:
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
+
+  axobject-query@4.1.0: {}
 
   b4a@1.7.3: {}
 
@@ -12796,6 +12971,8 @@ snapshots:
 
   clone@1.0.4: {}
 
+  clsx@2.1.1: {}
+
   co@4.6.0: {}
 
   code-block-writer@13.0.3: {}
@@ -12930,9 +13107,9 @@ snapshots:
 
   cookie-signature@1.2.2: {}
 
-  cookie@0.7.2: {}
+  cookie@0.6.0: {}
 
-  cookie@1.0.2: {}
+  cookie@0.7.2: {}
 
   cookie@1.1.1: {}
 
@@ -13215,6 +13392,8 @@ snapshots:
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
+
+  devalue@5.7.1: {}
 
   dezalgo@1.0.4:
     dependencies:
@@ -13608,6 +13787,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  esm-env@1.2.2: {}
+
   espree@10.4.0:
     dependencies:
       acorn: 8.16.0
@@ -13625,6 +13806,11 @@ snapshots:
   esquery@1.7.0:
     dependencies:
       estraverse: 5.3.0
+
+  esrap@2.2.4:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@typescript-eslint/types': 8.46.3
 
   esrecurse@4.3.0:
     dependencies:
@@ -14590,6 +14776,10 @@ snapshots:
 
   is-promise@4.0.0: {}
 
+  is-reference@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   is-regex@1.2.1:
     dependencies:
       call-bound: 1.0.4
@@ -15131,6 +15321,8 @@ snapshots:
 
   kind-of@6.0.3: {}
 
+  kleur@4.1.5: {}
+
   leven@3.1.0: {}
 
   levn@0.4.1:
@@ -15163,6 +15355,8 @@ snapshots:
       lit-html: 3.3.3
 
   loader-runner@4.3.2: {}
+
+  locate-character@3.0.0: {}
 
   locate-path@5.0.0:
     dependencies:
@@ -15400,7 +15594,7 @@ snapshots:
 
   mlly@1.8.0:
     dependencies:
-      acorn: 8.16.0
+      acorn: 8.17.0
       pathe: 2.0.3
       pkg-types: 1.3.1
       ufo: 1.6.1
@@ -15453,7 +15647,7 @@ snapshots:
       '@mswjs/interceptors': 0.40.0
       '@open-draft/deferred-promise': 2.2.0
       '@types/statuses': 2.0.6
-      cookie: 1.0.2
+      cookie: 1.1.1
       graphql: 16.12.0
       headers-polyfill: 4.0.3
       is-node-process: 1.2.0
@@ -15479,7 +15673,7 @@ snapshots:
       '@mswjs/interceptors': 0.40.0
       '@open-draft/deferred-promise': 2.2.0
       '@types/statuses': 2.0.6
-      cookie: 1.0.2
+      cookie: 1.1.1
       graphql: 16.12.0
       headers-polyfill: 4.0.3
       is-node-process: 1.2.0
@@ -16520,6 +16714,8 @@ snapshots:
 
   set-blocking@2.0.0: {}
 
+  set-cookie-parser@3.1.0: {}
+
   set-function-length@1.2.2:
     dependencies:
       define-data-property: 1.1.4
@@ -16868,6 +17064,25 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  svelte@5.55.2:
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@sveltejs/acorn-typescript': 1.0.9(acorn@8.17.0)
+      '@types/estree': 1.0.8
+      '@types/trusted-types': 2.0.7
+      acorn: 8.17.0
+      aria-query: 5.3.1
+      axobject-query: 4.1.0
+      clsx: 2.1.1
+      devalue: 5.7.1
+      esm-env: 1.2.2
+      esrap: 2.2.4
+      is-reference: 3.0.3
+      locate-character: 3.0.0
+      magic-string: 0.30.21
+      zimmerframe: 1.1.4
 
   swc-loader@0.2.7(@swc/core@1.15.30(@swc/helpers@0.5.21))(webpack@5.102.1(@swc/core@1.15.30(@swc/helpers@0.5.21))(postcss@8.5.26)):
     dependencies:
@@ -17471,6 +17686,10 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.9.0
 
+  vitefu@1.1.3(vite@7.3.6(@types/node@24.9.2)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)):
+    optionalDependencies:
+      vite: 7.3.6(@types/node@24.9.2)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+
   vitest-canvas-mock@1.1.3(vitest@3.2.6):
     dependencies:
       cssfontparser: 1.2.1
@@ -17800,6 +18019,8 @@ snapshots:
   yoctocolors-cjs@2.1.3: {}
 
   yoctocolors@2.1.2: {}
+
+  zimmerframe@1.1.4: {}
 
   zod-package-json@1.2.0:
     dependencies:


### PR DESCRIPTION
## Summary

**This is a complete proof of concept — not finished work.** It demonstrates the changes needed to make `journey-client` and `oidc-client` work in server-side rendering environments (SvelteKit, Next.js, etc.).

### Problem
- `@forgerock/storage` eagerly references `sessionStorage`/`localStorage` globals, crashing on import in Node.js
- `createAuthorizeUrl` couples PKCE generation with `sessionStorage`, preventing server-side authorize URL creation
- `window.location.assign()` in `redirect()` has no server guard

### Changes

**Storage (`@forgerock/storage`)**
- Replace eager browser global references with lazy `globalThis` access via `getBrowserStorage()`
- SSR callers use existing `type: 'custom'` with a no-op adapter — no new types needed

**Journey Client (`@forgerock/journey-client`)**
- Add optional `storage` config to `JourneyClientConfig` (defaults to sessionStorage)
- Guard `redirect()` with `typeof window` check
- Export `createJourneyObject` for client-side step reconstitution after SSR

**OIDC / PKCE (`@forgerock/sdk-oidc`, `@forgerock/oidc-client`)**
- Decouple PKCE generation from storage — `createAuthorizeUrl` now returns `{ url, verifier, state }` instead of writing to sessionStorage
- Callers persist PKCE values however they choose (cookies, server session, etc.)
- `token.exchange()` accepts optional `pkceValues` parameter to skip sessionStorage lookup
- Browser background flow still uses sessionStorage internally (unchanged behavior)

**SvelteKit PoC (`e2e/svelte-app`)**
- Demonstrates full end-to-end flow against the AM mock API:
  1. Server-side journey `start()` → SSR-rendered login form
  2. Client-side credential submission via `next()`
  3. Server-side PKCE authorize URL generation with cookie-based verifier persistence
  4. Server-side token exchange → tokens received

## Test plan
- [ ] `nx run storage:test` — 21 tests pass
- [ ] `nx run journey-client:test` — 193 tests pass  
- [ ] `nx run sdk-oidc:test` — 26 tests pass
- [ ] `nx run oidc-client:test` — 21 tests pass
- [ ] `nx run davinci-client:test` — 226 tests pass
- [ ] SvelteKit PoC: start `am-mock-api:serve` + `vite dev` in `e2e/svelte-app`, verify SSR rendering and token exchange