### PR TITLE
feat(davinci-client): rich-text-collector

### DIFF
--- a/.changeset/rich-content-links.md
+++ b/.changeset/rich-content-links.md
@@ -1,0 +1,7 @@
+---
+'@forgerock/davinci-client': minor
+---
+
+A new `ReadOnlyCollector.output.richContent` property is always present and contains the structured link data when a LABEL field includes `richContent`. Its shape is `CollectorRichContent` — a template string with `{{key}}` placeholders (`content`) and a validated `replacements` array (`ValidatedReplacement[]`). When no `richContent` is present, `replacements` is an empty array.
+
+**New type exports**: `RichContentLink`, `ValidatedReplacement`, `CollectorRichContent`

--- a/.nxignore
+++ b/.nxignore
@@ -1,0 +1,1 @@
+.opensource/

--- a/e2e/davinci-app/components/label.ts
+++ b/e2e/davinci-app/components/label.ts
@@ -4,12 +4,56 @@
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
  */
-import type { ReadOnlyCollector } from '@forgerock/davinci-client/types';
+import type { ReadOnlyCollector, RichTextCollector } from '@forgerock/davinci-client/types';
 
-export default function (formEl: HTMLFormElement, collector: ReadOnlyCollector) {
-  // create paragraph element with text of "Loading ... "
+export default function (
+  formEl: HTMLFormElement,
+  collector: ReadOnlyCollector | RichTextCollector,
+) {
   const p = document.createElement('p');
+  p.style.whiteSpace = 'pre-line';
 
-  p.innerText = collector.output.label;
+  if (collector.type !== 'RichTextCollector') {
+    p.innerText = collector.output.content;
+    formEl?.appendChild(p);
+    return;
+  }
+
+  const { richContent } = collector.output;
+
+  if (richContent.replacements.length === 0) {
+    p.innerText = collector.output.content;
+    formEl?.appendChild(p);
+    return;
+  }
+
+  // Interpolate the template by splitting on {{key}} and inserting links
+  const segments = richContent.content.split(/\{\{(\w+)\}\}/);
+  const replacementMap = new Map(richContent.replacements.map((r) => [r.key, r]));
+
+  for (let i = 0; i < segments.length; i++) {
+    if (i % 2 === 0) {
+      // Text segment
+      if (segments[i]) {
+        p.appendChild(document.createTextNode(segments[i]));
+      }
+    } else {
+      // Replacement key
+      const replacement = replacementMap.get(segments[i]);
+      if (replacement?.type === 'link') {
+        const a = document.createElement('a');
+        a.href = replacement.href;
+        a.textContent = replacement.value;
+        if (replacement.target) {
+          a.target = replacement.target;
+          if (replacement.target === '_blank') {
+            a.rel = 'noopener noreferrer';
+          }
+        }
+        p.appendChild(a);
+      }
+    }
+  }
+
   formEl?.appendChild(p);
 }

--- a/e2e/davinci-app/main.ts
+++ b/e2e/davinci-app/main.ts
@@ -221,7 +221,7 @@ const urlParams = new URLSearchParams(window.location.search);
           davinciClient.update(collector), // Returns an update function for this collector
           submitForm,
         );
-      } else if (collector.type === 'ReadOnlyCollector') {
+      } else if (collector.type === 'ReadOnlyCollector' || collector.type === 'RichTextCollector') {
         labelComponent(
           formEl, // You can ignore this; it's just for rendering
           collector, // This is the plain object of the collector

--- a/packages/davinci-client/api-report/davinci-client.api.md
+++ b/packages/davinci-client/api-report/davinci-client.api.md
@@ -177,8 +177,16 @@ export interface CollectorErrors {
     target: string;
 }
 
+// @public
+export interface CollectorRichContent {
+    // (undocumented)
+    content: string;
+    // (undocumented)
+    replacements: RichContentLink[];
+}
+
 // @public (undocumented)
-export type Collectors = FlowCollector | PasswordCollector | TextCollector | SingleSelectCollector | IdpCollector | SubmitCollector | ActionCollector<'ActionCollector'> | SingleValueCollector<'SingleValueCollector'> | MultiSelectCollector | DeviceAuthenticationCollector | DeviceRegistrationCollector | PhoneNumberCollector | ReadOnlyCollector | ValidatedTextCollector | ProtectCollector | PollingCollector | FidoRegistrationCollector | FidoAuthenticationCollector | QrCodeCollector | AgreementCollector | UnknownCollector;
+export type Collectors = FlowCollector | PasswordCollector | TextCollector | SingleSelectCollector | IdpCollector | SubmitCollector | ActionCollector<'ActionCollector'> | SingleValueCollector<'SingleValueCollector'> | MultiSelectCollector | DeviceAuthenticationCollector | DeviceRegistrationCollector | PhoneNumberCollector | PhoneNumberExtensionCollector | ReadOnlyCollector | RichTextCollector | ValidatedTextCollector | ProtectCollector | PollingCollector | FidoRegistrationCollector | FidoAuthenticationCollector | QrCodeCollector | AgreementCollector | UnknownCollector;
 
 // @public
 export type CollectorValueType<T> = T extends {
@@ -212,7 +220,7 @@ export type CollectorValueType<T> = T extends {
 } ? string[] : string | string[] | PhoneNumberInputValue | FidoRegistrationInputValue | FidoAuthenticationInputValue;
 
 // @public (undocumented)
-export type ComplexValueFields = DeviceAuthenticationField | DeviceRegistrationField | PhoneNumberField | FidoRegistrationField | FidoAuthenticationField | PollingField;
+export type ComplexValueFields = DeviceAuthenticationField | DeviceRegistrationField | PhoneNumberField | PhoneNumberExtensionField | FidoRegistrationField | FidoAuthenticationField | PollingField;
 
 // @public (undocumented)
 export interface ContinueNode {
@@ -267,13 +275,11 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
     resume: (input: {
         continueToken: string;
     }) => Promise<InternalErrorResponse | NodeStates>;
-    start: <QueryParams extends OutgoingQueryParams = OutgoingQueryParams>(options?: StartOptions<QueryParams> | undefined) => Promise<ContinueNode | StartNode | ErrorNode | FailureNode | SuccessNode>;
+    start: <QueryParams extends OutgoingQueryParams = OutgoingQueryParams>(options?: StartOptions<QueryParams> | undefined) => Promise<ContinueNode | ErrorNode | FailureNode | StartNode | SuccessNode>;
     update: <T extends SingleValueCollectors | MultiSelectCollector | ObjectValueCollectors | AutoCollectors>(collector: T) => Updater<T>;
     validate: (collector: SingleValueCollectors | ObjectValueCollectors | MultiValueCollectors | AutoCollectors) => Validator;
-    poll: (collector: PollingCollector) => Poller;
+    pollStatus: (collector: PollingCollector) => Poller;
     getClient: () => {
-        status: "start";
-    } | {
         action: string;
         collectors: Collectors[];
         description?: string;
@@ -287,6 +293,8 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         status: "error";
     } | {
         status: "failure";
+    } | {
+        status: "start";
     } | {
         authorization?: {
             code?: string;
@@ -297,7 +305,7 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
     getCollectors: () => Collectors[];
     getError: () => DaVinciError | null;
     getErrorCollectors: () => CollectorErrors[];
-    getNode: () => ContinueNode | StartNode | ErrorNode | FailureNode | SuccessNode;
+    getNode: () => ContinueNode | ErrorNode | FailureNode | StartNode | SuccessNode;
     getServer: () => {
         _links?: Links;
         id?: string;
@@ -306,8 +314,6 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         href?: string;
         eventName?: string;
         status: "continue";
-    } | {
-        status: "start";
     } | {
         _links?: Links;
         eventName?: string;
@@ -323,6 +329,8 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         interactionId?: string;
         interactionToken?: string;
         status: "failure";
+    } | {
+        status: "start";
     } | {
         _links?: Links;
         eventName?: string;
@@ -1029,13 +1037,13 @@ export type InferAutoCollectorType<T extends AutoCollectorTypes> = T extends 'Pr
 export type InferMultiValueCollectorType<T extends MultiValueCollectorTypes> = T extends 'MultiSelectCollector' ? MultiValueCollectorWithValue<'MultiSelectCollector'> : MultiValueCollectorWithValue<'MultiValueCollector'> | MultiValueCollectorNoValue<'MultiValueCollector'>;
 
 // @public
-export type InferNoValueCollectorType<T extends NoValueCollectorTypes> = T extends 'ReadOnlyCollector' ? NoValueCollectorBase<'ReadOnlyCollector'> : T extends 'QrCodeCollector' ? QrCodeCollectorBase : T extends 'AgreementCollector' ? AgreementCollector : NoValueCollectorBase<'NoValueCollector'>;
+export type InferNoValueCollectorType<T extends NoValueCollectorTypes> = T extends 'ReadOnlyCollector' ? ReadOnlyCollector : T extends 'RichTextCollector' ? RichTextCollector : T extends 'QrCodeCollector' ? QrCodeCollector : T extends 'AgreementCollector' ? AgreementCollector : NoValueCollectorBase<'NoValueCollector'>;
 
 // @public
 export type InferSingleValueCollectorType<T extends SingleValueCollectorTypes> = T extends 'TextCollector' ? TextCollector : T extends 'SingleSelectCollector' ? SingleSelectCollector : T extends 'ValidatedTextCollector' ? ValidatedTextCollector : T extends 'PasswordCollector' ? PasswordCollector : SingleValueCollectorWithValue<'SingleValueCollector'> | SingleValueCollectorNoValue<'SingleValueCollector'>;
 
 // @public (undocumented)
-export type InferValueObjectCollectorType<T extends ObjectValueCollectorTypes> = T extends 'DeviceAuthenticationCollector' ? DeviceAuthenticationCollector : T extends 'DeviceRegistrationCollector' ? DeviceRegistrationCollector : T extends 'PhoneNumberCollector' ? PhoneNumberCollector : ObjectOptionsCollectorWithObjectValue<'ObjectValueCollector'> | ObjectOptionsCollectorWithStringValue<'ObjectValueCollector'>;
+export type InferValueObjectCollectorType<T extends ObjectValueCollectorTypes> = T extends 'DeviceAuthenticationCollector' ? DeviceAuthenticationCollector : T extends 'DeviceRegistrationCollector' ? DeviceRegistrationCollector : T extends 'PhoneNumberCollector' ? PhoneNumberCollector : T extends 'PhoneNumberExtensionCollector' ? PhoneNumberExtensionCollector : ObjectOptionsCollectorWithObjectValue<'ObjectValueCollector'> | ObjectOptionsCollectorWithStringValue<'ObjectValueCollector'>;
 
 // @public (undocumented)
 export type InitFlow = () => Promise<FlowNode | InternalErrorResponse>;
@@ -1170,15 +1178,15 @@ value: Record<string, unknown>;
 }, string>;
 
 // @public
-export const nodeCollectorReducer: Reducer<(TextCollector | SingleSelectCollector | ValidatedTextCollector | PasswordCollector | MultiSelectCollector | DeviceAuthenticationCollector | DeviceRegistrationCollector | PhoneNumberCollector | IdpCollector | SubmitCollector | FlowCollector | QrCodeCollectorBase | AgreementCollector | ReadOnlyCollector | UnknownCollector | ProtectCollector | FidoRegistrationCollector | FidoAuthenticationCollector | PollingCollector | ActionCollector<"ActionCollector"> | SingleValueCollector<"SingleValueCollector">)[]> & {
-    getInitialState: () => (TextCollector | SingleSelectCollector | ValidatedTextCollector | PasswordCollector | MultiSelectCollector | DeviceAuthenticationCollector | DeviceRegistrationCollector | PhoneNumberCollector | IdpCollector | SubmitCollector | FlowCollector | QrCodeCollectorBase | AgreementCollector | ReadOnlyCollector | UnknownCollector | ProtectCollector | FidoRegistrationCollector | FidoAuthenticationCollector | PollingCollector | ActionCollector<"ActionCollector"> | SingleValueCollector<"SingleValueCollector">)[];
+export const nodeCollectorReducer: Reducer<(TextCollector | SingleSelectCollector | ValidatedTextCollector | PasswordCollector | MultiSelectCollector | PhoneNumberExtensionCollector | DeviceAuthenticationCollector | DeviceRegistrationCollector | PhoneNumberCollector | IdpCollector | SubmitCollector | FlowCollector | QrCodeCollector | ReadOnlyCollector | RichTextCollector | AgreementCollector | UnknownCollector | ProtectCollector | FidoRegistrationCollector | FidoAuthenticationCollector | PollingCollector | ActionCollector<"ActionCollector"> | SingleValueCollector<"SingleValueCollector">)[]> & {
+    getInitialState: () => (TextCollector | SingleSelectCollector | ValidatedTextCollector | PasswordCollector | MultiSelectCollector | PhoneNumberExtensionCollector | DeviceAuthenticationCollector | DeviceRegistrationCollector | PhoneNumberCollector | IdpCollector | SubmitCollector | FlowCollector | QrCodeCollector | ReadOnlyCollector | RichTextCollector | AgreementCollector | UnknownCollector | ProtectCollector | FidoRegistrationCollector | FidoAuthenticationCollector | PollingCollector | ActionCollector<"ActionCollector"> | SingleValueCollector<"SingleValueCollector">)[];
 };
 
 // @public (undocumented)
 export type NodeStates = StartNode | ContinueNode | ErrorNode | SuccessNode | FailureNode;
 
 // @public (undocumented)
-export type NoValueCollector<T extends NoValueCollectorTypes> = NoValueCollectorBase<T>;
+export type NoValueCollector<T extends NoValueCollectorTypes> = InferNoValueCollectorType<T>;
 
 // @public (undocumented)
 export interface NoValueCollectorBase<T extends NoValueCollectorTypes> {
@@ -1201,10 +1209,10 @@ export interface NoValueCollectorBase<T extends NoValueCollectorTypes> {
 }
 
 // @public (undocumented)
-export type NoValueCollectors = NoValueCollectorBase<'NoValueCollector'> | NoValueCollectorBase<'ReadOnlyCollector'> | QrCodeCollectorBase | AgreementCollector;
+export type NoValueCollectors = NoValueCollectorBase<'NoValueCollector'> | ReadOnlyCollector | RichTextCollector | QrCodeCollector | AgreementCollector;
 
 // @public
-export type NoValueCollectorTypes = 'ReadOnlyCollector' | 'NoValueCollector' | 'QrCodeCollector' | 'AgreementCollector';
+export type NoValueCollectorTypes = 'ReadOnlyCollector' | 'RichTextCollector' | 'NoValueCollector' | 'QrCodeCollector' | 'AgreementCollector';
 
 // @public
 export interface OAuthDetails {
@@ -1283,10 +1291,10 @@ export type ObjectValueAutoCollectorTypes = 'ObjectValueAutoCollector' | 'FidoRe
 export type ObjectValueCollector<T extends ObjectValueCollectorTypes> = ObjectOptionsCollectorWithObjectValue<T> | ObjectOptionsCollectorWithStringValue<T> | ObjectValueCollectorWithObjectValue<T>;
 
 // @public (undocumented)
-export type ObjectValueCollectors = DeviceAuthenticationCollector | DeviceRegistrationCollector | PhoneNumberCollector | ObjectOptionsCollectorWithObjectValue<'ObjectSelectCollector'> | ObjectOptionsCollectorWithStringValue<'ObjectSelectCollector'>;
+export type ObjectValueCollectors = DeviceAuthenticationCollector | DeviceRegistrationCollector | PhoneNumberCollector | PhoneNumberExtensionCollector | ObjectOptionsCollectorWithObjectValue<'ObjectSelectCollector'> | ObjectOptionsCollectorWithStringValue<'ObjectSelectCollector'>;
 
 // @public
-export type ObjectValueCollectorTypes = 'DeviceAuthenticationCollector' | 'DeviceRegistrationCollector' | 'PhoneNumberCollector' | 'ObjectOptionsCollector' | 'ObjectValueCollector' | 'ObjectSelectCollector';
+export type ObjectValueCollectorTypes = 'DeviceAuthenticationCollector' | 'DeviceRegistrationCollector' | 'PhoneNumberCollector' | 'PhoneNumberExtensionCollector' | 'ObjectOptionsCollector' | 'ObjectValueCollector' | 'ObjectSelectCollector';
 
 // @public (undocumented)
 export interface ObjectValueCollectorWithObjectValue<T extends ObjectValueCollectorTypes, IV = Record<string, string>, OV = Record<string, string>> {
@@ -1329,12 +1337,67 @@ export type PasswordCollector = SingleValueCollectorNoValue<'PasswordCollector'>
 export type PhoneNumberCollector = ObjectValueCollectorWithObjectValue<'PhoneNumberCollector', PhoneNumberInputValue, PhoneNumberOutputValue>;
 
 // @public (undocumented)
+export interface PhoneNumberExtensionCollector {
+    // (undocumented)
+    category: 'ObjectValueCollector';
+    // (undocumented)
+    error: string | null;
+    // (undocumented)
+    id: string;
+    // (undocumented)
+    input: {
+        key: string;
+        value: PhoneNumberExtensionInputValue;
+        type: string;
+        validation: (ValidationRequired | ValidationPhoneNumber)[] | null;
+    };
+    // (undocumented)
+    name: string;
+    // (undocumented)
+    output: {
+        key: string;
+        label: string;
+        type: string;
+        extensionLabel: string;
+        value: PhoneNumberExtensionOutputValue;
+    };
+    // (undocumented)
+    type: 'PhoneNumberExtensionCollector';
+}
+
+// @public (undocumented)
+export type PhoneNumberExtensionField = PhoneNumberField & {
+    showExtension: boolean;
+    extensionLabel: string;
+};
+
+// @public (undocumented)
+export interface PhoneNumberExtensionInputValue {
+    // (undocumented)
+    countryCode: string;
+    // (undocumented)
+    extension: string;
+    // (undocumented)
+    phoneNumber: string;
+}
+
+// @public (undocumented)
+export interface PhoneNumberExtensionOutputValue {
+    // (undocumented)
+    countryCode?: string;
+    // (undocumented)
+    extension?: string;
+    // (undocumented)
+    phoneNumber?: string;
+}
+
+// @public (undocumented)
 export type PhoneNumberField = {
     type: 'PHONE_NUMBER';
     key: string;
     label: string;
-    defaultCountryCode: string | null;
     required: boolean;
+    defaultCountryCode: string | null;
     validatePhoneNumber: boolean;
 };
 
@@ -1415,28 +1478,12 @@ export interface ProtectOutputValue {
     universalDeviceIdentification: boolean;
 }
 
-// @public (undocumented)
-export type QrCodeCollector = QrCodeCollectorBase;
-
-// @public (undocumented)
-export interface QrCodeCollectorBase {
+// @public
+export interface QrCodeCollector extends NoValueCollectorBase<'QrCodeCollector'> {
     // (undocumented)
-    category: 'NoValueCollector';
-    // (undocumented)
-    error: string | null;
-    // (undocumented)
-    id: string;
-    // (undocumented)
-    name: string;
-    // (undocumented)
-    output: {
-        key: string;
-        label: string;
-        type: string;
+    output: NoValueCollectorBase<'QrCodeCollector'>['output'] & {
         src: string;
     };
-    // (undocumented)
-    type: 'QrCodeCollector';
 }
 
 // @public (undocumented)
@@ -1447,13 +1494,19 @@ export type QrCodeField = {
     fallbackText?: string;
 };
 
-// @public (undocumented)
-export type ReadOnlyCollector = NoValueCollectorBase<'ReadOnlyCollector'>;
+// @public
+export interface ReadOnlyCollector extends NoValueCollectorBase<'ReadOnlyCollector'> {
+    // (undocumented)
+    output: NoValueCollectorBase<'ReadOnlyCollector'>['output'] & {
+        content: string;
+    };
+}
 
-// @public (undocumented)
+// @public
 export type ReadOnlyField = {
     type: 'LABEL';
     content: string;
+    richContent?: RichContent;
     key?: string;
 };
 
@@ -1472,6 +1525,43 @@ export type RedirectField = {
 export type RedirectFields = RedirectField;
 
 export { RequestMiddleware }
+
+// @public
+export type RichContent = {
+    content: string;
+    replacements?: Record<string, RichContentReplacement>;
+};
+
+// @public
+export interface RichContentLink {
+    // (undocumented)
+    href: string;
+    // (undocumented)
+    key: string;
+    // (undocumented)
+    target?: '_self' | '_blank';
+    // (undocumented)
+    type: 'link';
+    // (undocumented)
+    value: string;
+}
+
+// @public
+export type RichContentReplacement = {
+    type: 'link';
+    value: string;
+    href: string;
+    target?: '_self' | '_blank';
+};
+
+// @public
+export interface RichTextCollector extends NoValueCollectorBase<'RichTextCollector'> {
+    // (undocumented)
+    output: NoValueCollectorBase<'RichTextCollector'>['output'] & {
+        content: string;
+        richContent: CollectorRichContent;
+    };
+}
 
 // @public (undocumented)
 export interface SelectorOption {
@@ -1724,7 +1814,7 @@ export type UnknownField = Record<string, unknown>;
 // @public (undocumented)
 export const updateCollectorValues: ActionCreatorWithPayload<    {
 id: string;
-value: string | string[] | PhoneNumberInputValue | FidoRegistrationInputValue | FidoAuthenticationInputValue;
+value: string | string[] | PhoneNumberInputValue | PhoneNumberExtensionInputValue | FidoRegistrationInputValue | FidoAuthenticationInputValue;
 index?: number;
 }, string>;
 

--- a/packages/davinci-client/api-report/davinci-client.types.api.md
+++ b/packages/davinci-client/api-report/davinci-client.types.api.md
@@ -177,8 +177,16 @@ export interface CollectorErrors {
     target: string;
 }
 
+// @public
+export interface CollectorRichContent {
+    // (undocumented)
+    content: string;
+    // (undocumented)
+    replacements: RichContentLink[];
+}
+
 // @public (undocumented)
-export type Collectors = FlowCollector | PasswordCollector | TextCollector | SingleSelectCollector | IdpCollector | SubmitCollector | ActionCollector<'ActionCollector'> | SingleValueCollector<'SingleValueCollector'> | MultiSelectCollector | DeviceAuthenticationCollector | DeviceRegistrationCollector | PhoneNumberCollector | ReadOnlyCollector | ValidatedTextCollector | ProtectCollector | PollingCollector | FidoRegistrationCollector | FidoAuthenticationCollector | QrCodeCollector | AgreementCollector | UnknownCollector;
+export type Collectors = FlowCollector | PasswordCollector | TextCollector | SingleSelectCollector | IdpCollector | SubmitCollector | ActionCollector<'ActionCollector'> | SingleValueCollector<'SingleValueCollector'> | MultiSelectCollector | DeviceAuthenticationCollector | DeviceRegistrationCollector | PhoneNumberCollector | PhoneNumberExtensionCollector | ReadOnlyCollector | RichTextCollector | ValidatedTextCollector | ProtectCollector | PollingCollector | FidoRegistrationCollector | FidoAuthenticationCollector | QrCodeCollector | AgreementCollector | UnknownCollector;
 
 // @public
 export type CollectorValueType<T> = T extends {
@@ -212,7 +220,7 @@ export type CollectorValueType<T> = T extends {
 } ? string[] : string | string[] | PhoneNumberInputValue | FidoRegistrationInputValue | FidoAuthenticationInputValue;
 
 // @public (undocumented)
-export type ComplexValueFields = DeviceAuthenticationField | DeviceRegistrationField | PhoneNumberField | FidoRegistrationField | FidoAuthenticationField | PollingField;
+export type ComplexValueFields = DeviceAuthenticationField | DeviceRegistrationField | PhoneNumberField | PhoneNumberExtensionField | FidoRegistrationField | FidoAuthenticationField | PollingField;
 
 // @public (undocumented)
 export interface ContinueNode {
@@ -267,13 +275,11 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
     resume: (input: {
         continueToken: string;
     }) => Promise<InternalErrorResponse | NodeStates>;
-    start: <QueryParams extends OutgoingQueryParams = OutgoingQueryParams>(options?: StartOptions<QueryParams> | undefined) => Promise<ContinueNode | StartNode | ErrorNode | FailureNode | SuccessNode>;
+    start: <QueryParams extends OutgoingQueryParams = OutgoingQueryParams>(options?: StartOptions<QueryParams> | undefined) => Promise<ContinueNode | ErrorNode | FailureNode | StartNode | SuccessNode>;
     update: <T extends SingleValueCollectors | MultiSelectCollector | ObjectValueCollectors | AutoCollectors>(collector: T) => Updater<T>;
     validate: (collector: SingleValueCollectors | ObjectValueCollectors | MultiValueCollectors | AutoCollectors) => Validator;
-    poll: (collector: PollingCollector) => Poller;
+    pollStatus: (collector: PollingCollector) => Poller;
     getClient: () => {
-        status: "start";
-    } | {
         action: string;
         collectors: Collectors[];
         description?: string;
@@ -287,6 +293,8 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         status: "error";
     } | {
         status: "failure";
+    } | {
+        status: "start";
     } | {
         authorization?: {
             code?: string;
@@ -297,7 +305,7 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
     getCollectors: () => Collectors[];
     getError: () => DaVinciError | null;
     getErrorCollectors: () => CollectorErrors[];
-    getNode: () => ContinueNode | StartNode | ErrorNode | FailureNode | SuccessNode;
+    getNode: () => ContinueNode | ErrorNode | FailureNode | StartNode | SuccessNode;
     getServer: () => {
         _links?: Links;
         id?: string;
@@ -306,8 +314,6 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         href?: string;
         eventName?: string;
         status: "continue";
-    } | {
-        status: "start";
     } | {
         _links?: Links;
         eventName?: string;
@@ -323,6 +329,8 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         interactionId?: string;
         interactionToken?: string;
         status: "failure";
+    } | {
+        status: "start";
     } | {
         _links?: Links;
         eventName?: string;
@@ -1026,13 +1034,13 @@ export type InferAutoCollectorType<T extends AutoCollectorTypes> = T extends 'Pr
 export type InferMultiValueCollectorType<T extends MultiValueCollectorTypes> = T extends 'MultiSelectCollector' ? MultiValueCollectorWithValue<'MultiSelectCollector'> : MultiValueCollectorWithValue<'MultiValueCollector'> | MultiValueCollectorNoValue<'MultiValueCollector'>;
 
 // @public
-export type InferNoValueCollectorType<T extends NoValueCollectorTypes> = T extends 'ReadOnlyCollector' ? NoValueCollectorBase<'ReadOnlyCollector'> : T extends 'QrCodeCollector' ? QrCodeCollectorBase : T extends 'AgreementCollector' ? AgreementCollector : NoValueCollectorBase<'NoValueCollector'>;
+export type InferNoValueCollectorType<T extends NoValueCollectorTypes> = T extends 'ReadOnlyCollector' ? ReadOnlyCollector : T extends 'RichTextCollector' ? RichTextCollector : T extends 'QrCodeCollector' ? QrCodeCollector : T extends 'AgreementCollector' ? AgreementCollector : NoValueCollectorBase<'NoValueCollector'>;
 
 // @public
 export type InferSingleValueCollectorType<T extends SingleValueCollectorTypes> = T extends 'TextCollector' ? TextCollector : T extends 'SingleSelectCollector' ? SingleSelectCollector : T extends 'ValidatedTextCollector' ? ValidatedTextCollector : T extends 'PasswordCollector' ? PasswordCollector : SingleValueCollectorWithValue<'SingleValueCollector'> | SingleValueCollectorNoValue<'SingleValueCollector'>;
 
 // @public (undocumented)
-export type InferValueObjectCollectorType<T extends ObjectValueCollectorTypes> = T extends 'DeviceAuthenticationCollector' ? DeviceAuthenticationCollector : T extends 'DeviceRegistrationCollector' ? DeviceRegistrationCollector : T extends 'PhoneNumberCollector' ? PhoneNumberCollector : ObjectOptionsCollectorWithObjectValue<'ObjectValueCollector'> | ObjectOptionsCollectorWithStringValue<'ObjectValueCollector'>;
+export type InferValueObjectCollectorType<T extends ObjectValueCollectorTypes> = T extends 'DeviceAuthenticationCollector' ? DeviceAuthenticationCollector : T extends 'DeviceRegistrationCollector' ? DeviceRegistrationCollector : T extends 'PhoneNumberCollector' ? PhoneNumberCollector : T extends 'PhoneNumberExtensionCollector' ? PhoneNumberExtensionCollector : ObjectOptionsCollectorWithObjectValue<'ObjectValueCollector'> | ObjectOptionsCollectorWithStringValue<'ObjectValueCollector'>;
 
 // @public (undocumented)
 export type InitFlow = () => Promise<FlowNode | InternalErrorResponse>;
@@ -1167,15 +1175,15 @@ value: Record<string, unknown>;
 }, string>;
 
 // @public
-export const nodeCollectorReducer: Reducer<(TextCollector | SingleSelectCollector | ValidatedTextCollector | PasswordCollector | MultiSelectCollector | DeviceAuthenticationCollector | DeviceRegistrationCollector | PhoneNumberCollector | IdpCollector | SubmitCollector | FlowCollector | QrCodeCollectorBase | AgreementCollector | ReadOnlyCollector | UnknownCollector | ProtectCollector | FidoRegistrationCollector | FidoAuthenticationCollector | PollingCollector | ActionCollector<"ActionCollector"> | SingleValueCollector<"SingleValueCollector">)[]> & {
-    getInitialState: () => (TextCollector | SingleSelectCollector | ValidatedTextCollector | PasswordCollector | MultiSelectCollector | DeviceAuthenticationCollector | DeviceRegistrationCollector | PhoneNumberCollector | IdpCollector | SubmitCollector | FlowCollector | QrCodeCollectorBase | AgreementCollector | ReadOnlyCollector | UnknownCollector | ProtectCollector | FidoRegistrationCollector | FidoAuthenticationCollector | PollingCollector | ActionCollector<"ActionCollector"> | SingleValueCollector<"SingleValueCollector">)[];
+export const nodeCollectorReducer: Reducer<(TextCollector | SingleSelectCollector | ValidatedTextCollector | PasswordCollector | MultiSelectCollector | PhoneNumberExtensionCollector | DeviceAuthenticationCollector | DeviceRegistrationCollector | PhoneNumberCollector | IdpCollector | SubmitCollector | FlowCollector | QrCodeCollector | ReadOnlyCollector | RichTextCollector | AgreementCollector | UnknownCollector | ProtectCollector | FidoRegistrationCollector | FidoAuthenticationCollector | PollingCollector | ActionCollector<"ActionCollector"> | SingleValueCollector<"SingleValueCollector">)[]> & {
+    getInitialState: () => (TextCollector | SingleSelectCollector | ValidatedTextCollector | PasswordCollector | MultiSelectCollector | PhoneNumberExtensionCollector | DeviceAuthenticationCollector | DeviceRegistrationCollector | PhoneNumberCollector | IdpCollector | SubmitCollector | FlowCollector | QrCodeCollector | ReadOnlyCollector | RichTextCollector | AgreementCollector | UnknownCollector | ProtectCollector | FidoRegistrationCollector | FidoAuthenticationCollector | PollingCollector | ActionCollector<"ActionCollector"> | SingleValueCollector<"SingleValueCollector">)[];
 };
 
 // @public (undocumented)
 export type NodeStates = StartNode | ContinueNode | ErrorNode | SuccessNode | FailureNode;
 
 // @public (undocumented)
-export type NoValueCollector<T extends NoValueCollectorTypes> = NoValueCollectorBase<T>;
+export type NoValueCollector<T extends NoValueCollectorTypes> = InferNoValueCollectorType<T>;
 
 // @public (undocumented)
 export interface NoValueCollectorBase<T extends NoValueCollectorTypes> {
@@ -1198,10 +1206,10 @@ export interface NoValueCollectorBase<T extends NoValueCollectorTypes> {
 }
 
 // @public (undocumented)
-export type NoValueCollectors = NoValueCollectorBase<'NoValueCollector'> | NoValueCollectorBase<'ReadOnlyCollector'> | QrCodeCollectorBase | AgreementCollector;
+export type NoValueCollectors = NoValueCollectorBase<'NoValueCollector'> | ReadOnlyCollector | RichTextCollector | QrCodeCollector | AgreementCollector;
 
 // @public
-export type NoValueCollectorTypes = 'ReadOnlyCollector' | 'NoValueCollector' | 'QrCodeCollector' | 'AgreementCollector';
+export type NoValueCollectorTypes = 'ReadOnlyCollector' | 'RichTextCollector' | 'NoValueCollector' | 'QrCodeCollector' | 'AgreementCollector';
 
 // @public
 export interface OAuthDetails {
@@ -1280,10 +1288,10 @@ export type ObjectValueAutoCollectorTypes = 'ObjectValueAutoCollector' | 'FidoRe
 export type ObjectValueCollector<T extends ObjectValueCollectorTypes> = ObjectOptionsCollectorWithObjectValue<T> | ObjectOptionsCollectorWithStringValue<T> | ObjectValueCollectorWithObjectValue<T>;
 
 // @public (undocumented)
-export type ObjectValueCollectors = DeviceAuthenticationCollector | DeviceRegistrationCollector | PhoneNumberCollector | ObjectOptionsCollectorWithObjectValue<'ObjectSelectCollector'> | ObjectOptionsCollectorWithStringValue<'ObjectSelectCollector'>;
+export type ObjectValueCollectors = DeviceAuthenticationCollector | DeviceRegistrationCollector | PhoneNumberCollector | PhoneNumberExtensionCollector | ObjectOptionsCollectorWithObjectValue<'ObjectSelectCollector'> | ObjectOptionsCollectorWithStringValue<'ObjectSelectCollector'>;
 
 // @public
-export type ObjectValueCollectorTypes = 'DeviceAuthenticationCollector' | 'DeviceRegistrationCollector' | 'PhoneNumberCollector' | 'ObjectOptionsCollector' | 'ObjectValueCollector' | 'ObjectSelectCollector';
+export type ObjectValueCollectorTypes = 'DeviceAuthenticationCollector' | 'DeviceRegistrationCollector' | 'PhoneNumberCollector' | 'PhoneNumberExtensionCollector' | 'ObjectOptionsCollector' | 'ObjectValueCollector' | 'ObjectSelectCollector';
 
 // @public (undocumented)
 export interface ObjectValueCollectorWithObjectValue<T extends ObjectValueCollectorTypes, IV = Record<string, string>, OV = Record<string, string>> {
@@ -1326,12 +1334,67 @@ export type PasswordCollector = SingleValueCollectorNoValue<'PasswordCollector'>
 export type PhoneNumberCollector = ObjectValueCollectorWithObjectValue<'PhoneNumberCollector', PhoneNumberInputValue, PhoneNumberOutputValue>;
 
 // @public (undocumented)
+export interface PhoneNumberExtensionCollector {
+    // (undocumented)
+    category: 'ObjectValueCollector';
+    // (undocumented)
+    error: string | null;
+    // (undocumented)
+    id: string;
+    // (undocumented)
+    input: {
+        key: string;
+        value: PhoneNumberExtensionInputValue;
+        type: string;
+        validation: (ValidationRequired | ValidationPhoneNumber)[] | null;
+    };
+    // (undocumented)
+    name: string;
+    // (undocumented)
+    output: {
+        key: string;
+        label: string;
+        type: string;
+        extensionLabel: string;
+        value: PhoneNumberExtensionOutputValue;
+    };
+    // (undocumented)
+    type: 'PhoneNumberExtensionCollector';
+}
+
+// @public (undocumented)
+export type PhoneNumberExtensionField = PhoneNumberField & {
+    showExtension: boolean;
+    extensionLabel: string;
+};
+
+// @public (undocumented)
+export interface PhoneNumberExtensionInputValue {
+    // (undocumented)
+    countryCode: string;
+    // (undocumented)
+    extension: string;
+    // (undocumented)
+    phoneNumber: string;
+}
+
+// @public (undocumented)
+export interface PhoneNumberExtensionOutputValue {
+    // (undocumented)
+    countryCode?: string;
+    // (undocumented)
+    extension?: string;
+    // (undocumented)
+    phoneNumber?: string;
+}
+
+// @public (undocumented)
 export type PhoneNumberField = {
     type: 'PHONE_NUMBER';
     key: string;
     label: string;
-    defaultCountryCode: string | null;
     required: boolean;
+    defaultCountryCode: string | null;
     validatePhoneNumber: boolean;
 };
 
@@ -1412,28 +1475,12 @@ export interface ProtectOutputValue {
     universalDeviceIdentification: boolean;
 }
 
-// @public (undocumented)
-export type QrCodeCollector = QrCodeCollectorBase;
-
-// @public (undocumented)
-export interface QrCodeCollectorBase {
+// @public
+export interface QrCodeCollector extends NoValueCollectorBase<'QrCodeCollector'> {
     // (undocumented)
-    category: 'NoValueCollector';
-    // (undocumented)
-    error: string | null;
-    // (undocumented)
-    id: string;
-    // (undocumented)
-    name: string;
-    // (undocumented)
-    output: {
-        key: string;
-        label: string;
-        type: string;
+    output: NoValueCollectorBase<'QrCodeCollector'>['output'] & {
         src: string;
     };
-    // (undocumented)
-    type: 'QrCodeCollector';
 }
 
 // @public (undocumented)
@@ -1444,13 +1491,19 @@ export type QrCodeField = {
     fallbackText?: string;
 };
 
-// @public (undocumented)
-export type ReadOnlyCollector = NoValueCollectorBase<'ReadOnlyCollector'>;
+// @public
+export interface ReadOnlyCollector extends NoValueCollectorBase<'ReadOnlyCollector'> {
+    // (undocumented)
+    output: NoValueCollectorBase<'ReadOnlyCollector'>['output'] & {
+        content: string;
+    };
+}
 
-// @public (undocumented)
+// @public
 export type ReadOnlyField = {
     type: 'LABEL';
     content: string;
+    richContent?: RichContent;
     key?: string;
 };
 
@@ -1469,6 +1522,43 @@ export type RedirectField = {
 export type RedirectFields = RedirectField;
 
 export { RequestMiddleware }
+
+// @public
+export type RichContent = {
+    content: string;
+    replacements?: Record<string, RichContentReplacement>;
+};
+
+// @public
+export interface RichContentLink {
+    // (undocumented)
+    href: string;
+    // (undocumented)
+    key: string;
+    // (undocumented)
+    target?: '_self' | '_blank';
+    // (undocumented)
+    type: 'link';
+    // (undocumented)
+    value: string;
+}
+
+// @public
+export type RichContentReplacement = {
+    type: 'link';
+    value: string;
+    href: string;
+    target?: '_self' | '_blank';
+};
+
+// @public
+export interface RichTextCollector extends NoValueCollectorBase<'RichTextCollector'> {
+    // (undocumented)
+    output: NoValueCollectorBase<'RichTextCollector'>['output'] & {
+        content: string;
+        richContent: CollectorRichContent;
+    };
+}
 
 // @public (undocumented)
 export interface SelectorOption {
@@ -1721,7 +1811,7 @@ export type UnknownField = Record<string, unknown>;
 // @public (undocumented)
 export const updateCollectorValues: ActionCreatorWithPayload<    {
 id: string;
-value: string | string[] | PhoneNumberInputValue | FidoRegistrationInputValue | FidoAuthenticationInputValue;
+value: string | string[] | PhoneNumberInputValue | PhoneNumberExtensionInputValue | FidoRegistrationInputValue | FidoAuthenticationInputValue;
 index?: number;
 }, string>;
 

--- a/packages/davinci-client/src/lib/collector.types.test-d.ts
+++ b/packages/davinci-client/src/lib/collector.types.test-d.ts
@@ -25,6 +25,7 @@ import type {
   InferActionCollectorType,
   InferNoValueCollectorType,
   ReadOnlyCollector,
+  RichTextCollector,
   QrCodeCollector,
   AgreementCollector,
   PhoneNumberCollector,
@@ -35,6 +36,9 @@ import type {
   PhoneNumberOutputValue,
   PhoneNumberExtensionInputValue,
   PhoneNumberExtensionOutputValue,
+  RichContentLink,
+  CollectorRichContent,
+  NoValueCollector,
 } from './collector.types.js';
 
 describe('Collector Types', () => {
@@ -486,10 +490,30 @@ describe('Collector Types', () => {
           key: 'read-only',
           label: 'Read Only Field',
           type: 'READ_ONLY',
+          content: '',
         },
       };
 
       expectTypeOf(tCollector).toEqualTypeOf<ReadOnlyCollector>();
+    });
+
+    it('should correctly infer RichTextCollector Type', () => {
+      const tCollector: InferNoValueCollectorType<'RichTextCollector'> = {
+        category: 'NoValueCollector',
+        error: null,
+        type: 'RichTextCollector',
+        id: 'rich-text-0',
+        name: 'rich-text-0',
+        output: {
+          key: 'rich-text-0',
+          label: 'Rich Text Field',
+          type: 'LABEL',
+          content: '',
+          richContent: { content: '', replacements: [] },
+        },
+      };
+
+      expectTypeOf(tCollector).toEqualTypeOf<RichTextCollector>();
     });
 
     it('should correctly infer QrCodeCollector Type', () => {
@@ -532,6 +556,98 @@ describe('Collector Types', () => {
       };
 
       expectTypeOf(tCollector).toEqualTypeOf<AgreementCollector>();
+    });
+  });
+
+  describe('Rich Content Types', () => {
+    describe('RichContentLink', () => {
+      it('should require key, type, value, and href', () => {
+        expectTypeOf<RichContentLink>().toHaveProperty('key').toBeString();
+        expectTypeOf<RichContentLink>().toHaveProperty('type').toEqualTypeOf<'link'>();
+        expectTypeOf<RichContentLink>().toHaveProperty('value').toBeString();
+        expectTypeOf<RichContentLink>().toHaveProperty('href').toBeString();
+      });
+
+      it('should have optional target constrained to _self or _blank', () => {
+        expectTypeOf<RichContentLink>()
+          .toHaveProperty('target')
+          .toEqualTypeOf<'_self' | '_blank' | undefined>();
+      });
+    });
+
+    describe('CollectorRichContent', () => {
+      it('should have required content string and replacements array', () => {
+        expectTypeOf<CollectorRichContent>().toHaveProperty('content').toBeString();
+        expectTypeOf<CollectorRichContent>()
+          .toHaveProperty('replacements')
+          .toEqualTypeOf<RichContentLink[]>();
+      });
+    });
+
+    describe('ReadOnlyCollector', () => {
+      it('should have content as string', () => {
+        expectTypeOf<ReadOnlyCollector['output']['content']>().toBeString();
+      });
+
+      it('should not have richContent', () => {
+        expectTypeOf<ReadOnlyCollector['output']>().not.toHaveProperty('richContent');
+      });
+
+      it('should have standard collector fields', () => {
+        expectTypeOf<ReadOnlyCollector>()
+          .toHaveProperty('category')
+          .toEqualTypeOf<'NoValueCollector'>();
+        expectTypeOf<ReadOnlyCollector>()
+          .toHaveProperty('type')
+          .toEqualTypeOf<'ReadOnlyCollector'>();
+        expectTypeOf<ReadOnlyCollector>().toHaveProperty('error').toEqualTypeOf<string | null>();
+      });
+    });
+
+    describe('RichTextCollector', () => {
+      it('should have content as string', () => {
+        expectTypeOf<RichTextCollector['output']['content']>().toBeString();
+      });
+
+      it('should have required richContent with CollectorRichContent shape', () => {
+        expectTypeOf<
+          RichTextCollector['output']['richContent']
+        >().toEqualTypeOf<CollectorRichContent>();
+      });
+
+      it('should have standard collector fields', () => {
+        expectTypeOf<RichTextCollector>()
+          .toHaveProperty('category')
+          .toEqualTypeOf<'NoValueCollector'>();
+        expectTypeOf<RichTextCollector>()
+          .toHaveProperty('type')
+          .toEqualTypeOf<'RichTextCollector'>();
+        expectTypeOf<RichTextCollector>().toHaveProperty('error').toEqualTypeOf<string | null>();
+      });
+    });
+
+    describe("NoValueCollector<'ReadOnlyCollector'>", () => {
+      it('should resolve to ReadOnlyCollector', () => {
+        expectTypeOf<NoValueCollector<'ReadOnlyCollector'>>().toEqualTypeOf<ReadOnlyCollector>();
+      });
+
+      it('should have content on output but no richContent', () => {
+        type Resolved = NoValueCollector<'ReadOnlyCollector'>;
+        expectTypeOf<Resolved['output']['content']>().toBeString();
+        expectTypeOf<Resolved['output']>().not.toHaveProperty('richContent');
+      });
+    });
+
+    describe("NoValueCollector<'RichTextCollector'>", () => {
+      it('should resolve to RichTextCollector', () => {
+        expectTypeOf<NoValueCollector<'RichTextCollector'>>().toEqualTypeOf<RichTextCollector>();
+      });
+
+      it('should have content and richContent on output', () => {
+        type Resolved = NoValueCollector<'RichTextCollector'>;
+        expectTypeOf<Resolved['output']['content']>().toBeString();
+        expectTypeOf<Resolved['output']['richContent']>().toEqualTypeOf<CollectorRichContent>();
+      });
     });
   });
 });

--- a/packages/davinci-client/src/lib/collector.types.ts
+++ b/packages/davinci-client/src/lib/collector.types.ts
@@ -521,6 +521,7 @@ export type SubmitCollector = ActionCollectorNoUrl<'SubmitCollector'>;
  */
 export type NoValueCollectorTypes =
   | 'ReadOnlyCollector'
+  | 'RichTextCollector'
   | 'NoValueCollector'
   | 'QrCodeCollector'
   | 'AgreementCollector';
@@ -538,17 +539,62 @@ export interface NoValueCollectorBase<T extends NoValueCollectorTypes> {
   };
 }
 
-export interface QrCodeCollectorBase {
-  category: 'NoValueCollector';
-  error: string | null;
-  type: 'QrCodeCollector';
-  id: string;
-  name: string;
-  output: {
-    key: string;
-    label: string;
-    type: string;
+/**
+ * @interface RichContentLink - A hyperlink replacement embedded inside a
+ * `RichTextCollector` template. The `key` matches the `{{key}}` token in the
+ * template; `href` is passed through from DaVinci unmodified — consumers are
+ * responsible for sanitizing it before rendering.
+ */
+export interface RichContentLink {
+  key: string;
+  type: 'link';
+  value: string;
+  href: string;
+  target?: '_self' | '_blank';
+}
+
+/**
+ * @interface CollectorRichContent - The normalized rich-content payload exposed on a
+ * `RichTextCollector`. `content` holds the raw template (with `{{key}}` tokens), and
+ * `replacements` is the array of substitution entries (the API's keyed Record flattened
+ * into an array, with the original key carried on each entry).
+ */
+export interface CollectorRichContent {
+  content: string;
+  replacements: RichContentLink[];
+}
+
+/**
+ * @interface QrCodeCollector - Collector for displaying a QR code image. Extends the
+ * generic `NoValueCollectorBase` with the image `src` on `output`.
+ */
+export interface QrCodeCollector extends NoValueCollectorBase<'QrCodeCollector'> {
+  output: NoValueCollectorBase<'QrCodeCollector'>['output'] & {
     src: string;
+  };
+}
+
+/**
+ * @interface ReadOnlyCollector - Display-only collector for plain LABEL fields.
+ * Extends `NoValueCollectorBase` with the plain-text `content` from the field.
+ */
+export interface ReadOnlyCollector extends NoValueCollectorBase<'ReadOnlyCollector'> {
+  output: NoValueCollectorBase<'ReadOnlyCollector'>['output'] & {
+    content: string;
+  };
+}
+
+/**
+ * @interface RichTextCollector - Display-only collector for LABEL fields that carry
+ * inline link replacements. Extends `NoValueCollectorBase` with the plain-text
+ * `content` fallback and a structured `richContent` payload (template +
+ * normalized replacements). Use this type — not `ReadOnlyCollector` — when you
+ * need to render `{{key}}` tokens as anchor elements.
+ */
+export interface RichTextCollector extends NoValueCollectorBase<'RichTextCollector'> {
+  output: NoValueCollectorBase<'RichTextCollector'>['output'] & {
+    content: string;
+    richContent: CollectorRichContent;
   };
 }
 
@@ -576,24 +622,23 @@ export interface AgreementCollector extends NoValueCollectorBase<'AgreementColle
  */
 export type InferNoValueCollectorType<T extends NoValueCollectorTypes> =
   T extends 'ReadOnlyCollector'
-    ? NoValueCollectorBase<'ReadOnlyCollector'>
-    : T extends 'QrCodeCollector'
-      ? QrCodeCollectorBase
-      : T extends 'AgreementCollector'
-        ? AgreementCollector
-        : NoValueCollectorBase<'NoValueCollector'>;
+    ? ReadOnlyCollector
+    : T extends 'RichTextCollector'
+      ? RichTextCollector
+      : T extends 'QrCodeCollector'
+        ? QrCodeCollector
+        : T extends 'AgreementCollector'
+          ? AgreementCollector
+          : NoValueCollectorBase<'NoValueCollector'>;
 
 export type NoValueCollectors =
   | NoValueCollectorBase<'NoValueCollector'>
-  | NoValueCollectorBase<'ReadOnlyCollector'>
-  | QrCodeCollectorBase
+  | ReadOnlyCollector
+  | RichTextCollector
+  | QrCodeCollector
   | AgreementCollector;
 
-export type NoValueCollector<T extends NoValueCollectorTypes> = NoValueCollectorBase<T>;
-
-export type ReadOnlyCollector = NoValueCollectorBase<'ReadOnlyCollector'>;
-
-export type QrCodeCollector = QrCodeCollectorBase;
+export type NoValueCollector<T extends NoValueCollectorTypes> = InferNoValueCollectorType<T>;
 
 /** *********************************************************************
  * UNKNOWN COLLECTOR

--- a/packages/davinci-client/src/lib/collector.utils.test.ts
+++ b/packages/davinci-client/src/lib/collector.utils.test.ts
@@ -24,6 +24,7 @@ import {
   returnObjectValueAutoCollector,
   returnQrCodeCollector,
   returnAgreementCollector,
+  normalizeReplacements,
 } from './collector.utils.js';
 import type {
   DaVinciField,
@@ -38,6 +39,7 @@ import type {
   PollingField,
   ReadOnlyField,
   RedirectField,
+  RichContentReplacement,
   StandardField,
   AgreementField,
 } from './davinci.types.js';
@@ -47,6 +49,7 @@ import type {
   PhoneNumberExtensionCollector,
   PhoneNumberOutputValue,
   PhoneNumberExtensionOutputValue,
+  RichTextCollector,
   ValidatedTextCollector,
 } from './collector.types.js';
 
@@ -905,7 +908,7 @@ describe('No Value Collectors', () => {
   });
 
   describe('returnReadOnlyCollector', () => {
-    it('should return a valid ReadOnlyCollector with value in output', () => {
+    it('should return a ReadOnlyCollector with plain content when no richContent on field', () => {
       const result = returnReadOnlyCollector(mockField, 0);
       expect(result).toEqual({
         category: 'NoValueCollector',
@@ -917,7 +920,81 @@ describe('No Value Collectors', () => {
           key: 'LABEL-0',
           label: mockField.content,
           type: mockField.type,
+          content: mockField.content,
         },
+      });
+    });
+
+    it('should return a RichTextCollector when richContent is present', () => {
+      const field: ReadOnlyField = {
+        type: 'LABEL',
+        content: 'I agree to the terms and conditions',
+        richContent: {
+          content: 'I agree to the {{link}}',
+          replacements: {
+            link: {
+              type: 'link',
+              value: 'terms and conditions',
+              href: 'https://example.com',
+              target: '_blank',
+            },
+          },
+        },
+        key: 'terms',
+      };
+
+      const result = returnReadOnlyCollector(field, 0);
+
+      expect(result).toEqual({
+        category: 'NoValueCollector',
+        error: null,
+        type: 'RichTextCollector',
+        id: 'terms-0',
+        name: 'terms-0',
+        output: {
+          key: 'terms-0',
+          label: 'I agree to the terms and conditions',
+          type: 'LABEL',
+          content: 'I agree to the terms and conditions',
+          richContent: {
+            content: 'I agree to the {{link}}',
+            replacements: [
+              {
+                key: 'link',
+                type: 'link',
+                value: 'terms and conditions',
+                href: 'https://example.com',
+                target: '_blank',
+              },
+            ],
+          },
+        },
+      });
+    });
+
+    it('should pass through unsafe-looking hrefs unchanged (consumer is responsible for sanitization)', () => {
+      const field: ReadOnlyField = {
+        type: 'LABEL',
+        content: 'Click the link',
+        richContent: {
+          content: 'Click {{bad}}',
+          replacements: {
+            bad: {
+              type: 'link',
+              value: 'here',
+              href: 'javascript:alert(1)',
+            },
+          },
+        },
+      };
+
+      const result = returnReadOnlyCollector(field, 0) as RichTextCollector;
+
+      expect(result.error).toBeNull();
+      expect(result.type).toBe('RichTextCollector');
+      expect(result.output.richContent).toEqual({
+        content: 'Click {{bad}}',
+        replacements: [{ key: 'bad', type: 'link', value: 'here', href: 'javascript:alert(1)' }],
       });
     });
   });
@@ -1288,5 +1365,150 @@ describe('Return collector validator', () => {
     expect(result).toContain(
       'Invalid regular expression: /[invalid/: Unterminated character class',
     );
+  });
+});
+
+describe('normalizeReplacements', () => {
+  it('should flatten a single link replacement', () => {
+    const replacements: Record<string, RichContentReplacement> = {
+      link1: {
+        type: 'link',
+        value: 'terms and conditions',
+        href: 'https://example.com',
+        target: '_blank',
+      },
+    };
+
+    expect(normalizeReplacements(replacements)).toEqual([
+      {
+        key: 'link1',
+        type: 'link',
+        value: 'terms and conditions',
+        href: 'https://example.com',
+        target: '_blank',
+      },
+    ]);
+  });
+
+  it('should flatten multiple link replacements', () => {
+    const replacements: Record<string, RichContentReplacement> = {
+      link1: {
+        type: 'link',
+        value: 'terms',
+        href: 'https://example.com',
+        target: '_blank',
+      },
+      link2: {
+        type: 'link',
+        value: 'policy',
+        href: 'https://xyz.com',
+        target: '_self',
+      },
+    };
+
+    expect(normalizeReplacements(replacements)).toEqual([
+      {
+        key: 'link1',
+        type: 'link',
+        value: 'terms',
+        href: 'https://example.com',
+        target: '_blank',
+      },
+      { key: 'link2', type: 'link', value: 'policy', href: 'https://xyz.com', target: '_self' },
+    ]);
+  });
+
+  it('should omit target when not provided', () => {
+    const replacements: Record<string, RichContentReplacement> = {
+      link: {
+        type: 'link',
+        value: 'here',
+        href: 'https://example.com',
+      },
+    };
+
+    expect(normalizeReplacements(replacements)).toEqual([
+      { key: 'link', type: 'link', value: 'here', href: 'https://example.com' },
+    ]);
+  });
+
+  it('should return empty array for empty replacements', () => {
+    expect(normalizeReplacements({})).toEqual([]);
+  });
+
+  it('should pass non-http(s) hrefs through unchanged', () => {
+    const replacements: Record<string, RichContentReplacement> = {
+      link: {
+        type: 'link',
+        value: 'here',
+        href: 'javascript:alert(1)',
+      },
+    };
+
+    expect(normalizeReplacements(replacements)).toEqual([
+      { key: 'link', type: 'link', value: 'here', href: 'javascript:alert(1)' },
+    ]);
+  });
+});
+
+describe('Terms and Conditions Integration', () => {
+  it('should handle a form with a checkbox and a label with a T&C link', () => {
+    const labelField: ReadOnlyField = {
+      type: 'LABEL',
+      content: 'I agree to the terms and conditions',
+      richContent: {
+        content: 'I agree to the {{link}}',
+        replacements: {
+          link: {
+            type: 'link',
+            value: 'terms and conditions',
+            href: 'https://example.com/terms',
+            target: '_blank',
+          },
+        },
+      },
+      key: 'terms-label',
+    };
+
+    const checkboxField = {
+      type: 'CHECKBOX' as const,
+      key: 'agree-checkbox',
+      label: 'Agreement',
+      required: true,
+      options: [{ label: 'I agree', value: 'agree' }],
+      inputType: 'MULTI_SELECT' as const,
+    };
+
+    const labelCollector = returnReadOnlyCollector(labelField, 0) as RichTextCollector;
+    const checkboxCollector = returnMultiSelectCollector(checkboxField, 1, []);
+
+    // Verify label collector has pass-through richContent
+    expect(labelCollector.type).toBe('RichTextCollector');
+    expect(labelCollector.category).toBe('NoValueCollector');
+    expect(labelCollector.error).toBeNull();
+    expect(labelCollector.output.label).toBe('I agree to the terms and conditions');
+    expect(labelCollector.output.content).toBe('I agree to the terms and conditions');
+    expect(labelCollector.output.richContent).toEqual({
+      content: 'I agree to the {{link}}',
+      replacements: [
+        {
+          key: 'link',
+          type: 'link',
+          value: 'terms and conditions',
+          href: 'https://example.com/terms',
+          target: '_blank',
+        },
+      ],
+    });
+
+    // Verify checkbox collector works alongside
+    expect(checkboxCollector.type).toBe('MultiSelectCollector');
+    expect(checkboxCollector.category).toBe('MultiValueCollector');
+    expect(checkboxCollector.error).toBeNull();
+    expect(checkboxCollector.output.options).toEqual([{ label: 'I agree', value: 'agree' }]);
+    expect(checkboxCollector.input.value).toEqual([]);
+    expect(checkboxCollector.input.validation).toEqual([
+      { type: 'required', message: 'Value cannot be empty', rule: true },
+    ]);
   });
 });

--- a/packages/davinci-client/src/lib/collector.utils.ts
+++ b/packages/davinci-client/src/lib/collector.utils.ts
@@ -29,7 +29,10 @@ import type {
   AutoCollectors,
   SingleValueAutoCollectorTypes,
   ObjectValueAutoCollectorTypes,
-  QrCodeCollectorBase,
+  QrCodeCollector,
+  ReadOnlyCollector,
+  RichTextCollector,
+  RichContentLink,
   AgreementCollector,
   PhoneNumberExtensionOutputValue,
 } from './collector.types.js';
@@ -45,6 +48,7 @@ import type {
   PollingField,
   ReadOnlyField,
   RedirectField,
+  RichContentReplacement,
   SingleSelectField,
   StandardField,
   ValidatedField,
@@ -756,6 +760,27 @@ export function returnObjectValueCollector(
 }
 
 /**
+ * @function normalizeReplacements - Flattens the API's keyed
+ * `Record<string, RichContentReplacement>` into an array of `RichContentLink`
+ * with the original key carried on each entry. Hrefs are passed through
+ * unmodified — consumers are responsible for sanitizing before rendering.
+ *
+ * @param {Record<string, RichContentReplacement>} replacements - The replacements map from the API.
+ * @returns {RichContentLink[]} The flattened array of replacement entries.
+ */
+export function normalizeReplacements(
+  replacements: Record<string, RichContentReplacement>,
+): RichContentLink[] {
+  return Object.entries(replacements).map(([key, replacement]) => ({
+    key,
+    type: replacement.type,
+    value: replacement.value,
+    href: replacement.href,
+    ...(replacement.target && { target: replacement.target }),
+  }));
+}
+
+/**
  * @function returnNoValueCollector - Creates a NoValueCollector object based on the provided field, index, and optional collector type.
  * @param {DaVinciField} field - The field object containing key, label, type, and links.
  * @param {number} idx - The index to be used in the id of the NoValueCollector.
@@ -789,22 +814,50 @@ export function returnNoValueCollector<
 }
 
 /**
- * @function returnReadOnlyCollector - Creates a ReadOnlyCollector object based on the provided field and index.
- * @param {DaVinciField} field - The field object containing key, label, type, and links.
- * @param {number} idx - The index to be used in the id of the ReadOnlyCollector.
- * @returns {ReadOnlyCollector} The constructed ReadOnlyCollector object.
+ * @function returnReadOnlyCollector - Creates a `ReadOnlyCollector` (plain text) or
+ * `RichTextCollector` (template + link replacements) depending on whether the field
+ * carries a `richContent` payload.
+ *
+ * @param {ReadOnlyField} field - The LABEL field from the API response.
+ * @param {number} idx - The index to be used in the id of the collector.
+ * @returns {ReadOnlyCollector | RichTextCollector} The constructed collector.
  */
-export function returnReadOnlyCollector(field: ReadOnlyField, idx: number) {
-  return returnNoValueCollector(field, idx, 'ReadOnlyCollector');
+export function returnReadOnlyCollector(
+  field: ReadOnlyField,
+  idx: number,
+): ReadOnlyCollector | RichTextCollector {
+  if (field.richContent) {
+    const base = returnNoValueCollector(field, idx, 'RichTextCollector');
+    return {
+      ...base,
+      output: {
+        ...base.output,
+        content: field.content,
+        richContent: {
+          content: field.richContent.content,
+          replacements: normalizeReplacements(field.richContent.replacements ?? {}),
+        },
+      },
+    };
+  }
+
+  const base = returnNoValueCollector(field, idx, 'ReadOnlyCollector');
+  return {
+    ...base,
+    output: {
+      ...base.output,
+      content: field.content,
+    },
+  };
 }
 
 /**
  * @function returnQrCodeCollector - Creates a QrCodeCollector object for displaying QR code images.
  * @param {QrCodeField} field - The field object containing key, content, type, and optional fallbackText.
  * @param {number} idx - The index to be used in the id of the QrCodeCollector.
- * @returns {QrCodeCollectorBase} The constructed QrCodeCollector object.
+ * @returns {QrCodeCollector} The constructed QrCodeCollector object.
  */
-export function returnQrCodeCollector(field: QrCodeField, idx: number): QrCodeCollectorBase {
+export function returnQrCodeCollector(field: QrCodeField, idx: number): QrCodeCollector {
   const base = returnNoValueCollector(field, idx, 'QrCodeCollector');
 
   return {

--- a/packages/davinci-client/src/lib/davinci.types.ts
+++ b/packages/davinci-client/src/lib/davinci.types.ts
@@ -68,9 +68,38 @@ export type StandardField = {
   required?: boolean;
 };
 
+/**
+ * A single replacement entry in the raw DaVinci `richContent.replacements` map.
+ * The map's key (set on the parent `RichContent`) corresponds to the `{{key}}`
+ * token in `content`. Currently only `link` is supported.
+ */
+export type RichContentReplacement = {
+  type: 'link';
+  value: string;
+  href: string;
+  target?: '_self' | '_blank';
+};
+
+/**
+ * Raw rich-content payload as returned by DaVinci on a LABEL field.
+ * `content` is a template string with `{{key}}` tokens; `replacements` maps
+ * each key to its substitution data. Validated and normalized into
+ * `CollectorRichContent` by the SDK.
+ */
+export type RichContent = {
+  content: string;
+  replacements?: Record<string, RichContentReplacement>;
+};
+
+/**
+ * The shape of a LABEL field in a DaVinci form. `content` is the plain-text
+ * fallback; `richContent`, when present, carries a template + replacement data
+ * for rendering inline links.
+ */
 export type ReadOnlyField = {
   type: 'LABEL';
   content: string;
+  richContent?: RichContent;
   key?: string;
 };
 

--- a/packages/davinci-client/src/lib/mock-data/mock-form-fields.data.ts
+++ b/packages/davinci-client/src/lib/mock-data/mock-form-fields.data.ts
@@ -24,6 +24,22 @@ export const obj = {
           content: 'Welcome to Ping Identity',
         },
         {
+          type: 'LABEL',
+          content: 'I agree to the terms and conditions',
+          richContent: {
+            content: 'I agree to the {{link}}',
+            replacements: {
+              link: {
+                type: 'link',
+                value: 'terms and conditions',
+                href: 'https://example.com/terms',
+                target: '_blank',
+              },
+            },
+          },
+          key: 'terms-label',
+        },
+        {
           type: 'ERROR_DISPLAY',
         },
         {

--- a/packages/davinci-client/src/lib/node.reducer.ts
+++ b/packages/davinci-client/src/lib/node.reducer.ts
@@ -44,6 +44,7 @@ import type {
   SubmitCollector,
   TextCollector,
   ReadOnlyCollector,
+  RichTextCollector,
   ValidatedTextCollector,
   DeviceAuthenticationCollector,
   DeviceRegistrationCollector,
@@ -105,6 +106,7 @@ const initialCollectorValues: (
   | PhoneNumberCollector
   | PhoneNumberExtensionCollector
   | ReadOnlyCollector
+  | RichTextCollector
   | ValidatedTextCollector
   | UnknownCollector
   | ProtectCollector

--- a/packages/davinci-client/src/lib/node.types.test-d.ts
+++ b/packages/davinci-client/src/lib/node.types.test-d.ts
@@ -22,6 +22,7 @@ import {
   MultiSelectCollector,
   PasswordCollector,
   ReadOnlyCollector,
+  RichTextCollector,
   SingleSelectCollector,
   SingleValueCollector,
   IdpCollector,
@@ -236,6 +237,7 @@ describe('Node Types', () => {
         | PhoneNumberCollector
         | PhoneNumberExtensionCollector
         | ReadOnlyCollector
+        | RichTextCollector
         | SingleSelectCollector
         | ValidatedTextCollector
         | ProtectCollector

--- a/packages/davinci-client/src/lib/node.types.ts
+++ b/packages/davinci-client/src/lib/node.types.ts
@@ -19,6 +19,7 @@ import type {
   DeviceAuthenticationCollector,
   DeviceRegistrationCollector,
   ReadOnlyCollector,
+  RichTextCollector,
   ValidatedTextCollector,
   PhoneNumberCollector,
   ProtectCollector,
@@ -47,6 +48,7 @@ export type Collectors =
   | PhoneNumberCollector
   | PhoneNumberExtensionCollector
   | ReadOnlyCollector
+  | RichTextCollector
   | ValidatedTextCollector
   | ProtectCollector
   | PollingCollector


### PR DESCRIPTION
# JIRA Ticket

https://pingidentity.atlassian.net/browse/SDKS-4248

## Description

- Add support for links from Translatable Rich Text in PingOne Forms (DV-19096)
- Pass through `richContent` structure (template + validated replacements array) on `ReadOnlyCollector`
- Validate href protocols against allowlist (OWASP A03)
- Pure functional implementation — no throws, discriminated result types throughout

## Changes

- **API Types**: `RichContentReplacement`, `RichContent` (with optional `replacements`)
- **Collector Types**: `RichContentLink`, `ValidatedReplacement` (extensible union), `CollectorRichContent`, `ReadOnlyCollectorBase`
- **Validation**: `validateReplacements()` — validates hrefs, converts `Record` to array with `key` field
- **Collector**: `returnReadOnlyCollector()` — `output.content` is plain text string, `output.richContent` is always present with template and validated replacements array
- **Security**: href validation rejects `javascript:`, `data:`, and other unsafe URI schemes (allowlist: `http:`, `https:` only)

## Collector Output Shape

```typescript
output: {
  key: "rich-text-0",
  label: "This is a link...",          // plain text
  type: "LABEL",
  content: "This is a link...",     
  richContent: {                        // always present
    content: "This is a {{link1}}...", // template
    replacements: [                     // validated array, [] if none/error
      { key: "link1", type: "link", value: "link", href: "https://...", target: "_blank" }
    ]
  }
}
```
<img width="388" height="362" alt="Screenshot 2026-04-22 at 2 08 38 PM" src="https://github.com/user-attachments/assets/0aa54a65-1d1f-4cf9-b68d-b2ea049d38a4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Labels support rich-content templates with {{key}} placeholders and normalized replacement arrays (including link entries); mock data includes a sample label with a link.
  * QR-code items now expose a src value for rendering.

* **Bug Fixes**
  * Replacement links preserve non-http(s) hrefs (no automatic rejection/alteration).
  * Links opened in a new tab include rel="noopener noreferrer".

* **Breaking Changes**
  * Label output always includes a rich-content payload alongside plain content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->