### PR TITLE
fix(ci): disable lefthook in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,6 +40,8 @@ jobs:
       pull-requests: write
       id-token: write
     runs-on: ubuntu-latest
+    env:
+      LEFTHOOK: 0
     steps:
       - uses: actions/checkout@v4
         with:
@@ -101,7 +103,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     env:
-      HUSKY: 0
+      LEFTHOOK: 0
     steps:
       - name: Branch name
         run: |


### PR DESCRIPTION
## Summary
- Adds `LEFTHOOK=0` to the `publish-or-pr` job so changesets' version commit doesn't trigger lefthook pre-commit hooks in CI
- Replaces stale `HUSKY=0` with `LEFTHOOK=0` in the `snapshot` job

## Context
Merging #564 triggered the publish workflow, where changesets ran `git commit` to version packages. This fired lefthook's pre-commit hook which runs `nx affected` — but there's no Nx Cloud DTE agent context for that secondary commit, causing CI to fail.

Fixes: https://github.com/ForgeRock/ping-javascript-sdk/actions/runs/24483747421/job/71553933332

## Test plan
- [ ] Merge to main and verify the publish workflow succeeds
- [ ] Verify the Release PR is created/updated correctly by changesets