### PR TITLE
fix(davinci-client): fix challenge polling headers

### DIFF
--- a/packages/davinci-client/src/lib/davinci.api.ts
+++ b/packages/davinci-client/src/lib/davinci.api.ts
@@ -58,12 +58,10 @@ export const davinciApi = createApi({
   reducerPath: 'davinci',
   // TODO: implement extraOptions for request interceptors: https://stackoverflow.com/a/77569083 & https://stackoverflow.com/a/65129117
   baseQuery: fetchBaseQuery({
-    prepareHeaders: (headers, { endpoint }) => {
+    prepareHeaders: (headers) => {
       headers.set('Accept', 'application/json');
-      if (endpoint !== 'poll') {
-        headers.set('x-requested-with', 'ping-sdk');
-        headers.set('x-requested-platform', 'javascript');
-      }
+      headers.set('x-requested-with', 'ping-sdk');
+      headers.set('x-requested-platform', 'javascript');
       return headers;
     },
   }),


### PR DESCRIPTION
Fixes challenge polling `/status` endpoint headers now addressed by https://pingidentity.atlassian.net/browse/DV-23136. No CORS error when hitting `/status`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved consistency in API request handling across all endpoint types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->