### PR TITLE
feat(davinci-client): support form agreements with AgreementCollector

### DIFF
--- a/.changeset/silent-ideas-joke.md
+++ b/.changeset/silent-ideas-joke.md
@@ -1,0 +1,5 @@
+---
+'@forgerock/davinci-client': minor
+---
+
+Support form agreements with AgreementCollector

--- a/e2e/davinci-app/components/agreement.ts
+++ b/e2e/davinci-app/components/agreement.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+import type { AgreementCollector } from '@forgerock/davinci-client/types';
+
+export default function (formEl: HTMLFormElement, collector: AgreementCollector) {
+  const output = collector.output;
+  const componentEnabled = output.enabled;
+
+  if (!componentEnabled) {
+    return;
+  }
+
+  const content = output.label;
+  const titleEnabled = output.titleEnabled;
+  const title = output.title;
+
+  if (titleEnabled) {
+    const titleEl = document.createElement('h3');
+    titleEl.innerText = title;
+    formEl?.appendChild(titleEl);
+  }
+
+  const agreement = document.createElement('p');
+  agreement.innerText = content;
+  formEl?.appendChild(agreement);
+}

--- a/e2e/davinci-app/main.ts
+++ b/e2e/davinci-app/main.ts
@@ -33,6 +33,7 @@ import labelComponent from './components/label.js';
 import objectValueComponent from './components/object-value.js';
 import fidoComponent from './components/fido.js';
 import qrCodeComponent from './components/qr-code.js';
+import agreementComponent from './components/agreement.js';
 import pollingComponent from './components/polling.js';
 
 const loggerFn = {
@@ -227,6 +228,8 @@ const urlParams = new URLSearchParams(window.location.search);
         );
       } else if (collector.type === 'QrCodeCollector') {
         qrCodeComponent(formEl, collector);
+      } else if (collector.type === 'AgreementCollector') {
+        agreementComponent(formEl, collector);
       } else if (collector.type === 'TextCollector') {
         textComponent(
           formEl, // You can ignore this; it's just for rendering

--- a/packages/davinci-client/src/lib/collector.types.test-d.ts
+++ b/packages/davinci-client/src/lib/collector.types.test-d.ts
@@ -23,6 +23,10 @@ import type {
   InferSingleValueCollectorType,
   InferMultiValueCollectorType,
   InferActionCollectorType,
+  InferNoValueCollectorType,
+  ReadOnlyCollector,
+  QrCodeCollector,
+  AgreementCollector,
 } from './collector.types.js';
 
 describe('Collector Types', () => {
@@ -353,6 +357,67 @@ describe('Collector Types', () => {
       };
 
       expectTypeOf(tCollector).toMatchTypeOf<FlowCollector>();
+    });
+  });
+
+  describe('InferNoValueCollectorType', () => {
+    it('should correctly infer ReadOnlyCollector Type', () => {
+      const tCollector: InferNoValueCollectorType<'ReadOnlyCollector'> = {
+        category: 'NoValueCollector',
+        error: null,
+        type: 'ReadOnlyCollector',
+        id: 'read-only-0',
+        name: 'read-only',
+        output: {
+          key: 'read-only',
+          label: 'Read Only Field',
+          type: 'READ_ONLY',
+        },
+      };
+
+      expectTypeOf(tCollector).toEqualTypeOf<ReadOnlyCollector>();
+    });
+
+    it('should correctly infer QrCodeCollector Type', () => {
+      const tCollector: InferNoValueCollectorType<'QrCodeCollector'> = {
+        category: 'NoValueCollector',
+        error: null,
+        type: 'QrCodeCollector',
+        id: 'qr-code-0',
+        name: 'qr-code-0',
+        output: {
+          key: 'qr-code-0',
+          label: 'FALLBACK TEXT',
+          type: 'QR_CODE',
+          src: 'data:image/png;base64,abc123',
+        },
+      };
+
+      expectTypeOf(tCollector).toEqualTypeOf<QrCodeCollector>();
+    });
+
+    it('should correctly infer AgreementCollector Type', () => {
+      const tCollector: InferNoValueCollectorType<'AgreementCollector'> = {
+        category: 'NoValueCollector',
+        error: null,
+        type: 'AgreementCollector',
+        id: 'agreement-0',
+        name: 'agreement-0',
+        output: {
+          key: 'agreement-0',
+          label: 'Please accept the terms and conditions',
+          type: 'AGREEMENT',
+          titleEnabled: true,
+          title: 'Terms and Conditions',
+          agreement: {
+            id: 'agreement-123',
+            useDynamicAgreement: false,
+          },
+          enabled: true,
+        },
+      };
+
+      expectTypeOf(tCollector).toEqualTypeOf<AgreementCollector>();
     });
   });
 });

--- a/packages/davinci-client/src/lib/collector.types.ts
+++ b/packages/davinci-client/src/lib/collector.types.ts
@@ -482,7 +482,11 @@ export type SubmitCollector = ActionCollectorNoUrl<'SubmitCollector'>;
 /**
  * @interface NoValueCollector - Represents a collector that collects no value; text only for display.
  */
-export type NoValueCollectorTypes = 'ReadOnlyCollector' | 'NoValueCollector' | 'QrCodeCollector';
+export type NoValueCollectorTypes =
+  | 'ReadOnlyCollector'
+  | 'NoValueCollector'
+  | 'QrCodeCollector'
+  | 'AgreementCollector';
 
 export interface NoValueCollectorBase<T extends NoValueCollectorTypes> {
   category: 'NoValueCollector';
@@ -511,6 +515,21 @@ export interface QrCodeCollectorBase {
   };
 }
 
+export interface AgreementCollector extends NoValueCollectorBase<'AgreementCollector'> {
+  output: {
+    key: string;
+    label: string;
+    type: string;
+    titleEnabled: boolean;
+    title: string;
+    agreement: {
+      id: string;
+      useDynamicAgreement: boolean;
+    };
+    enabled: boolean;
+  };
+}
+
 /**
  * Type to help infer the collector based on the collector type
  * Used specifically in the returnNoValueCollector wrapper function.
@@ -523,18 +542,25 @@ export type InferNoValueCollectorType<T extends NoValueCollectorTypes> =
     ? NoValueCollectorBase<'ReadOnlyCollector'>
     : T extends 'QrCodeCollector'
       ? QrCodeCollectorBase
-      : NoValueCollectorBase<'NoValueCollector'>;
+      : T extends 'AgreementCollector'
+        ? AgreementCollector
+        : NoValueCollectorBase<'NoValueCollector'>;
 
 export type NoValueCollectors =
   | NoValueCollectorBase<'NoValueCollector'>
   | NoValueCollectorBase<'ReadOnlyCollector'>
-  | QrCodeCollectorBase;
+  | QrCodeCollectorBase
+  | AgreementCollector;
 
 export type NoValueCollector<T extends NoValueCollectorTypes> = NoValueCollectorBase<T>;
 
 export type ReadOnlyCollector = NoValueCollectorBase<'ReadOnlyCollector'>;
 
 export type QrCodeCollector = QrCodeCollectorBase;
+
+/** *********************************************************************
+ * UNKNOWN COLLECTOR
+ */
 
 export type UnknownCollector = {
   category: 'UnknownCollector';

--- a/packages/davinci-client/src/lib/collector.utils.test.ts
+++ b/packages/davinci-client/src/lib/collector.utils.test.ts
@@ -23,6 +23,7 @@ import {
   returnSingleValueAutoCollector,
   returnObjectValueAutoCollector,
   returnQrCodeCollector,
+  returnAgreementCollector,
 } from './collector.utils.js';
 import type {
   DaVinciField,
@@ -37,6 +38,7 @@ import type {
   ReadOnlyField,
   RedirectField,
   StandardField,
+  AgreementField,
 } from './davinci.types.js';
 import type {
   MultiSelectCollector,
@@ -879,6 +881,49 @@ describe('returnQrCodeCollector', () => {
   it('should only report content error when both key and content are missing', () => {
     const mockField = { type: 'QR_CODE' } as unknown as QrCodeField;
     const result = returnQrCodeCollector(mockField, 0);
+    expect(result.error).toContain('Content is not found');
+  });
+});
+
+describe('returnAgreementCollector', () => {
+  it('should return a valid AgreementCollector with all fields', () => {
+    const mockField: AgreementField = {
+      type: 'AGREEMENT',
+      key: 'agreement-field',
+      content: 'Please accept the terms and conditions',
+      titleEnabled: true,
+      title: 'Terms and Conditions',
+      agreement: {
+        id: 'agreement-123',
+        useDynamicAgreement: false,
+      },
+      enabled: true,
+    };
+    const result = returnAgreementCollector(mockField, 0);
+    expect(result).toEqual({
+      category: 'NoValueCollector',
+      error: null,
+      type: 'AgreementCollector',
+      id: 'agreement-field-0',
+      name: 'agreement-field-0',
+      output: {
+        key: 'agreement-field-0',
+        label: 'Please accept the terms and conditions',
+        type: 'AGREEMENT',
+        titleEnabled: true,
+        title: 'Terms and Conditions',
+        agreement: {
+          id: 'agreement-123',
+          useDynamicAgreement: false,
+        },
+        enabled: true,
+      },
+    });
+  });
+
+  it('should set error when content is missing', () => {
+    const mockField = { type: 'AGREEMENT', key: 'agreement-field' } as unknown as AgreementField;
+    const result = returnAgreementCollector(mockField, 0);
     expect(result.error).toContain('Content is not found');
   });
 });

--- a/packages/davinci-client/src/lib/collector.utils.ts
+++ b/packages/davinci-client/src/lib/collector.utils.ts
@@ -30,6 +30,7 @@ import type {
   SingleValueAutoCollectorTypes,
   ObjectValueAutoCollectorTypes,
   QrCodeCollectorBase,
+  AgreementCollector,
 } from './collector.types.js';
 import type {
   DeviceAuthenticationField,
@@ -46,6 +47,8 @@ import type {
   SingleSelectField,
   StandardField,
   ValidatedField,
+  AgreementField,
+  ReadOnlyFields,
 } from './davinci.types.js';
 
 /**
@@ -717,7 +720,7 @@ export function returnObjectValueCollector(
  * @returns {NoValueCollector} The constructed NoValueCollector object.
  */
 export function returnNoValueCollector<
-  Field extends ReadOnlyField | QrCodeField,
+  Field extends ReadOnlyFields,
   CollectorType extends NoValueCollectorTypes = 'NoValueCollector',
 >(field: Field, idx: number, collectorType: CollectorType) {
   let error = '';
@@ -767,6 +770,29 @@ export function returnQrCodeCollector(field: QrCodeField, idx: number): QrCodeCo
       ...base.output,
       label: field.fallbackText || '',
       src: field.content || '',
+    },
+  };
+}
+
+/**
+ * @function returnAgreementCollector - Creates an AgreementCollector object based on the provided field and index.
+ * @param {AgreementField} field - The field object containing key, label, type, and agreement details.
+ * @param {number} idx - The index to be used in the id of the AgreementCollector.
+ * @returns {AgreementCollector} The constructed AgreementCollector object.
+ */
+export function returnAgreementCollector(field: AgreementField, idx: number): AgreementCollector {
+  const base = returnNoValueCollector(field, idx, 'AgreementCollector');
+  return {
+    ...base,
+    output: {
+      ...base.output,
+      titleEnabled: field.titleEnabled,
+      title: field.title,
+      agreement: {
+        id: field.agreement?.id ?? '',
+        useDynamicAgreement: field.agreement?.useDynamicAgreement ?? false,
+      },
+      enabled: field.enabled ?? false,
     },
   };
 }

--- a/packages/davinci-client/src/lib/davinci.types.ts
+++ b/packages/davinci-client/src/lib/davinci.types.ts
@@ -81,6 +81,19 @@ export type QrCodeField = {
   fallbackText?: string;
 };
 
+export type AgreementField = {
+  type: 'AGREEMENT';
+  key: string;
+  content: string;
+  titleEnabled: boolean;
+  title: string;
+  agreement: {
+    id: string;
+    useDynamicAgreement: boolean;
+  };
+  enabled: boolean;
+};
+
 export type RedirectField = {
   type: 'SOCIAL_LOGIN_BUTTON';
   key: string;
@@ -238,7 +251,7 @@ export type ComplexValueFields =
   | FidoAuthenticationField
   | PollingField;
 export type MultiValueFields = MultiSelectField;
-export type ReadOnlyFields = ReadOnlyField | QrCodeField;
+export type ReadOnlyFields = ReadOnlyField | QrCodeField | AgreementField;
 export type RedirectFields = RedirectField;
 export type SingleValueFields = StandardField | ValidatedField | SingleSelectField | ProtectField;
 

--- a/packages/davinci-client/src/lib/node.reducer.test.ts
+++ b/packages/davinci-client/src/lib/node.reducer.test.ts
@@ -17,6 +17,7 @@ import type {
   PollingCollector,
   ProtectCollector,
   QrCodeCollector,
+  AgreementCollector,
   SubmitCollector,
   TextCollector,
 } from './collector.types.js';
@@ -448,6 +449,50 @@ describe('The node collector reducer', () => {
           src: 'data:image/png;base64,abc123',
         },
       } satisfies QrCodeCollector,
+    ]);
+  });
+
+  it('should handle AGREEMENT field type', () => {
+    const action = {
+      type: 'node/next',
+      payload: {
+        fields: [
+          {
+            type: 'AGREEMENT',
+            key: 'agreement-field',
+            content: 'Please accept the terms and conditions',
+            titleEnabled: true,
+            title: 'Terms and Conditions',
+            agreement: {
+              id: 'agreement-123',
+              useDynamicAgreement: false,
+            },
+            enabled: true,
+          },
+        ],
+      },
+    };
+    const result = nodeCollectorReducer(undefined, action);
+    expect(result).toEqual([
+      {
+        category: 'NoValueCollector',
+        error: null,
+        type: 'AgreementCollector',
+        id: 'agreement-field-0',
+        name: 'agreement-field-0',
+        output: {
+          key: 'agreement-field-0',
+          label: 'Please accept the terms and conditions',
+          type: 'AGREEMENT',
+          titleEnabled: true,
+          title: 'Terms and Conditions',
+          agreement: {
+            id: 'agreement-123',
+            useDynamicAgreement: false,
+          },
+          enabled: true,
+        },
+      } satisfies AgreementCollector,
     ]);
   });
 });

--- a/packages/davinci-client/src/lib/node.reducer.ts
+++ b/packages/davinci-client/src/lib/node.reducer.ts
@@ -30,6 +30,7 @@ import {
   returnFidoRegistrationCollector,
   returnFidoAuthenticationCollector,
   returnQrCodeCollector,
+  returnAgreementCollector,
 } from './collector.utils.js';
 import type { DaVinciField, UnknownField } from './davinci.types.js';
 import type {
@@ -57,6 +58,7 @@ import type {
   FidoAuthenticationInputValue,
   FidoRegistrationInputValue,
   QrCodeCollector,
+  AgreementCollector,
 } from './collector.types.js';
 
 /**
@@ -105,6 +107,7 @@ const initialCollectorValues: (
   | FidoRegistrationCollector
   | FidoAuthenticationCollector
   | QrCodeCollector
+  | AgreementCollector
 )[] = [];
 
 /**
@@ -133,6 +136,10 @@ export const nodeCollectorReducer = createReducer(initialCollectorValues, (build
 
             if (field.type === 'QR_CODE') {
               return returnQrCodeCollector(field, idx);
+            }
+
+            if (field.type === 'AGREEMENT') {
+              return returnAgreementCollector(field, idx);
             }
 
             // *Some* collectors may have default or existing data to display

--- a/packages/davinci-client/src/lib/node.types.test-d.ts
+++ b/packages/davinci-client/src/lib/node.types.test-d.ts
@@ -37,6 +37,7 @@ import {
   FidoRegistrationCollector,
   FidoAuthenticationCollector,
   QrCodeCollector,
+  AgreementCollector,
 } from './collector.types.js';
 // ErrorDetail and Links are used as part of the DaVinciError and server._links types respectively
 
@@ -240,6 +241,7 @@ describe('Node Types', () => {
         | FidoRegistrationCollector
         | FidoAuthenticationCollector
         | QrCodeCollector
+        | AgreementCollector
         | UnknownCollector
       >();
 

--- a/packages/davinci-client/src/lib/node.types.ts
+++ b/packages/davinci-client/src/lib/node.types.ts
@@ -27,6 +27,7 @@ import type {
   FidoRegistrationCollector,
   FidoAuthenticationCollector,
   QrCodeCollector,
+  AgreementCollector,
 } from './collector.types.js';
 import type { Links } from './davinci.types.js';
 
@@ -50,6 +51,7 @@ export type Collectors =
   | FidoRegistrationCollector
   | FidoAuthenticationCollector
   | QrCodeCollector
+  | AgreementCollector
   | UnknownCollector;
 
 export interface CollectorErrors {


### PR DESCRIPTION
# JIRA Ticket

https://pingidentity.atlassian.net/browse/SDKS-4691

## Description

Adds a new NoValueCollector called AgreementCollector that stores AGREEMENT field options in the `output`. Includes unit tests. Agreement component has been added to e2e app but e2e tests will be handled in another ticket once we can create more flows in DaVinci. SINGLE_CHECKBOX will be addressed in another ticket.

<img width="1318" height="660" alt="Screenshot 2026-04-23 at 11 32 20 AM" src="https://github.com/user-attachments/assets/3c3acb52-55ab-4fce-9037-257ad434168c" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Forms now support agreement fields, enabling display of configurable agreement content with optional titles, enable/disable visibility controls, and customizable agreement metadata for enhanced user interaction.

* **Tests**
  * Added comprehensive type safety validation and unit tests covering agreement field creation, initialization, type inference, and end-to-end rendering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->