### PR TITLE
feat(journey-client): webauthn conditional mediation autofill passkey support …

### DIFF
--- a/.changeset/ready-snakes-sell.md
+++ b/.changeset/ready-snakes-sell.md
@@ -1,0 +1,10 @@
+---
+'@forgerock/journey-client': minor
+---
+
+Add WebAuthn conditional mediation (passkey autofill) support.
+
+- `WebAuthn.authenticate(step, mediation?, signal?)` forwards `mediation` and `signal` to `navigator.credentials.get`.
+- When `mediation` is `'conditional'`, an `AbortSignal` is required.
+- If conditional mediation is requested but not supported, `authenticate()` throws `NotSupportedError` (and the existing error handling sets the hidden outcome to `unsupported`).
+- Adds `WebAuthn.isConditionalMediationSupported()` helper, docs, and unit tests.

--- a/.changeset/ready-snakes-sell.md
+++ b/.changeset/ready-snakes-sell.md
@@ -4,7 +4,7 @@
 
 Add WebAuthn conditional mediation (passkey autofill) support.
 
-- `WebAuthn.authenticate(step, mediation?, signal?)` forwards `mediation` and `signal` to `navigator.credentials.get`.
-- When `mediation` is `'conditional'`, an `AbortSignal` is required.
+- `WebAuthn.authenticate(step, signal?)` derives mediation from WebAuthn metadata (`meta.mediation`).
+- When `meta.mediation` is `'conditional'`, an `AbortSignal` is used (caller-provided if present, otherwise created by the SDK).
 - If conditional mediation is requested but not supported, `authenticate()` throws `NotSupportedError` (and the existing error handling sets the hidden outcome to `unsupported`).
 - Adds `WebAuthn.isConditionalMediationSupported()` helper, docs, and unit tests.

--- a/e2e/journey-app/components/text-input.ts
+++ b/e2e/journey-app/components/text-input.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2025-2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -20,6 +20,10 @@ export default function textComponent(
   input.type = 'text';
   input.id = collectorKey;
   input.name = collectorKey;
+
+  if (callback.getType() === 'NameCallback') {
+    input.setAttribute('autocomplete', 'webauthn');
+  }
 
   journeyEl?.appendChild(label);
   journeyEl?.appendChild(input);

--- a/e2e/journey-app/components/validated-username.ts
+++ b/e2e/journey-app/components/validated-username.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2025-2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -20,6 +20,7 @@ export default function validatedUsernameComponent(
   input.type = 'text';
   input.id = collectorKey;
   input.name = collectorKey;
+  input.setAttribute('autocomplete', 'webauthn');
 
   journeyEl?.appendChild(label);
   journeyEl?.appendChild(input);

--- a/e2e/journey-app/components/webauthn-step.ts
+++ b/e2e/journey-app/components/webauthn-step.ts
@@ -5,8 +5,15 @@
  * of the MIT license. See the LICENSE file for details.
  */
 
-import { JourneyStep } from '@forgerock/journey-client/types';
+import type { BaseCallback, JourneyStep } from '@forgerock/journey-client/types';
 import { WebAuthn, WebAuthnStepType } from '@forgerock/journey-client/webauthn';
+
+import { renderCallbacks } from '../callback-map.js';
+
+type WebAuthnStepHandlerResult = {
+  callbacksRendered: boolean;
+  didSubmit: boolean;
+};
 
 export function webauthnComponent(journeyEl: HTMLDivElement, step: JourneyStep, idx: number) {
   const container = document.createElement('div');
@@ -38,4 +45,60 @@ export function webauthnComponent(journeyEl: HTMLDivElement, step: JourneyStep, 
   }
 
   return handleWebAuthn();
+}
+
+export async function handleWebAuthnStep(
+  journeyEl: HTMLDivElement,
+  step: JourneyStep,
+  callbacks: BaseCallback[],
+  submitForm: () => void,
+  setError: (message: string) => void,
+): Promise<WebAuthnStepHandlerResult> {
+  const webAuthnStep = WebAuthn.getWebAuthnStepType(step);
+
+  if (webAuthnStep === WebAuthnStepType.Authentication) {
+    // For conditional mediation, we need an input with `autocomplete="webauthn"` to exist.
+    renderCallbacks(journeyEl, callbacks, submitForm);
+
+    const conditionalInput = journeyEl.querySelector(
+      'input[autocomplete="webauthn"]',
+    ) as HTMLInputElement | null;
+    conditionalInput?.focus();
+
+    const isConditionalSupported = await WebAuthn.isConditionalMediationSupported();
+    if (isConditionalSupported && conditionalInput) {
+      const controller = new AbortController();
+      void WebAuthn.authenticate(step, 'conditional', controller.signal)
+        .then(() => submitForm())
+        .catch(() => {
+          setError('WebAuthn failed or was cancelled. Please try again or use a different method.');
+        });
+
+      return { callbacksRendered: true, didSubmit: false };
+    }
+
+    // Fallback to the traditional (prompted) WebAuthn flow.
+    const webAuthnSuccess = await webauthnComponent(journeyEl, step, 0);
+    if (webAuthnSuccess) {
+      submitForm();
+      return { callbacksRendered: true, didSubmit: true };
+    }
+
+    setError('WebAuthn failed or was cancelled. Please try again or use a different method.');
+    return { callbacksRendered: true, didSubmit: false };
+  }
+
+  if (webAuthnStep === WebAuthnStepType.Registration) {
+    // For registration, we keep the traditional (prompted) WebAuthn flow.
+    const webAuthnSuccess = await webauthnComponent(journeyEl, step, 0);
+    if (webAuthnSuccess) {
+      submitForm();
+      return { callbacksRendered: false, didSubmit: true };
+    }
+
+    setError('WebAuthn failed or was cancelled. Please try again or use a different method.');
+    return { callbacksRendered: false, didSubmit: false };
+  }
+
+  return { callbacksRendered: false, didSubmit: false };
 }

--- a/e2e/journey-app/components/webauthn-step.ts
+++ b/e2e/journey-app/components/webauthn-step.ts
@@ -66,9 +66,17 @@ export async function handleWebAuthnStep(
     conditionalInput?.focus();
 
     const isConditionalSupported = await WebAuthn.isConditionalMediationSupported();
-    if (isConditionalSupported && conditionalInput) {
+
+    const metadataCallback = WebAuthn.getMetadataCallback(step);
+    const meta = metadataCallback?.getData<{
+      mediation?: CredentialMediationRequirement;
+      conditional?: boolean;
+    }>();
+    const isConditionalMediation = meta?.mediation === 'conditional' || meta?.conditional === true;
+
+    if (isConditionalSupported && conditionalInput && isConditionalMediation) {
       const controller = new AbortController();
-      void WebAuthn.authenticate(step, 'conditional', controller.signal)
+      void WebAuthn.authenticate(step, controller.signal)
         .then(() => submitForm())
         .catch(() => {
           setError('WebAuthn failed or was cancelled. Please try again or use a different method.');

--- a/e2e/journey-app/main.ts
+++ b/e2e/journey-app/main.ts
@@ -7,7 +7,6 @@
 import './style.css';
 
 import { journey } from '@forgerock/journey-client';
-import { WebAuthn, WebAuthnStepType } from '@forgerock/journey-client/webauthn';
 
 import type { JourneyClient, RequestMiddleware } from '@forgerock/journey-client/types';
 
@@ -16,7 +15,7 @@ import { renderDeleteDevicesSection } from './components/delete-device.js';
 import { renderQRCodeStep } from './components/qr-code.js';
 import { renderRecoveryCodesStep } from './components/recovery-codes.js';
 import { deleteWebAuthnDevice } from './services/delete-webauthn-device.js';
-import { webauthnComponent } from './components/webauthn-step.js';
+import { handleWebAuthnStep } from './components/webauthn-step.js';
 import { serverConfigs } from './server-configs.js';
 
 const qs = window.location.search;
@@ -107,27 +106,24 @@ if (searchParams.get('middleware') === 'true') {
 
     const submitForm = () => formEl.requestSubmit();
 
-    // Handle WebAuthn steps first so we can hide the Submit button while processing,
-    // auto-submit on success, and show an error on failure.
-    const webAuthnStep = WebAuthn.getWebAuthnStepType(step);
-    if (
-      webAuthnStep === WebAuthnStepType.Authentication ||
-      webAuthnStep === WebAuthnStepType.Registration
-    ) {
-      const webAuthnSuccess = await webauthnComponent(journeyEl, step, 0);
-      if (webAuthnSuccess) {
-        submitForm();
-        return;
-      } else {
-        errorEl.textContent =
-          'WebAuthn failed or was cancelled. Please try again or use a different method.';
-      }
+    const { callbacksRendered, didSubmit } = await handleWebAuthnStep(
+      journeyEl,
+      step,
+      step.callbacks,
+      submitForm,
+      (message) => {
+        errorEl.textContent = message;
+      },
+    );
+
+    if (didSubmit) {
+      return;
     }
 
     const stepRendered =
       renderQRCodeStep(journeyEl, step) || renderRecoveryCodesStep(journeyEl, step);
 
-    if (!stepRendered) {
+    if (!stepRendered && !callbacksRendered) {
       const callbacks = step.callbacks;
       renderCallbacks(journeyEl, callbacks, submitForm);
     }

--- a/e2e/journey-suites/src/webauthn-device.test.ts
+++ b/e2e/journey-suites/src/webauthn-device.test.ts
@@ -15,8 +15,8 @@ const WEBAUTHN_CREDENTIAL_ID_QUERY_PARAM = 'webauthnCredentialId';
 test.use({ browserName: 'chromium' });
 
 test.describe('WebAuthn register, authenticate, and delete device', () => {
-  let cdp: CDPSession | undefined;
-  let authenticatorId: string | undefined;
+  let cdp!: CDPSession;
+  let authenticatorId!: string;
 
   test.beforeEach(async ({ context, page }) => {
     cdp = await context.newCDPSession(page);
@@ -35,17 +35,11 @@ test.describe('WebAuthn register, authenticate, and delete device', () => {
   });
 
   test.afterEach(async () => {
-    if (cdp && authenticatorId) {
-      await cdp.send('WebAuthn.removeVirtualAuthenticator', { authenticatorId });
-      await cdp.send('WebAuthn.disable');
-    }
+    await cdp.send('WebAuthn.removeVirtualAuthenticator', { authenticatorId });
+    await cdp.send('WebAuthn.disable');
   });
 
   test('should register, authenticate, and delete a device', async ({ page }) => {
-    if (!cdp || !authenticatorId) {
-      throw new Error('Virtual authenticator was not initialized');
-    }
-
     const { clickButton, navigate } = asyncEvents(page);
 
     const registeredCredentialId =
@@ -110,6 +104,86 @@ test.describe('WebAuthn register, authenticate, and delete device', () => {
       const deviceStatus = page.locator('#deviceStatus');
       await expect(deviceStatus).toContainText('Deleted WebAuthn device');
       await expect(deviceStatus).toContainText(`credential id ${registeredCredentialId} for user`);
+    });
+  });
+});
+
+test.describe('WebAuthn conditional autofill (passkey)', () => {
+  let cdp!: CDPSession;
+  let authenticatorId!: string;
+
+  test.beforeEach(async ({ context, page }) => {
+    // Chromium + CDP WebAuthn virtual authenticator is required for repeatable automation.
+    cdp = await context.newCDPSession(page);
+    await cdp.send('WebAuthn.enable');
+
+    // Configure a platform authenticator with resident keys and auto presence simulation.
+    const response = await cdp.send('WebAuthn.addVirtualAuthenticator', {
+      options: {
+        protocol: 'ctap2',
+        transport: 'internal',
+        hasResidentKey: true,
+        hasUserVerification: true,
+        isUserVerified: true,
+        automaticPresenceSimulation: true,
+      },
+    });
+    authenticatorId = response.authenticatorId;
+  });
+
+  test.afterEach(async () => {
+    await cdp.send('WebAuthn.removeVirtualAuthenticator', { authenticatorId });
+    await cdp.send('WebAuthn.disable');
+  });
+
+  // TODO: This test is currently skipped because the journey used does not allow enabling conditional mediation in admin console
+  // When we start using v2.0 of Page Node in admin console, this test can be executed again
+  test.skip('registers a passkey then authenticates via conditional autofill', async ({ page }) => {
+    const { clickButton, navigate } = asyncEvents(page);
+
+    await test.step('Register a WebAuthn credential', async () => {
+      // Start with an empty virtual authenticator.
+      const { credentials: initialCredentials } = await cdp.send('WebAuthn.getCredentials', {
+        authenticatorId,
+      });
+      expect(initialCredentials).toHaveLength(0);
+
+      // Run a registration journey that creates a credential in the authenticator.
+      await navigate('/?clientId=tenant&journey=TEST_WebAuthn-Registration');
+      await expect(page.getByLabel('User Name')).toBeVisible();
+      await page.getByLabel('User Name').fill(username);
+      await page.getByLabel('Password').fill(password);
+      await clickButton('Submit', '/authenticate');
+      await expect(page.getByRole('button', { name: 'Logout' })).toBeVisible();
+
+      const { credentials } = await cdp.send('WebAuthn.getCredentials', { authenticatorId });
+      expect(credentials.length).toBeGreaterThan(0);
+    });
+
+    await test.step('Authenticate using conditional UI / passkey autofill', async () => {
+      // Ensure we are not reusing an existing AM session.
+      // This makes the test exercise passkey auth, not cookie auth.
+      await page.context().clearCookies();
+
+      // This journey emits conditional mediation metadata and should complete via background
+      // WebAuthn (journey-app triggers the request and submits when a credential is returned).
+      await navigate('/?clientId=tenant&journey=TEST_AutofillPasskeyWebAuthn');
+
+      const conditionalInput = page.locator('input[autocomplete="webauthn"]');
+      await expect(conditionalInput).toBeVisible({ timeout: 10000 });
+      await conditionalInput.focus();
+      await expect(conditionalInput).toBeFocused();
+
+      // Re-enable presence simulation so the in-flight WebAuthn request can resolve.
+      await cdp.send('WebAuthn.setAutomaticPresenceSimulation', {
+        authenticatorId,
+        enabled: true,
+      });
+
+      // With a virtual authenticator configured for automatic presence simulation, this should
+      // complete without any manual click.
+      await expect(page.getByRole('button', { name: 'Logout' })).toBeVisible();
+      await expect(page.getByRole('heading', { name: 'Complete' })).toBeVisible();
     });
   });
 });

--- a/packages/journey-client/api-report/journey-client.webauthn.api.md
+++ b/packages/journey-client/api-report/journey-client.webauthn.api.md
@@ -92,10 +92,10 @@ export enum UserVerificationType {
 
 // @public
 export abstract class WebAuthn {
-    static authenticate(step: JourneyStep): Promise<JourneyStep>;
+    static authenticate(step: JourneyStep, mediation?: CredentialMediationRequirement, signal?: AbortSignal): Promise<JourneyStep>;
     static createAuthenticationPublicKey(metadata: WebAuthnAuthenticationMetadata): PublicKeyCredentialRequestOptions;
     static createRegistrationPublicKey(metadata: WebAuthnRegistrationMetadata): PublicKeyCredentialCreationOptions;
-    static getAuthenticationCredential(options: PublicKeyCredentialRequestOptions): Promise<PublicKeyCredential | null>;
+    static getAuthenticationCredential(options: PublicKeyCredentialRequestOptions, mediation?: CredentialMediationRequirement, signal?: AbortSignal): Promise<PublicKeyCredential | null>;
     static getAuthenticationOutcome(credential: PublicKeyCredential | null): OutcomeWithName<string, AttestationType, PublicKeyCredential> | OutcomeWithName<string, AttestationType, PublicKeyCredential, string>;
     static getCallbacks(step: JourneyStep): WebAuthnCallbacks;
     static getMetadataCallback(step: JourneyStep): MetadataCallback | undefined;
@@ -104,6 +104,7 @@ export abstract class WebAuthn {
     static getRegistrationOutcome(credential: PublicKeyCredential | null): OutcomeWithName<string, AttestationType, PublicKeyCredential>;
     static getTextOutputCallback(step: JourneyStep): TextOutputCallback | undefined;
     static getWebAuthnStepType(step: JourneyStep): WebAuthnStepType;
+    static isConditionalMediationSupported(): Promise<boolean>;
     static register<T extends string = ''>(step: JourneyStep, deviceName?: T): Promise<JourneyStep>;
 }
 

--- a/packages/journey-client/api-report/journey-client.webauthn.api.md
+++ b/packages/journey-client/api-report/journey-client.webauthn.api.md
@@ -92,7 +92,7 @@ export enum UserVerificationType {
 
 // @public
 export abstract class WebAuthn {
-    static authenticate(step: JourneyStep, mediation?: CredentialMediationRequirement, signal?: AbortSignal): Promise<JourneyStep>;
+    static authenticate(step: JourneyStep, signal?: AbortSignal): Promise<JourneyStep>;
     static createAuthenticationPublicKey(metadata: WebAuthnAuthenticationMetadata): PublicKeyCredentialRequestOptions;
     static createRegistrationPublicKey(metadata: WebAuthnRegistrationMetadata): PublicKeyCredentialCreationOptions;
     static getAuthenticationCredential(options: PublicKeyCredentialRequestOptions, mediation?: CredentialMediationRequirement, signal?: AbortSignal): Promise<PublicKeyCredential | null>;
@@ -116,6 +116,8 @@ export interface WebAuthnAuthenticationMetadata {
     allowCredentials?: string;
     // (undocumented)
     challenge: string;
+    // (undocumented)
+    mediation?: CredentialMediationRequirement;
     // (undocumented)
     relyingPartyId: string;
     // (undocumented)

--- a/packages/journey-client/src/lib/webauthn/interfaces.ts
+++ b/packages/journey-client/src/lib/webauthn/interfaces.ts
@@ -80,6 +80,7 @@ export interface WebAuthnAuthenticationMetadata {
   acceptableCredentials?: string;
   allowCredentials?: string;
   challenge: string;
+  mediation?: CredentialMediationRequirement;
   relyingPartyId: string;
   timeout: number;
   userVerification: UserVerificationType;

--- a/packages/journey-client/src/lib/webauthn/webauthn.test.ts
+++ b/packages/journey-client/src/lib/webauthn/webauthn.test.ts
@@ -3,7 +3,7 @@
  *
  * fr-webauthn.test.ts
  *
- * Copyright (c) 2020 - 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2020 - 2026 Ping Identity Corporation. All rights reserved.
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
  */
@@ -23,6 +23,7 @@ import {
   webAuthnAuthMetaCallback70StoredUsername,
 } from './webauthn.mock.data.js';
 import { createJourneyStep } from '../step.utils.js';
+import { vi, afterEach, beforeEach, expect } from 'vitest';
 
 describe('Test FRWebAuthn class with 6.5.3 "Passwordless"', () => {
   it('should return Registration type with register text-output callbacks', () => {
@@ -96,5 +97,106 @@ describe('Test FRWebAuthn class with 7.0 "Usernameless"', () => {
     const step = createJourneyStep(webAuthnAuthMetaCallback70StoredUsername as any);
     const stepType = WebAuthn.getWebAuthnStepType(step);
     expect(stepType).toBe(WebAuthnStepType.Authentication);
+  });
+});
+
+describe('WebAuthn conditional mediation', () => {
+  const originalNavigatorCredentials = navigator.credentials;
+  const originalPublicKeyCredential = globalThis.PublicKeyCredential;
+
+  beforeEach(() => {
+    Object.defineProperty(globalThis, 'PublicKeyCredential', {
+      configurable: true,
+      writable: true,
+      value: class PublicKeyCredential {
+        static async isConditionalMediationAvailable(): Promise<boolean> {
+          return true;
+        }
+      },
+    });
+
+    Object.defineProperty(navigator, 'credentials', {
+      configurable: true,
+      value: {
+        get: vi.fn(),
+      },
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(navigator, 'credentials', {
+      configurable: true,
+      value: originalNavigatorCredentials,
+    });
+
+    Object.defineProperty(globalThis, 'PublicKeyCredential', {
+      configurable: true,
+      writable: true,
+      value: originalPublicKeyCredential,
+    });
+
+    vi.restoreAllMocks();
+  });
+
+  it('requires an AbortSignal when mediation is conditional', async () => {
+    // eslint-disable-next-line
+    const step = createJourneyStep(webAuthnAuthMetaCallback70 as any);
+    const hiddenCallback = WebAuthn.getOutcomeCallback(step);
+    if (!hiddenCallback) throw new Error('Missing hidden callback for test');
+
+    await expect(WebAuthn.authenticate(step, 'conditional')).rejects.toThrow(
+      'AbortSignal is required for conditional mediation WebAuthn requests',
+    );
+
+    expect(hiddenCallback.getInputValue()).toContain(
+      'AbortSignal is required for conditional mediation WebAuthn requests',
+    );
+  });
+
+  it('throws NotSupportedError when conditional mediation is not supported by the browser', async () => {
+    // eslint-disable-next-line
+    const step = createJourneyStep(webAuthnAuthMetaCallback70 as any);
+    const hiddenCallback = WebAuthn.getOutcomeCallback(step);
+    if (!hiddenCallback) throw new Error('Missing hidden callback for test');
+
+    const conditionalSupportSpy = vi
+      .spyOn(WebAuthn, 'isConditionalMediationSupported')
+      .mockResolvedValue(false);
+
+    await expect(
+      WebAuthn.authenticate(step, 'conditional', new AbortController().signal),
+    ).rejects.toMatchObject({ name: 'NotSupportedError' });
+
+    expect(conditionalSupportSpy).toHaveBeenCalledTimes(1);
+    expect(hiddenCallback.getInputValue()).toBe('unsupported');
+    expect(navigator.credentials.get as unknown as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+  });
+
+  it('passes mediation + signal through to navigator.credentials.get when supported', async () => {
+    // eslint-disable-next-line
+    const step = createJourneyStep(webAuthnAuthMetaCallback70 as any);
+    const hiddenCallback = WebAuthn.getOutcomeCallback(step);
+    if (!hiddenCallback) throw new Error('Missing hidden callback for test');
+
+    const abortController = new AbortController();
+    const credentialsGet = vi
+      .spyOn(navigator.credentials, 'get')
+      .mockResolvedValue({} as unknown as Credential);
+
+    const outcomeSpy = vi
+      .spyOn(WebAuthn, 'getAuthenticationOutcome')
+      .mockReturnValue('ok' as unknown as ReturnType<typeof WebAuthn.getAuthenticationOutcome>);
+
+    await WebAuthn.authenticate(step, 'conditional', abortController.signal);
+
+    expect(outcomeSpy).toHaveBeenCalledTimes(1);
+    expect(credentialsGet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mediation: 'conditional',
+        signal: abortController.signal,
+        publicKey: expect.any(Object),
+      }),
+    );
+    expect(hiddenCallback.getInputValue()).toBe('ok');
   });
 });

--- a/packages/journey-client/src/lib/webauthn/webauthn.test.ts
+++ b/packages/journey-client/src/lib/webauthn/webauthn.test.ts
@@ -23,7 +23,6 @@ import {
   webAuthnAuthMetaCallback70StoredUsername,
 } from './webauthn.mock.data.js';
 import { createJourneyStep } from '../step.utils.js';
-import { vi, afterEach, beforeEach, expect } from 'vitest';
 
 describe('Test FRWebAuthn class with 6.5.3 "Passwordless"', () => {
   it('should return Registration type with register text-output callbacks', () => {
@@ -53,7 +52,6 @@ describe('Test FRWebAuthn class with 7.0 "Passwordless"', () => {
     // eslint-disable-next-line
     const step = createJourneyStep(webAuthnAuthJSCallback70 as any);
     const stepType = WebAuthn.getWebAuthnStepType(step);
-    console.log('the step type', stepType, WebAuthnStepType.Authentication);
     expect(stepType).toBe(WebAuthnStepType.Authentication);
   });
 
@@ -97,106 +95,5 @@ describe('Test FRWebAuthn class with 7.0 "Usernameless"', () => {
     const step = createJourneyStep(webAuthnAuthMetaCallback70StoredUsername as any);
     const stepType = WebAuthn.getWebAuthnStepType(step);
     expect(stepType).toBe(WebAuthnStepType.Authentication);
-  });
-});
-
-describe('WebAuthn conditional mediation', () => {
-  const originalNavigatorCredentials = navigator.credentials;
-  const originalPublicKeyCredential = globalThis.PublicKeyCredential;
-
-  beforeEach(() => {
-    Object.defineProperty(globalThis, 'PublicKeyCredential', {
-      configurable: true,
-      writable: true,
-      value: class PublicKeyCredential {
-        static async isConditionalMediationAvailable(): Promise<boolean> {
-          return true;
-        }
-      },
-    });
-
-    Object.defineProperty(navigator, 'credentials', {
-      configurable: true,
-      value: {
-        get: vi.fn(),
-      },
-    });
-  });
-
-  afterEach(() => {
-    Object.defineProperty(navigator, 'credentials', {
-      configurable: true,
-      value: originalNavigatorCredentials,
-    });
-
-    Object.defineProperty(globalThis, 'PublicKeyCredential', {
-      configurable: true,
-      writable: true,
-      value: originalPublicKeyCredential,
-    });
-
-    vi.restoreAllMocks();
-  });
-
-  it('requires an AbortSignal when mediation is conditional', async () => {
-    // eslint-disable-next-line
-    const step = createJourneyStep(webAuthnAuthMetaCallback70 as any);
-    const hiddenCallback = WebAuthn.getOutcomeCallback(step);
-    if (!hiddenCallback) throw new Error('Missing hidden callback for test');
-
-    await expect(WebAuthn.authenticate(step, 'conditional')).rejects.toThrow(
-      'AbortSignal is required for conditional mediation WebAuthn requests',
-    );
-
-    expect(hiddenCallback.getInputValue()).toContain(
-      'AbortSignal is required for conditional mediation WebAuthn requests',
-    );
-  });
-
-  it('throws NotSupportedError when conditional mediation is not supported by the browser', async () => {
-    // eslint-disable-next-line
-    const step = createJourneyStep(webAuthnAuthMetaCallback70 as any);
-    const hiddenCallback = WebAuthn.getOutcomeCallback(step);
-    if (!hiddenCallback) throw new Error('Missing hidden callback for test');
-
-    const conditionalSupportSpy = vi
-      .spyOn(WebAuthn, 'isConditionalMediationSupported')
-      .mockResolvedValue(false);
-
-    await expect(
-      WebAuthn.authenticate(step, 'conditional', new AbortController().signal),
-    ).rejects.toMatchObject({ name: 'NotSupportedError' });
-
-    expect(conditionalSupportSpy).toHaveBeenCalledTimes(1);
-    expect(hiddenCallback.getInputValue()).toBe('unsupported');
-    expect(navigator.credentials.get as unknown as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
-  });
-
-  it('passes mediation + signal through to navigator.credentials.get when supported', async () => {
-    // eslint-disable-next-line
-    const step = createJourneyStep(webAuthnAuthMetaCallback70 as any);
-    const hiddenCallback = WebAuthn.getOutcomeCallback(step);
-    if (!hiddenCallback) throw new Error('Missing hidden callback for test');
-
-    const abortController = new AbortController();
-    const credentialsGet = vi
-      .spyOn(navigator.credentials, 'get')
-      .mockResolvedValue({} as unknown as Credential);
-
-    const outcomeSpy = vi
-      .spyOn(WebAuthn, 'getAuthenticationOutcome')
-      .mockReturnValue('ok' as unknown as ReturnType<typeof WebAuthn.getAuthenticationOutcome>);
-
-    await WebAuthn.authenticate(step, 'conditional', abortController.signal);
-
-    expect(outcomeSpy).toHaveBeenCalledTimes(1);
-    expect(credentialsGet).toHaveBeenCalledWith(
-      expect.objectContaining({
-        mediation: 'conditional',
-        signal: abortController.signal,
-        publicKey: expect.any(Object),
-      }),
-    );
-    expect(hiddenCallback.getInputValue()).toBe('ok');
   });
 });

--- a/packages/journey-client/src/lib/webauthn/webauthn.ts
+++ b/packages/journey-client/src/lib/webauthn/webauthn.ts
@@ -1,9 +1,9 @@
 /*
  * @forgerock/ping-javascript-sdk
  *
- * index.ts
+ * webauthn.ts
  *
- * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2024 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -60,6 +60,28 @@ type WebAuthnMetadata = WebAuthnAuthenticationMetadata | WebAuthnRegistrationMet
  *   await WebAuthn.authenticate(step);
  * }
  * ```
+ *
+ * Conditional mediation (passkey autofill) support:
+ *
+ * Conditional mediation is **opt-in** in this SDK via the `authenticate()` parameters.
+ *
+ * ```js
+ * // Optional: feature-detect conditional UI before attempting
+ * const supportsConditionalUI = await WebAuthn.isConditionalMediationSupported();
+ *
+ * if (supportsConditionalUI) {
+ *   const controller = new AbortController();
+ *
+ *   await WebAuthn.authenticate(step, 'conditional', controller.signal);
+ * }
+ * ```
+ *
+ * Notes:
+ * - When `mediation` is `'conditional'`, an `AbortSignal` is required.
+ * - If conditional mediation is requested but not supported by the browser,
+ *   `authenticate()` throws a `NotSupportedError` and sets the hidden WebAuthn outcome to `unsupported`.
+ * - To enable passkey autofill, add `autocomplete="webauthn"` to your username field:
+ *   `<input type="text" name="username" autocomplete="webauthn" />`
  */
 export abstract class WebAuthn {
   /**
@@ -101,9 +123,15 @@ export abstract class WebAuthn {
    * Populates the step with the necessary authentication outcome.
    *
    * @param step The step that contains WebAuthn authentication data
+   * @param mediation Optional mediation requirement passed through to `navigator.credentials.get()`
+   * @param signal Optional AbortSignal passed through to `navigator.credentials.get()` (required when `mediation` is `'conditional'`)
    * @return The populated step
    */
-  public static async authenticate(step: JourneyStep): Promise<JourneyStep> {
+  public static async authenticate(
+    step: JourneyStep,
+    mediation?: CredentialMediationRequirement,
+    signal?: AbortSignal,
+  ): Promise<JourneyStep> {
     const { hiddenCallback, metadataCallback, textOutputCallback } = this.getCallbacks(step);
     if (hiddenCallback && (metadataCallback || textOutputCallback)) {
       let outcome: ReturnType<typeof this.getAuthenticationOutcome>;
@@ -115,8 +143,27 @@ export abstract class WebAuthn {
           const meta = metadataCallback.getOutputValue('data') as WebAuthnAuthenticationMetadata;
           publicKey = this.createAuthenticationPublicKey(meta);
 
+          if (mediation === 'conditional') {
+            if (!signal) {
+              throw new Error(
+                'AbortSignal is required for conditional mediation WebAuthn requests',
+              );
+            }
+
+            const isConditionalMediationSupported = await this.isConditionalMediationSupported();
+            if (!isConditionalMediationSupported) {
+              const e = new Error(
+                'Conditional mediation was requested, but is not supported by this browser.',
+              );
+              e.name = WebAuthnOutcomeType.NotSupportedError;
+              throw e;
+            }
+          }
+
           credential = await this.getAuthenticationCredential(
             publicKey as PublicKeyCredentialRequestOptions,
+            mediation,
+            signal,
           );
           outcome = this.getAuthenticationOutcome(credential);
         } else {
@@ -126,6 +173,12 @@ export abstract class WebAuthn {
         }
       } catch (error) {
         if (!(error instanceof Error)) throw error;
+        // In conditional mediation flows, the app may abort an in-flight request when the user
+        // submits a different method or the step changes. Treat this as cancellation and do not
+        // mutate the hidden outcome.
+        if (mediation === 'conditional' && error.name === 'AbortError') {
+          throw error;
+        }
         // NotSupportedError is a special case
         if (error.name === WebAuthnOutcomeType.NotSupportedError) {
           hiddenCallback.setInputValue(WebAuthnOutcome.Unsupported);
@@ -295,10 +348,14 @@ export abstract class WebAuthn {
    * Retrieves the credential from the browser Web Authentication API.
    *
    * @param options The public key options associated with the request
+   * @param mediation Optional mediation requirement passed through to `navigator.credentials.get()`
+   * @param signal Optional AbortSignal passed through to `navigator.credentials.get()`
    * @return The credential
    */
   public static async getAuthenticationCredential(
     options: PublicKeyCredentialRequestOptions,
+    mediation?: CredentialMediationRequirement,
+    signal?: AbortSignal,
   ): Promise<PublicKeyCredential | null> {
     // Feature check before we attempt registering a device
     if (!window.PublicKeyCredential) {
@@ -306,8 +363,26 @@ export abstract class WebAuthn {
       e.name = WebAuthnOutcomeType.NotSupportedError;
       throw e;
     }
-    const credential = await navigator.credentials.get({ publicKey: options });
+
+    const credential = await navigator.credentials.get({
+      publicKey: options,
+      ...(mediation && { mediation }),
+      ...(signal && { signal }),
+    });
     return credential as PublicKeyCredential;
+  }
+
+  /**
+   * Determines if the browser supports conditional mediation.
+   *
+   * @return Whether the browser supports conditional mediation
+   */
+  public static async isConditionalMediationSupported(): Promise<boolean> {
+    return (
+      typeof PublicKeyCredential !== 'undefined' &&
+      typeof PublicKeyCredential.isConditionalMediationAvailable === 'function' &&
+      (await PublicKeyCredential.isConditionalMediationAvailable())
+    );
   }
 
   /**

--- a/packages/journey-client/src/lib/webauthn/webauthn.ts
+++ b/packages/journey-client/src/lib/webauthn/webauthn.ts
@@ -63,7 +63,7 @@ type WebAuthnMetadata = WebAuthnAuthenticationMetadata | WebAuthnRegistrationMet
  *
  * Conditional mediation (passkey autofill) support:
  *
- * Conditional mediation is **opt-in** in this SDK via the `authenticate()` parameters.
+ * Conditional mediation is **server-driven** in this SDK via WebAuthn metadata (`meta.mediation`).
  *
  * ```js
  * // Optional: feature-detect conditional UI before attempting
@@ -72,18 +72,22 @@ type WebAuthnMetadata = WebAuthnAuthenticationMetadata | WebAuthnRegistrationMet
  * if (supportsConditionalUI) {
  *   const controller = new AbortController();
  *
- *   await WebAuthn.authenticate(step, 'conditional', controller.signal);
+ *   // Optional: provide a signal to cancel an in-flight request
+ *   await WebAuthn.authenticate(step, controller.signal);
  * }
  * ```
  *
  * Notes:
- * - When `mediation` is `'conditional'`, an `AbortSignal` is required.
+ * - When server-driven mediation is `'conditional'`, an `AbortSignal` will be used.
+ *   If you don't provide one, the SDK will create one.
  * - If conditional mediation is requested but not supported by the browser,
  *   `authenticate()` throws a `NotSupportedError` and sets the hidden WebAuthn outcome to `unsupported`.
  * - To enable passkey autofill, add `autocomplete="webauthn"` to your username field:
  *   `<input type="text" name="username" autocomplete="webauthn" />`
  */
 export abstract class WebAuthn {
+  private static conditionalAbortController?: AbortController;
+
   /**
    * Determines if the given step is a WebAuthn step.
    *
@@ -120,35 +124,45 @@ export abstract class WebAuthn {
   }
 
   /**
+   * Determines if the browser supports conditional mediation.
+   *
+   * @return Whether the browser supports conditional mediation
+   */
+  public static async isConditionalMediationSupported(): Promise<boolean> {
+    return (
+      typeof PublicKeyCredential !== 'undefined' &&
+      typeof PublicKeyCredential.isConditionalMediationAvailable === 'function' &&
+      (await PublicKeyCredential.isConditionalMediationAvailable())
+    );
+  }
+
+  /**
    * Populates the step with the necessary authentication outcome.
    *
    * @param step The step that contains WebAuthn authentication data
-   * @param mediation Optional mediation requirement passed through to `navigator.credentials.get()`
-   * @param signal Optional AbortSignal passed through to `navigator.credentials.get()` (required when `mediation` is `'conditional'`)
+   * @param signal Optional AbortSignal passed through to `navigator.credentials.get()`
    * @return The populated step
    */
-  public static async authenticate(
-    step: JourneyStep,
-    mediation?: CredentialMediationRequirement,
-    signal?: AbortSignal,
-  ): Promise<JourneyStep> {
+  public static async authenticate(step: JourneyStep, signal?: AbortSignal): Promise<JourneyStep> {
     const { hiddenCallback, metadataCallback, textOutputCallback } = this.getCallbacks(step);
     if (hiddenCallback && (metadataCallback || textOutputCallback)) {
       let outcome: ReturnType<typeof this.getAuthenticationOutcome>;
       let credential: PublicKeyCredential | null = null;
+      let mediation: CredentialMediationRequirement | undefined;
 
       try {
         let publicKey: PublicKeyCredentialRequestOptions;
         if (metadataCallback) {
           const meta = metadataCallback.getOutputValue('data') as WebAuthnAuthenticationMetadata;
+          mediation = meta.mediation;
           publicKey = this.createAuthenticationPublicKey(meta);
 
           if (mediation === 'conditional') {
-            if (!signal) {
-              throw new Error(
-                'AbortSignal is required for conditional mediation WebAuthn requests',
-              );
-            }
+            // Abort any prior conditional request started by the SDK.
+            // (If the caller provides their own signal, we still abort the prior SDK-owned one.)
+            this.conditionalAbortController?.abort();
+
+            const abortSignal = signal ?? this.createAbortController().signal;
 
             const isConditionalMediationSupported = await this.isConditionalMediationSupported();
             if (!isConditionalMediationSupported) {
@@ -158,14 +172,21 @@ export abstract class WebAuthn {
               e.name = WebAuthnOutcomeType.NotSupportedError;
               throw e;
             }
-          }
 
-          credential = await this.getAuthenticationCredential(
-            publicKey as PublicKeyCredentialRequestOptions,
-            mediation,
-            signal,
-          );
-          outcome = this.getAuthenticationOutcome(credential);
+            credential = await this.getAuthenticationCredential(
+              publicKey as PublicKeyCredentialRequestOptions,
+              mediation,
+              abortSignal,
+            );
+            outcome = this.getAuthenticationOutcome(credential);
+          } else {
+            credential = await this.getAuthenticationCredential(
+              publicKey as PublicKeyCredentialRequestOptions,
+              mediation,
+              signal,
+            );
+            outcome = this.getAuthenticationOutcome(credential);
+          }
         } else {
           throw new Error(
             'No metadata callback found for WebAuthn authentication. Please disable JavaScript in server node.',
@@ -373,19 +394,6 @@ export abstract class WebAuthn {
   }
 
   /**
-   * Determines if the browser supports conditional mediation.
-   *
-   * @return Whether the browser supports conditional mediation
-   */
-  public static async isConditionalMediationSupported(): Promise<boolean> {
-    return (
-      typeof PublicKeyCredential !== 'undefined' &&
-      typeof PublicKeyCredential.isConditionalMediationAvailable === 'function' &&
-      (await PublicKeyCredential.isConditionalMediationAvailable())
-    );
-  }
-
-  /**
    * Converts an authentication credential into the outcome expected by OpenAM.
    *
    * @param credential The credential to convert
@@ -515,7 +523,7 @@ export abstract class WebAuthn {
       challenge: Uint8Array.from(atob(challenge), (c) => c.charCodeAt(0)).buffer,
       timeout,
       // only add key-value pair if proper value is provided
-      ...(allowCredentialsValue && { allowCredentials: allowCredentialsValue }),
+      ...(allowCredentialsValue?.length ? { allowCredentials: allowCredentialsValue } : {}),
       ...(userVerification && { userVerification }),
       ...(rpId && { rpId }),
     };
@@ -571,6 +579,19 @@ export abstract class WebAuthn {
         name: displayName || userName,
       },
     };
+  }
+
+  /**
+   * Creates and stores an SDK-owned {@link AbortController} for conditional mediation,
+   * aborting any previous SDK-owned controller first.
+   *
+   * @return A new AbortController for conditional mediation.
+   */
+  private static createAbortController(): AbortController {
+    this.conditionalAbortController?.abort();
+    const abortController = new AbortController();
+    this.conditionalAbortController = abortController;
+    return abortController;
   }
 }
 


### PR DESCRIPTION
# JIRA Ticket
[pingidentity.atlassian.net/browse/SDKS-4612](https://pingidentity.atlassian.net/browse/SDKS-4612)

## Description
Add WebAuthn conditional mediation (passkey autofill) support to @forgerock/journey-client.
This enables consumers to opt-in to conditional UI by passing mediation: 'conditional' and an AbortSignal through to navigator.credentials.get(...) with a helper to feature-detect browser support.

## What changed
- WebAuthn authenticate now supports conditional mediation: WebAuthn.authenticate(step, mediation?, signal?)
- Forwards mediation and signal to navigator.credentials.get({ publicKey, mediation, signal })
- Requires an AbortSignal when mediation === 'conditional' If conditional mediation is requested but unsupported, throws NotSupportedError and existing error handling sets the hidden outcome to unsupported
- Added WebAuthn.isConditionalMediationSupported() helper for feature detection
- Added unit tests 
- Updated journey app to show autofill passkey option

## How to test
- Build and start the journey app by going to `e2e/journey-app` folder and with commands `pnpm build` followed by `pnpm serve`
- Set mediation = 'conditional' locally because at the moment our openam-sdks tenant does not have the option to enable or disable conditional mediation. https://github.com/ForgeRock/ping-javascript-sdk/blob/a935fc4aa93ab2b27df693fde6547f340ea0d07b/packages/journey-client/src/lib/webauthn/webauthn.ts#L151 This option is available only with Page Node v2.0 according to the documentation here: https://docs.pingidentity.com/auth-node-ref/latest/webauthn-authentication.html#example_2_webauthn_authentication_with_conditional_ui 
- Register with webauthn by going to TEST_WebAuthn-Registration journey and then try authenticating by going to TEST_AutofillPasskeyWebAuthn journey which has the autofill option. You can follow the attached recording for reference.

## Recording
https://github.com/user-attachments/assets/d387c2e3-d788-4f70-acfd-5920eb340796

## Did you add a changeset?
Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds passkey conditional mediation support with optional cancellation control and a runtime helper to detect browser support.

* **Bug Fixes / UX**
  * Improved autocomplete hints on credential and username fields to enhance passkey autofill.
  * Authentication now reports unsupported platforms and cancellation consistently and coordinates passkey UI to avoid unintended submissions.

* **Tests**
  * Adds unit and end-to-end tests for conditional mediation (e2e currently skipped).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->