### PR TITLE
fix(davinci-suites): support two phone collectors in form-fields e2e

### DIFF
--- a/e2e/davinci-app/components/object-value.ts
+++ b/e2e/davinci-app/components/object-value.ts
@@ -62,15 +62,17 @@ export default function objectValueComponent(
       formEl.appendChild(buttonEl);
     }
   } else {
+    const inputId = `phone-number-input-${collector.output.key}`;
+
     const phoneLabel = document.createElement('label');
     phoneLabel.textContent = collector.output.label || 'Phone Number';
     phoneLabel.className = 'object-options-title';
-    phoneLabel.setAttribute('for', 'phone-number-input');
+    phoneLabel.setAttribute('for', inputId);
 
     const phoneInput = document.createElement('input');
     phoneInput.setAttribute('type', 'tel');
-    phoneInput.setAttribute('id', 'phone-number-input');
-    phoneInput.setAttribute('name', 'phone-number-input');
+    phoneInput.setAttribute('id', inputId);
+    phoneInput.setAttribute('name', inputId);
     phoneInput.setAttribute('placeholder', 'Enter phone number');
 
     // Add change event listener

--- a/e2e/davinci-suites/src/form-fields.test.ts
+++ b/e2e/davinci-suites/src/form-fields.test.ts
@@ -31,7 +31,7 @@ test('Should render form fields', async ({ page }) => {
   await page.locator('#combobox-field-key-3').check();
   await page.locator('#combobox-field-key-2').uncheck();
 
-  await page.locator('#phone-number-input').fill('1234567890');
+  await page.getByLabel('Phone', { exact: true }).fill('1234567890');
 
   await expect(page.getByRole('button', { name: 'Flow Button' })).toBeVisible();
   await expect(page.getByRole('button', { name: 'Flow Link' })).toBeVisible();
@@ -53,8 +53,12 @@ test('Should render form fields', async ({ page }) => {
     'radio-group-key': 'option2 value',
     'combobox-field-key': ['option1 value', 'option3 value'],
     'phone-field': {
-      phoneNumber: '1234567890',
+      phoneNumber: '(555)555-1234',
       countryCode: 'GB',
+    },
+    'phone-field1': {
+      phoneNumber: '1234567890',
+      countryCode: 'CR',
     },
   });
 });


### PR DESCRIPTION
## Summary

`e2e/davinci-suites/src/form-fields.test.ts` is failing on main. Root cause: the PingOne form rendered for `clientId=60de77d5-...` now contains **two** `PhoneNumberCollector` instances ("Phone" and "Phone Number w/Extension"), but the davinci-app phone component hardcoded `id="phone-number-input"` on every render. With two inputs sharing the same id, `page.locator('#phone-number-input').fill(...)` hit a Playwright strict-mode violation.

## Changes

### `e2e/davinci-app/components/object-value.ts`

Derive the input id from `collector.output.key`:

```ts
const inputId = `phone-number-input-${collector.output.key}`;
```

This fixes the duplicate-id HTML invalidity and ensures each `<label for>` correctly associates with its own `<input>`.

### `e2e/davinci-suites/src/form-fields.test.ts`

- Replace the CSS-selector lookup `page.locator('#phone-number-input')` with `page.getByLabel('Phone', { exact: true })` — semantic locator that selects by the input's accessible name rather than a brittle id.
- Update the expected `formData`. The form now submits both phone collectors:
  - `phone-field`: prefilled `(555)555-1234`, `countryCode: 'GB'`
  - `phone-field1`: typed `1234567890`, `countryCode: 'CR'`

## Verification

- `nx run @forgerock/davinci-suites:e2e-ci--src/form-fields.test.ts --skip-nx-cache` — both tests pass (55s).
- `nx lint`, `nx typecheck` — clean.

## Test plan

- [x] e2e test passes locally
- [x] typecheck + lint clean
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue preventing multiple phone number input fields from functioning correctly on the same page.
  * Enhanced phone number formatting support for different regions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->