### PR TITLE
docs(journey-client): fix FRDevice mapping, export PolicyParams, improve migration guide

### DIFF
--- a/.changeset/cool-kings-learn.md
+++ b/.changeset/cool-kings-learn.md
@@ -1,0 +1,5 @@
+---
+'@forgerock/journey-client': patch
+---
+
+patch @forgerock/journey-client: export PolicyParams from journey-client/types

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -150,6 +150,37 @@ if ('error' in result) {
 
 ---
 
+## StepOptions → StartParam / NextOptions / ResumeOptions
+
+For the full type-level mapping see [`interface_mapping.md` § Authentication Flow](./interface_mapping.md#3-authentication-flow). The three implementation pain points that aren't obvious from the type table:
+
+**1. `tree` is no longer threaded through `next()`.**
+
+The legacy pattern merged `initOptions` and `nextOptions` and passed the combined object to both `start()` and `next()`, carrying `tree` through every call. In the new SDK, `next()` does not accept a journey name — it only takes `{ query? }`. Remove any options merging/forwarding from your `next()` wrapper.
+
+```typescript
+// Legacy — options object merged and threaded through every call
+const options = { ...initOptions, ...nextOptions };
+await FRAuth.next(prevStep, options); // tree still in options
+
+// New — next() has no journey param; don't merge options through
+await journeyClient.next(prevStep, { query: nextOptions?.query });
+```
+
+**2. A journey stack stored `StepOptions[]`; it now stores `StartParam[]`.**
+
+If you maintain a stack for switching between trees, the stored type changes from `StepOptions` to `StartParam` and the deduplication key changes from `tree` to `journey`:
+
+```typescript
+// Legacy
+if (options?.tree !== current[current.length - 1]?.tree) { ... }
+
+// New
+if (options?.journey !== current[current.length - 1]?.journey) { ... }
+```
+
+---
+
 ## Step Types
 
 | Legacy                            | New                                 | Notes                                                 |
@@ -159,6 +190,58 @@ if ('error' in result) {
 | `FRLoginFailure` (class instance) | `JourneyLoginFailure` (object type) | Use `result.type === 'LoginFailure'`                  |
 
 All step methods (`getCallbackOfType`, `getDescription`, `getHeader`, `getStage`, `getSessionToken`, etc.) remain identical.
+
+### Creating a JourneyStep for Tests and Stories
+
+The legacy SDK created step objects by instantiating `new FRStep(payload)`, `new FRLoginSuccess(payload)`, or `new FRLoginFailure(payload)`. The new SDK creates these internally — there are no classes to instantiate. Because all three types are plain objects, replace every `new FR*` call with an object literal typed against the corresponding interface:
+
+```typescript
+// Before
+import { FRStep, FRLoginSuccess, FRLoginFailure } from '@forgerock/javascript-sdk';
+const step = new FRStep(payload);
+const success = new FRLoginSuccess(payload);
+const failure = new FRLoginFailure(payload);
+
+// After
+import type {
+  JourneyStep,
+  JourneyLoginSuccess,
+  JourneyLoginFailure,
+} from '@forgerock/journey-client/types';
+import { StepType, createCallback } from '@forgerock/journey-client/types';
+
+const mockStep: JourneyStep = {
+  type: StepType.Step,
+  payload: rawPayload,
+  callbacks: rawPayload.callbacks?.map(createCallback) ?? [],
+  getCallbackOfType: (type) => {
+    throw new Error('not implemented');
+  },
+  getCallbacksOfType: (type) => [],
+  setCallbackValue: () => {},
+  getDescription: () => undefined,
+  getHeader: () => undefined,
+  getStage: () => undefined,
+};
+
+const mockSuccess: JourneyLoginSuccess = {
+  type: StepType.LoginSuccess,
+  payload: rawPayload,
+  getRealm: () => 'alpha',
+  getSessionToken: () => 'abc123',
+  getSuccessUrl: () => undefined,
+};
+
+const mockFailure: JourneyLoginFailure = {
+  type: StepType.LoginFailure,
+  payload: rawPayload,
+  getCode: () => 401,
+  getDetail: () => undefined,
+  getMessage: () => 'Login failure',
+  getReason: () => undefined,
+  getProcessedMessage: () => [],
+};
+```
 
 ---
 

--- a/interface_mapping.md
+++ b/interface_mapping.md
@@ -105,7 +105,7 @@ Flat lookup table for AI context injection. Every legacy symbol → new import i
 | `ErrorCode`                        | Removed — use `GenericError.type` instead                                                         |
 | `FRAuth`                           | `import { journey } from '@forgerock/journey-client'` — factory returns `JourneyClient`           |
 | `FRCallback`                       | `import { BaseCallback } from '@forgerock/journey-client/types'`                                  |
-| `FRDevice`                         | `import { deviceClient } from '@forgerock/device-client'`                                         |
+| `FRDevice`                         | `import { Device } from '@forgerock/journey-client/device'`                                       |
 | `FRLoginFailure`                   | `import type { JourneyLoginFailure } from '@forgerock/journey-client/types'`                      |
 | `FRLoginSuccess`                   | `import type { JourneyLoginSuccess } from '@forgerock/journey-client/types'`                      |
 | `FRPolicy`                         | `import { Policy } from '@forgerock/journey-client/policy'`                                       |
@@ -178,7 +178,7 @@ The legacy SDK is a single package. The new SDK splits concerns across multiple 
 | `import { deviceClient } from '@forgerock/javascript-sdk'`                        | `import { deviceClient } from '@forgerock/device-client'`                                  | deviceClient                   |
 | `import { FRAuth } from '@forgerock/javascript-sdk'`                              | `import { journey } from '@forgerock/journey-client'`                                      | FRAuth                         |
 | `import { FRCallback } from '@forgerock/javascript-sdk'`                          | `import { BaseCallback } from '@forgerock/journey-client/types'`                           | FRCallback                     |
-| `import { FRDevice } from '@forgerock/javascript-sdk'`                            | `import { deviceClient } from '@forgerock/device-client'`                                  | FRDevice                       |
+| `import { FRDevice } from '@forgerock/javascript-sdk'`                            | `import { Device } from '@forgerock/journey-client/device'`                                | FRDevice                       |
 | `import type { FRLoginFailure } from '@forgerock/javascript-sdk'`                 | `import type { JourneyLoginFailure } from '@forgerock/journey-client/types'`               | FRLoginFailure                 |
 | `import type { FRLoginSuccess } from '@forgerock/javascript-sdk'`                 | `import type { JourneyLoginSuccess } from '@forgerock/journey-client/types'`               | FRLoginSuccess                 |
 | `import { FRPolicy } from '@forgerock/javascript-sdk'`                            | `import { Policy } from '@forgerock/journey-client/policy'`                                | FRPolicy                       |
@@ -955,10 +955,10 @@ if (type === WebAuthnStepType.Authentication) {
 
 ### FRDevice (Device Profile Collection)
 
-| Legacy API                                                 | New API                                                     | Return Type Change                                   | Behavioral Notes                         |
-| ---------------------------------------------------------- | ----------------------------------------------------------- | ---------------------------------------------------- | ---------------------------------------- |
-| `import { FRDevice } from '@forgerock/javascript-sdk'`     | Device profile functionality via `@forgerock/device-client` | —                                                    | Class-based → factory function           |
-| `new FRDevice(config?).getProfile({ location, metadata })` | `deviceClient(config).profile.get(query)`                   | `DeviceProfileData` → `ProfileDevice[] \| { error }` | Returns error object instead of throwing |
+| Legacy API                                                 | New API                                                     | Return Type Change | Behavioral Notes                                                 |
+| ---------------------------------------------------------- | ----------------------------------------------------------- | ------------------ | ---------------------------------------------------------------- |
+| `import { FRDevice } from '@forgerock/javascript-sdk'`     | `import { Device } from '@forgerock/journey-client/device'` | —                  | Class renamed `FRDevice` → `Device`. **Subpath import required** |
+| `new FRDevice(config?).getProfile({ location, metadata })` | `new Device(config?).getProfile({ location, metadata })`    | Same               | Same signature and return type (`DeviceProfileData`)             |
 
 ### deviceClient (Device CRUD Operations)
 

--- a/packages/journey-client/api-report/journey-client.api.md
+++ b/packages/journey-client/api-report/journey-client.api.md
@@ -19,6 +19,7 @@ import { isValidWellknownUrl } from '@forgerock/sdk-utilities';
 import { LogLevel } from '@forgerock/sdk-logger';
 import { NameValue } from '@forgerock/sdk-types';
 import { PolicyKey } from '@forgerock/sdk-types';
+import { PolicyParams } from '@forgerock/sdk-types';
 import { PolicyRequirement } from '@forgerock/sdk-types';
 import { RequestMiddleware } from '@forgerock/sdk-request-middleware';
 import { Step } from '@forgerock/sdk-types';
@@ -337,6 +338,8 @@ export class PingOneProtectInitializeCallback extends BaseCallback {
 }
 
 export { PolicyKey }
+
+export { PolicyParams }
 
 export { PolicyRequirement }
 

--- a/packages/journey-client/api-report/journey-client.types.api.md
+++ b/packages/journey-client/api-report/journey-client.types.api.md
@@ -18,6 +18,7 @@ import { isValidWellknownUrl } from '@forgerock/sdk-utilities';
 import { LogLevel } from '@forgerock/sdk-logger';
 import { NameValue } from '@forgerock/sdk-types';
 import { PolicyKey } from '@forgerock/sdk-types';
+import { PolicyParams } from '@forgerock/sdk-types';
 import { PolicyRequirement } from '@forgerock/sdk-types';
 import { RequestMiddleware } from '@forgerock/sdk-request-middleware';
 import { Step } from '@forgerock/sdk-types';
@@ -324,6 +325,8 @@ export class PingOneProtectInitializeCallback extends BaseCallback {
 }
 
 export { PolicyKey }
+
+export { PolicyParams }
 
 export { PolicyRequirement }
 

--- a/packages/journey-client/src/types.ts
+++ b/packages/journey-client/src/types.ts
@@ -12,17 +12,17 @@ export type {
   Step,
   Callback,
   CallbackType,
-  StepType,
   GenericError,
   PolicyRequirement,
   FailedPolicyRequirement,
   NameValue,
+  PolicyParams,
   StepDetail,
   AuthResponse,
   FailureDetail,
 } from '@forgerock/sdk-types';
 
-export { PolicyKey } from '@forgerock/sdk-types';
+export { PolicyKey, StepType } from '@forgerock/sdk-types';
 
 // Re-export local types
 export * from './lib/client.types.js';


### PR DESCRIPTION
# JIRA Ticket
https://pingidentity.atlassian.net/browse/SDKS-4796

## Description

- Exports `PolicyParams` from `@forgerock/journey-client/types` (was only accessible via `@forgerock/sdk-types`)
- Moves `callbackType` re-export from `index.ts` into `types.ts` alongside other value exports — no consumer impact
- Fixes `FRDevice` mapping in `interface_mapping.md`: was incorrectly pointing to `deviceClient` from `@forgerock/device-client`; it maps to `Device` from `@forgerock/journey-client/device`
- Adds migration guide sections to `MIGRATION.md`:
  - `StepOptions` to `StartParam` / `NextOptions` / `ResumeOptions` — covers the three implementation pain points not obvious from the type table
  - How to replace `new FRStep()`/`new FRLoginSuccess()`/`new FRLoginFailure()` with typed object literals for mocks and stories

## Did you add a changeset?
Yes — patch for `@forgerock/journey-client` (new `PolicyParams` export).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `PolicyParams` is now exported from journey-client types.
  * DaVinci start flow now supports OAuth Pushed Authorization Requests (PAR) and includes PAR utilities and endpoint handling.

* **Documentation**
  * Added migration guide for the updated authentication flow and journey-switching patterns.
  * Updated device interface docs and package mapping guidance.

* **Tests**
  * Added tests covering PAR utilities and config handling of PAR-related well-known fields.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ForgeRock/ping-javascript-sdk/pull/630)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->