### PR TITLE
feat: expose subscribe method on journey-client and oidc-client

### DIFF
--- a/.changeset/export-subscribe-method.md
+++ b/.changeset/export-subscribe-method.md
@@ -1,0 +1,6 @@
+---
+'@forgerock/journey-client': minor
+'@forgerock/oidc-client': minor
+---
+
+Expose `subscribe` method on journey and oidc client instances, consistent with davinci-client. Allows consumers to listen for store state changes.

--- a/packages/journey-client/api-report/journey-client.api.md
+++ b/packages/journey-client/api-report/journey-client.api.md
@@ -195,6 +195,8 @@ export interface JourneyClient {
     // (undocumented)
     start: (options?: StartParam) => Promise<JourneyResult>;
     // (undocumented)
+    subscribe: (listener: () => void) => () => void;
+    // (undocumented)
     terminate: (options?: {
         query?: Record<string, string>;
     }) => Promise<void | GenericError>;

--- a/packages/journey-client/api-report/journey-client.types.api.md
+++ b/packages/journey-client/api-report/journey-client.types.api.md
@@ -182,6 +182,8 @@ export interface JourneyClient {
     // (undocumented)
     start: (options?: StartParam) => Promise<JourneyResult>;
     // (undocumented)
+    subscribe: (listener: () => void) => () => void;
+    // (undocumented)
     terminate: (options?: {
         query?: Record<string, string>;
     }) => Promise<void | GenericError>;

--- a/packages/journey-client/src/lib/client.store.test.ts
+++ b/packages/journey-client/src/lib/client.store.test.ts
@@ -108,6 +108,7 @@ describe('journey-client', () => {
     expect(client.redirect).toBeInstanceOf(Function);
     expect(client.resume).toBeInstanceOf(Function);
     expect(client.terminate).toBeInstanceOf(Function);
+    expect(client.subscribe).toBeInstanceOf(Function);
   });
 
   test('journey_InvalidWellknownUrl_ThrowsError', async () => {

--- a/packages/journey-client/src/lib/client.store.ts
+++ b/packages/journey-client/src/lib/client.store.ts
@@ -36,6 +36,7 @@ export type JourneyResult = JourneyStep | JourneyLoginSuccess | JourneyLoginFail
 
 /** The journey client instance returned by the `journey()` function. */
 export interface JourneyClient {
+  subscribe: (listener: () => void) => () => void;
   start: (options?: StartParam) => Promise<JourneyResult>;
   next: (step: JourneyStep, options?: NextOptions) => Promise<JourneyResult>;
   redirect: (step: JourneyStep) => Promise<void>;
@@ -154,6 +155,8 @@ export async function journey<ActionType extends ActionTypes = ActionTypes>({
   });
 
   const self: JourneyClient = {
+    subscribe: store.subscribe,
+
     start: async (options?: StartParam) => {
       const { data } = await store.dispatch(journeyApi.endpoints.start.initiate(options));
       if (!data) {

--- a/packages/oidc-client/api-report/oidc-client.api.md
+++ b/packages/oidc-client/api-report/oidc-client.api.md
@@ -27,6 +27,7 @@ import { StoreEnhancer } from '@reduxjs/toolkit';
 import { ThunkDispatch } from '@reduxjs/toolkit';
 import { Tuple } from '@reduxjs/toolkit';
 import { UnknownAction } from '@reduxjs/toolkit';
+import { Unsubscribe } from '@reduxjs/toolkit';
 import { WellknownResponse } from '@forgerock/sdk-types';
 
 export { ActionTypes }
@@ -252,10 +253,12 @@ export function oidc<ActionType extends ActionTypes = ActionTypes>(input: {
 }): Promise<{
     error: string;
     type: string;
+    subscribe?: undefined;
     authorize?: undefined;
     token?: undefined;
     user?: undefined;
 } | {
+    subscribe: (listener: () => void) => Unsubscribe;
     authorize: {
         url: (options?: GetAuthorizationUrlOptions) => Promise<string | GenericError>;
         background: (options?: GetAuthorizationUrlOptions) => Promise<AuthorizationSuccess | AuthorizationError>;

--- a/packages/oidc-client/api-report/oidc-client.types.api.md
+++ b/packages/oidc-client/api-report/oidc-client.types.api.md
@@ -27,6 +27,7 @@ import { StoreEnhancer } from '@reduxjs/toolkit';
 import { ThunkDispatch } from '@reduxjs/toolkit';
 import { Tuple } from '@reduxjs/toolkit';
 import { UnknownAction } from '@reduxjs/toolkit';
+import { Unsubscribe } from '@reduxjs/toolkit';
 import { WellknownResponse } from '@forgerock/sdk-types';
 
 export { ActionTypes }
@@ -252,10 +253,12 @@ export function oidc<ActionType extends ActionTypes = ActionTypes>(input: {
 }): Promise<{
     error: string;
     type: string;
+    subscribe?: undefined;
     authorize?: undefined;
     token?: undefined;
     user?: undefined;
 } | {
+    subscribe: (listener: () => void) => Unsubscribe;
     authorize: {
         url: (options?: GetAuthorizationUrlOptions) => Promise<string | GenericError>;
         background: (options?: GetAuthorizationUrlOptions) => Promise<AuthorizationSuccess | AuthorizationError>;

--- a/packages/oidc-client/src/lib/client.store.test.ts
+++ b/packages/oidc-client/src/lib/client.store.test.ts
@@ -129,6 +129,18 @@ describe('PingOne token get method', async () => {
     expect(tokens.error).toBe('No tokens found');
   });
 
+  it('exposes a subscribe method', async () => {
+    const oidcClient = await oidc({ config, storage: customStorageConfig });
+
+    if ('error' in oidcClient) {
+      throw new Error('Error creating OIDC Client');
+    }
+
+    expect(oidcClient.subscribe).toBeInstanceOf(Function);
+    const unsubscribe = oidcClient.subscribe(vi.fn());
+    expect(unsubscribe).toBeInstanceOf(Function);
+  });
+
   it('Get tokens', async () => {
     customStorage.set(
       storageKey,

--- a/packages/oidc-client/src/lib/client.store.ts
+++ b/packages/oidc-client/src/lib/client.store.ts
@@ -95,6 +95,9 @@ export async function oidc<ActionType extends ActionTypes = ActionTypes>({
   }
 
   return {
+    // Pass store methods to the client
+    subscribe: store.subscribe,
+
     /**
      * An object containing methods for the creation, and background use, of the authorization URL
      */


### PR DESCRIPTION
## Summary

- Adds `subscribe` to the `JourneyClient` interface and exposes `store.subscribe` from the `journey()` factory function
- Exposes `store.subscribe` from the `oidc()` factory function
- Aligns both packages with the existing pattern in `davinci-client`

## Changeset

Minor bump for `@forgerock/journey-client` and `@forgerock/oidc-client` — backwards-compatible public API addition.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Journey Client and OIDC Client now expose a subscribe(listener) method to listen for store state changes; subscribe returns an unsubscribe function for cleanup.

* **Tests**
  * Added tests to verify clients expose subscribe and that it returns an unsubscribe function.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ForgeRock/ping-javascript-sdk/pull/633?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->