### PR TITLE
test(davinci-client): add polling e2e tests

### DIFF
--- a/e2e/davinci-app/index.html
+++ b/e2e/davinci-app/index.html
@@ -15,9 +15,7 @@
         <a href="https://www.typescriptlang.org/" target="_blank">
           <img src="./public/typescript.svg" class="logo vanilla" alt="TypeScript logo" />
         </a>
-        <form id="form">
-          <div class="error-div"></div>
-        </form>
+        <form id="form"></form>
       </div>
     </div>
     <script type="module" src="main.ts"></script>

--- a/e2e/davinci-app/main.ts
+++ b/e2e/davinci-app/main.ts
@@ -177,7 +177,6 @@ const urlParams = new URLSearchParams(window.location.search);
     formEl.innerHTML = '';
 
     const clientInfo = davinciClient.getClient();
-    //const clientInfo = node.client;
 
     let formName = '';
 
@@ -191,11 +190,12 @@ const urlParams = new URLSearchParams(window.location.search);
 
     const error = davinciClient.getError();
     if (error) {
-      formEl.appendChild(document.createElement('div')).setAttribute('id', 'error-div');
-      const errorDiv = formEl.querySelector('#error-div');
-      if (errorDiv && clientInfo?.status === 'continue') {
+      const errorDiv = document.createElement('div');
+      formEl.appendChild(errorDiv).setAttribute('id', 'error-div');
+      if (errorDiv && clientInfo?.status === 'error') {
+        errorDiv.style.color = 'red';
         errorDiv.innerHTML = `
-          <div>${davinciClient.getError()?.message}</div>
+          <p><strong>Error</strong>: ${davinciClient.getError()?.message}</p>
         `;
       }
     }

--- a/e2e/davinci-app/server-configs.ts
+++ b/e2e/davinci-app/server-configs.ts
@@ -77,4 +77,16 @@ export const serverConfigs: Record<string, DaVinciConfig> = {
         'https://auth.pingone.ca/02fb4743-189a-4bc7-9d6c-a919edfe6447/as/.well-known/openid-configuration',
     },
   },
+  /**
+   * Polling
+   */
+  '31a587ce-9aa4-4f36-a09f-78cd8a0a74a0': {
+    clientId: '31a587ce-9aa4-4f36-a09f-78cd8a0a74a0',
+    redirectUri: window.location.origin + '/',
+    scope: 'openid profile email revoke',
+    serverConfig: {
+      wellknown:
+        'https://auth.pingone.ca/356a254c-cba3-4ade-be1a-860136e8df01/as/.well-known/openid-configuration',
+    },
+  },
 };

--- a/e2e/davinci-app/style.css
+++ b/e2e/davinci-app/style.css
@@ -81,6 +81,10 @@ input {
   color: #888;
 }
 
+.error {
+  color: red;
+}
+
 button {
   border-radius: 8px;
   border: 1px solid transparent;

--- a/e2e/davinci-suites/src/polling.test.ts
+++ b/e2e/davinci-suites/src/polling.test.ts
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+import { expect, test } from '@playwright/test';
+import { asyncEvents } from './utils/async-events.js';
+
+test.describe('Challenge Polling', () => {
+  test('should succeed when opening magic link', async ({ page, browser }) => {
+    const clientId = '31a587ce-9aa4-4f36-a09f-78cd8a0a74a0';
+    const davinciPolicy = 'f40b544a4dfb575daa0cf5e9487c206a';
+    const { navigate } = asyncEvents(page);
+    await navigate(`/?clientId=${clientId}&acr_values=${davinciPolicy}`);
+
+    await expect(page.url()).toBe(
+      `http://localhost:5829/?clientId=${clientId}&acr_values=${davinciPolicy}`,
+    );
+
+    await page.getByRole('button', { name: 'Sign On' }).click();
+    await expect(page.getByRole('heading', { name: 'Polling' })).toBeVisible();
+
+    // Get magic link
+    const linkLocator = page.getByText('Number Challenge https://auth.pingone');
+    await expect(linkLocator).toBeVisible();
+
+    const linkLocatorText = await linkLocator.innerText();
+    const magicLink = linkLocatorText.split('Number Challenge ')[1];
+    expect(magicLink).toContain('https://auth.pingone');
+
+    // Start polling
+    await page.getByRole('button', { name: 'Start polling' }).click();
+    await expect(page.getByText('Polling...')).toBeVisible();
+
+    // Go to magic link in another browser to complete challenge
+    const newContext = await browser.newContext();
+    const newPage = await newContext.newPage();
+    await newPage.goto(magicLink);
+    await expect(newPage.getByText('Close me')).toBeVisible();
+    await newContext.close();
+
+    // Check for success
+    await expect(page.getByText('Message: approved')).toBeVisible();
+  });
+
+  test('should timeout when retries are exhausted', async ({ page }) => {
+    const clientId = '31a587ce-9aa4-4f36-a09f-78cd8a0a74a0';
+    const davinciPolicy = 'f40b544a4dfb575daa0cf5e9487c206a';
+    const { navigate } = asyncEvents(page);
+    await navigate(`/?clientId=${clientId}&acr_values=${davinciPolicy}`);
+
+    await expect(page.url()).toBe(
+      `http://localhost:5829/?clientId=${clientId}&acr_values=${davinciPolicy}`,
+    );
+
+    await page.getByRole('button', { name: 'Sign On' }).click();
+    await expect(page.getByRole('heading', { name: 'Polling' })).toBeVisible();
+
+    // Track poll retries
+    let numPollRequests = 0;
+    page.on('request', (request) => {
+      const method = request.method();
+      const requestUrl = request.url();
+
+      if (method === 'POST' && requestUrl.includes('/status')) {
+        numPollRequests++;
+      }
+    });
+
+    // Start polling
+    await page.getByRole('button', { name: 'Start polling' }).click();
+    await expect(page.getByText('Polling...')).toBeVisible();
+
+    // Wait for timeout
+    const pollInterval = 2000; // milliseconds
+    const maxRetries = 5;
+    await expect(page.getByText('Error: timedOut')).toBeVisible({
+      timeout: 2 * pollInterval * maxRetries,
+    });
+
+    // Check max retry count
+    expect(numPollRequests).toBe(maxRetries);
+  });
+
+  test('should return expired status after challenge expires', async ({ page }) => {
+    const clientId = '31a587ce-9aa4-4f36-a09f-78cd8a0a74a0';
+    const davinciPolicy = 'f40b544a4dfb575daa0cf5e9487c206a';
+    const { navigate } = asyncEvents(page);
+    await navigate(`/?clientId=${clientId}&acr_values=${davinciPolicy}`);
+
+    await expect(page.url()).toBe(
+      `http://localhost:5829/?clientId=${clientId}&acr_values=${davinciPolicy}`,
+    );
+
+    await page.getByRole('button', { name: 'Sign On' }).click();
+    await expect(page.getByRole('heading', { name: 'Polling' })).toBeVisible();
+
+    // Track poll retries
+    let numPollRequests = 0;
+    page.on('request', (request) => {
+      const method = request.method();
+      const requestUrl = request.url();
+
+      if (method === 'POST' && requestUrl.includes('/status')) {
+        numPollRequests++;
+      }
+    });
+
+    // Wait for challenge to expire
+    const challengeExpiry = 15000; // milliseconds
+    await page.waitForTimeout(challengeExpiry + 5000);
+
+    // Start polling
+    await page.getByRole('button', { name: 'Start polling' }).click();
+    await expect(page.getByText('Polling...')).toBeVisible();
+
+    // Check for expired status
+    await expect(page.getByText('Error: expired')).toBeVisible();
+
+    // Check poll count
+    expect(numPollRequests).toBe(1);
+  });
+});
+
+test.describe('Continue Polling', () => {
+  test('should succeed on QR code scan simulation', async ({ page }) => {
+    const clientId = '31a587ce-9aa4-4f36-a09f-78cd8a0a74a0';
+    const davinciPolicy = '27aacf0efcc480dfcd00b04be8023cdc';
+    const { navigate } = asyncEvents(page);
+    await navigate(`/?clientId=${clientId}&acr_values=${davinciPolicy}`);
+
+    await expect(page.url()).toBe(
+      `http://localhost:5829/?clientId=${clientId}&acr_values=${davinciPolicy}`,
+    );
+
+    await expect(page.getByRole('heading', { name: 'Select Continue Polling Test' })).toBeVisible();
+    await page.getByRole('button', { name: 'Success' }).click();
+    await expect(page.getByRole('heading', { name: 'Polling' })).toBeVisible();
+
+    // Start polling
+    const numberCounterSuccess = 2;
+    for (let i = 0; i < numberCounterSuccess; i++) {
+      await page.getByRole('button', { name: 'Start polling' }).click();
+      await expect(page.getByText('Polling...')).toBeVisible();
+      await expect(page.getByRole('button', { name: 'Start polling' })).toBeDisabled();
+    }
+
+    // Check for success
+    await expect(page.getByText('Message: Done')).toBeVisible();
+  });
+
+  test('should timeout when retries are exhausted', async ({ page }) => {
+    const clientId = '31a587ce-9aa4-4f36-a09f-78cd8a0a74a0';
+    const davinciPolicy = '27aacf0efcc480dfcd00b04be8023cdc';
+    const { navigate } = asyncEvents(page);
+    await navigate(`/?clientId=${clientId}&acr_values=${davinciPolicy}`);
+
+    await expect(page.url()).toBe(
+      `http://localhost:5829/?clientId=${clientId}&acr_values=${davinciPolicy}`,
+    );
+
+    await expect(page.getByRole('heading', { name: 'Select Continue Polling Test' })).toBeVisible();
+    await page.getByRole('button', { name: 'Timeout' }).click();
+    await expect(page.getByRole('heading', { name: 'Polling' })).toBeVisible();
+
+    // Start polling
+    const maxRetries = 3;
+    for (let i = 0; i < maxRetries + 1; i++) {
+      await page.getByRole('button', { name: 'Start polling' }).click();
+      await expect(page.getByText('Polling...')).toBeVisible();
+      await expect(page.getByRole('button', { name: 'Start polling' })).toBeDisabled();
+    }
+
+    // Check for timeout
+    await expect(page.getByText('Error: timedOut')).toBeVisible();
+  });
+});

--- a/e2e/davinci-suites/src/protect.test.ts
+++ b/e2e/davinci-suites/src/protect.test.ts
@@ -17,7 +17,7 @@ test('Test Protect collector with Custom HTML component', async ({ page }) => {
 
   await expect(page.getByText('JS Protect - Custom HTML Form')).toBeVisible();
 
-  const requests = [];
+  const requests: string[] = [];
   page.on('request', (request) => {
     const method = request.method();
     const requestUrl = request.url();
@@ -54,7 +54,7 @@ test('Test Protect collector with P1 Forms component', async ({ page }) => {
 
   await expect(page.getByText('Example - Sign On')).toBeVisible();
 
-  const requests = [];
+  const requests: string[] = [];
   page.on('request', (request) => {
     const method = request.method();
     const requestUrl = request.url();

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -5,9 +5,6 @@ pre-commit:
     nx-check:
       run: pnpm nx affected -t typecheck lint build api-report --tui=false
       stage_fixed: true
-    format:
-      run: pnpm nx format:write
-      stage_fixed: true
     interface-mapping:
       glob: >-
         {tools/interface-mapping-validator/**/*.ts,
@@ -24,7 +21,9 @@ pre-commit:
          echo "Interface mapping is out of sync." &&
          echo "Run: pnpm mapping:generate" &&
          exit 1)
-
+    format:
+      run: pnpm nx format:write
+      stage_fixed: true
 commit-msg:
   commands:
     commitlint:


### PR DESCRIPTION
# JIRA Ticket
https://pingidentity.atlassian.net/browse/SDKS-4929

## Description

## Core Change: New E2E Polling Test Suite

[`e2e/davinci-suites/src/polling.test.ts`](e2e/davinci-suites/src/polling.test.ts) — 5 Playwright tests across two polling scenarios:

### Challenge Polling (3 tests)
- **Magic link success** — opens the link in a second browser context to complete the challenge
- **Timeout on exhausted retries** — lets 5 retries × 2s interval expire, asserts `Error: timedOut`
- **Expired challenge** — waits 20s for expiry before polling, asserts `Error: expired`

### Continue Polling (2 tests)
- **QR code scan simulation success** — polls twice, asserts `Message: Done`
- **Timeout on exhausted retries** — exceeds `maxRetries` (3), asserts `Error: timedOut`

## Supporting Changes

| File | Change |
|------|--------|
| [`e2e/davinci-app/server-configs.ts`](e2e/davinci-app/server-configs.ts) | New DaVinci client config for polling flows (SDK Web Team tenant) |
| [`e2e/davinci-app/main.ts`](e2e/davinci-app/main.ts) | Fixed error display: only shows when `clientInfo.status === 'error'`; error div styled red inline |
| [`e2e/davinci-app/index.html`](e2e/davinci-app/index.html) | Removed static `#error-div` (now created dynamically) |
| [`e2e/davinci-app/style.css`](e2e/davinci-app/style.css) | Added `.error { color: red; }` utility class |
| [`lefthook.yml`](lefthook.yml) | Reordered pre-commit hooks (`format` now runs after `interface-mapping`) |
| [`e2e/davinci-suites/src/protect.test.ts`](e2e/davinci-suites/src/protect.test.ts) | Added explicit `string[]` type annotations (TypeScript strictness) |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added polling functionality with Challenge and Continue flows.
  * Added a new tenant configuration for authentication testing.

* **Bug Fixes**
  * Improved error handling and UI error display; added visible error styling.

* **Tests**
  * Added comprehensive end-to-end tests covering polling success, timeout, and expiry paths.

* **Chores**
  * Adjusted pre-commit hook ordering for formatting checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ForgeRock/ping-javascript-sdk/pull/634?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->