### PR TITLE
test(davinci-client): e2e tests for agreements, single checkbox, rich text

### DIFF
--- a/.changeset/single-checkbox.md
+++ b/.changeset/single-checkbox.md
@@ -2,10 +2,12 @@
 '@forgerock/davinci-client': minor
 ---
 
-Adds support for the SINGLE_CHECKBOX field. A new ValidatedBooleanCollector type was introduced including validation support for required checkboxes and updater support for booleans.
+Adds support for the SINGLE_CHECKBOX field. A new ValidatedBooleanCollector interface was introduced including validation support for required checkboxes and updater support for booleans.
 
 **Type improvements**
 
 - `SingleValueCollectorWithValue<T, V>` and `ValidatedSingleValueCollectorWithValue<T, V>` are now generic over their value type (`V`, defaults to `string`), replacing the loose `string | number | boolean` union
+
+- `ValidatedBooleanCollector` interface extends `ValidatedSingleValueCollectorWithValue`, intersecting `output` with `appearance: string` and `richContent?: CollectorRichContent`
 
 - `Validator` is now generic over collector type `T`, replacing the hardcoded `string` input with `CollectorValueType<T>` — so validators receive the value type that matches their collector (e.g. `boolean` for `ValidatedBooleanCollector`, `string` for text collectors) rather than always `string`

--- a/e2e/davinci-app/components/boolean.ts
+++ b/e2e/davinci-app/components/boolean.ts
@@ -9,13 +9,14 @@ import type {
   Updater,
   Validator,
 } from '@forgerock/davinci-client/types';
-import { dotToCamelCase } from '../helper.js';
+import { dotToCamelCase, richContentInterpolation } from '../helper.js';
 
 /**
  * Creates a single checkbox and attaches it to the form
  * @param {HTMLFormElement} formEl - The form element to attach the checkbox to
  * @param {ValidatedBooleanCollector} collector - Contains the configuration
  * @param {Updater} updater - Function to call when selection changes
+ * @param {Validator} validator - Function to validate the input
  */
 export default function booleanComponent(
   formEl: HTMLFormElement,
@@ -36,13 +37,22 @@ export default function booleanComponent(
   const checkbox = document.createElement('input');
   checkbox.type = 'checkbox';
   checkbox.id = collectorKey;
-  checkbox.name = collectorKey || 'single-checkbox-field';
+  checkbox.name = collectorKey;
   checkbox.checked = collector.output.value;
   checkbox.value = 'checked';
 
   const label = document.createElement('label');
   label.htmlFor = checkbox.id;
-  label.textContent = collector.output.label;
+
+  const { richContent } = collector.output;
+  if (!richContent || richContent.replacements.length === 0) {
+    label.textContent = collector.output.label;
+  } else {
+    const pRichText = richContentInterpolation(richContent);
+    while (pRichText.firstChild) {
+      label.appendChild(pRichText.firstChild);
+    }
+  }
 
   // Add event listener to handle single-select behavior
   checkbox.addEventListener('change', (event) => {
@@ -50,20 +60,20 @@ export default function booleanComponent(
     const result = validator(checked);
     const errorEl = formEl?.querySelector(`.${collectorKey}-error`);
 
-    // Keep collector state aligned with the current UI value
-    const updateError = updater(checked);
-    if (updateError && 'error' in updateError) {
-      console.error(updateError.error.message);
-    }
-
     // Validate the input
     if (Array.isArray(result) && result.length && !errorEl) {
-      const errorEl = document.createElement('div');
-      errorEl.className = `${collectorKey}-error`;
-      errorEl.innerText = result.join(', ');
-      formEl?.querySelector(`#${collectorKey}`)?.after(errorEl);
+      const newErrorEl = document.createElement('div');
+      newErrorEl.className = `${collectorKey}-error`;
+      newErrorEl.innerText = result.join(', ');
+      formEl?.querySelector(`#${collectorKey}`)?.after(newErrorEl);
+    } else if (Array.isArray(result) && result.length) {
+      return;
     } else {
       formEl.querySelector(`.${collectorKey}-error`)?.remove();
+      const updateError = updater(checked);
+      if (updateError && 'error' in updateError) {
+        console.error(updateError.error.message);
+      }
     }
   });
 

--- a/e2e/davinci-app/components/boolean.ts
+++ b/e2e/davinci-app/components/boolean.ts
@@ -4,11 +4,16 @@
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
  */
-import type { ValidatedBooleanCollector, Updater } from '@forgerock/davinci-client/types';
+import type {
+  ValidatedBooleanCollector,
+  Updater,
+  Validator,
+} from '@forgerock/davinci-client/types';
+import { dotToCamelCase } from '../helper.js';
 
 /**
  * Creates a single checkbox and attaches it to the form
- * @param {HTMLFormElement} formEl - The form element to attach the checkboxes to
+ * @param {HTMLFormElement} formEl - The form element to attach the checkbox to
  * @param {ValidatedBooleanCollector} collector - Contains the configuration
  * @param {Updater} updater - Function to call when selection changes
  */
@@ -16,25 +21,22 @@ export default function booleanComponent(
   formEl: HTMLFormElement,
   collector: ValidatedBooleanCollector,
   updater: Updater<ValidatedBooleanCollector>,
+  validator: Validator<ValidatedBooleanCollector>,
 ) {
-  // Create a container for the checkboxes
+  const collectorKey = dotToCamelCase(collector.output.key);
+
+  // Create a container for the checkbox
   const containerDiv = document.createElement('div');
   containerDiv.className = 'single-checkbox-container';
 
-  // Create a heading/label for the checkbox group
-  const groupLabel = document.createElement('div');
-  groupLabel.textContent = collector.output.label || 'Single Checkbox';
-  groupLabel.className = 'single-checkbox-label';
-  containerDiv.appendChild(groupLabel);
-
-  // Create checkboxes for each option
+  // Create a single checkbox
   const wrapper = document.createElement('div');
   wrapper.className = 'checkbox-wrapper';
 
   const checkbox = document.createElement('input');
   checkbox.type = 'checkbox';
-  checkbox.id = collector.output.key;
-  checkbox.name = collector.output.key || 'single-checkbox-field';
+  checkbox.id = collectorKey;
+  checkbox.name = collectorKey || 'single-checkbox-field';
   checkbox.checked = collector.output.value;
   checkbox.value = 'checked';
 
@@ -44,8 +46,25 @@ export default function booleanComponent(
 
   // Add event listener to handle single-select behavior
   checkbox.addEventListener('change', (event) => {
-    const target = event.target as HTMLInputElement;
-    updater(target.checked);
+    const checked = (event.target as HTMLInputElement).checked;
+    const result = validator(checked);
+    const errorEl = formEl?.querySelector(`.${collectorKey}-error`);
+
+    // Keep collector state aligned with the current UI value
+    const updateError = updater(checked);
+    if (updateError && 'error' in updateError) {
+      console.error(updateError.error.message);
+    }
+
+    // Validate the input
+    if (Array.isArray(result) && result.length && !errorEl) {
+      const errorEl = document.createElement('div');
+      errorEl.className = `${collectorKey}-error`;
+      errorEl.innerText = result.join(', ');
+      formEl?.querySelector(`#${collectorKey}`)?.after(errorEl);
+    } else {
+      formEl.querySelector(`.${collectorKey}-error`)?.remove();
+    }
   });
 
   wrapper.appendChild(checkbox);

--- a/e2e/davinci-app/components/label.ts
+++ b/e2e/davinci-app/components/label.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/e2e/davinci-app/components/label.ts
+++ b/e2e/davinci-app/components/label.ts
@@ -5,6 +5,7 @@
  * of the MIT license. See the LICENSE file for details.
  */
 import type { ReadOnlyCollector, RichTextCollector } from '@forgerock/davinci-client/types';
+import { richContentInterpolation } from '../helper.js';
 
 export default function (
   formEl: HTMLFormElement,
@@ -28,32 +29,7 @@ export default function (
   }
 
   // Interpolate the template by splitting on {{key}} and inserting links
-  const segments = richContent.content.split(/\{\{(\w+)\}\}/);
-  const replacementMap = new Map(richContent.replacements.map((r) => [r.key, r]));
+  const pRichText = richContentInterpolation(richContent);
 
-  for (let i = 0; i < segments.length; i++) {
-    if (i % 2 === 0) {
-      // Text segment
-      if (segments[i]) {
-        p.appendChild(document.createTextNode(segments[i]));
-      }
-    } else {
-      // Replacement key
-      const replacement = replacementMap.get(segments[i]);
-      if (replacement?.type === 'link') {
-        const a = document.createElement('a');
-        a.href = replacement.href;
-        a.textContent = replacement.value;
-        if (replacement.target) {
-          a.target = replacement.target;
-          if (replacement.target === '_blank') {
-            a.rel = 'noopener noreferrer';
-          }
-        }
-        p.appendChild(a);
-      }
-    }
-  }
-
-  formEl?.appendChild(p);
+  formEl?.appendChild(pRichText);
 }

--- a/e2e/davinci-app/components/text.ts
+++ b/e2e/davinci-app/components/text.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/e2e/davinci-app/components/text.ts
+++ b/e2e/davinci-app/components/text.ts
@@ -16,7 +16,7 @@ export default function textComponent(
   formEl: HTMLFormElement,
   collector: TextCollector | ValidatedTextCollector,
   updater: Updater<TextCollector | ValidatedTextCollector>,
-  validator: Validator,
+  validator: Validator<ValidatedTextCollector>,
 ) {
   const collectorKey = dotToCamelCase(collector.output.key);
   const label = document.createElement('label');

--- a/e2e/davinci-app/helper.ts
+++ b/e2e/davinci-app/helper.ts
@@ -1,9 +1,11 @@
 /*
- * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
  */
+import type { CollectorRichContent } from '@forgerock/davinci-client';
+
 export function dotToCamelCase(str: string) {
   return str
     .split('.')
@@ -11,4 +13,39 @@ export function dotToCamelCase(str: string) {
       index === 0 ? part.toLowerCase() : part.charAt(0).toUpperCase() + part.slice(1).toLowerCase(),
     )
     .join('');
+}
+
+// Interpolate the template by splitting on {{key}} and inserting links
+export function richContentInterpolation(richContent: CollectorRichContent): HTMLParagraphElement {
+  const p = document.createElement('p');
+  p.style.whiteSpace = 'pre-line';
+
+  const segments = richContent.content.split(/\{\{(\w+)\}\}/);
+  const replacementMap = new Map(richContent.replacements.map((r) => [r.key, r]));
+
+  for (let i = 0; i < segments.length; i++) {
+    if (i % 2 === 0) {
+      // Text segment
+      if (segments[i]) {
+        p.appendChild(document.createTextNode(segments[i]));
+      }
+    } else {
+      // Replacement key
+      const replacement = replacementMap.get(segments[i]);
+      if (replacement?.type === 'link') {
+        const a = document.createElement('a');
+        a.href = replacement.href;
+        a.textContent = replacement.value;
+        if (replacement.target) {
+          a.target = replacement.target;
+          if (replacement.target === '_blank') {
+            a.rel = 'noopener noreferrer';
+          }
+        }
+        p.appendChild(a);
+      }
+    }
+  }
+
+  return p;
 }

--- a/e2e/davinci-app/main.ts
+++ b/e2e/davinci-app/main.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/e2e/davinci-app/main.ts
+++ b/e2e/davinci-app/main.ts
@@ -300,7 +300,12 @@ const urlParams = new URLSearchParams(window.location.search);
       } else if (collector.type === 'MultiSelectCollector') {
         multiValueComponent(formEl, collector, davinciClient.update(collector));
       } else if (collector.type === 'ValidatedBooleanCollector') {
-        booleanComponent(formEl, collector, davinciClient.update(collector));
+        booleanComponent(
+          formEl,
+          collector,
+          davinciClient.update(collector),
+          davinciClient.validate(collector),
+        );
       }
     });
 

--- a/e2e/davinci-app/server-configs.ts
+++ b/e2e/davinci-app/server-configs.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/e2e/davinci-app/server-configs.ts
+++ b/e2e/davinci-app/server-configs.ts
@@ -46,13 +46,16 @@ export const serverConfigs: Record<string, DaVinciConfig> = {
         'https://auth.pingone.ca/02fb4743-189a-4bc7-9d6c-a919edfe6447/as/.well-known/openid-configuration',
     },
   },
-  '60de77d5-dd2c-41ef-8c40-f8bb2381a359': {
-    clientId: '60de77d5-dd2c-41ef-8c40-f8bb2381a359',
+  /**
+   * Form Fields
+   */
+  'e4ef2896-8d90-4abd-bf0f-7b8034995927': {
+    clientId: 'e4ef2896-8d90-4abd-bf0f-7b8034995927',
     redirectUri: window.location.origin + '/',
     scope: 'openid profile email name revoke',
     serverConfig: {
       wellknown:
-        'https://auth.pingone.ca/02fb4743-189a-4bc7-9d6c-a919edfe6447/as/.well-known/openid-configuration',
+        'https://auth.pingone.ca/356a254c-cba3-4ade-be1a-860136e8df01/as/.well-known/openid-configuration',
     },
   },
   /**

--- a/e2e/davinci-suites/src/form-fields.test.ts
+++ b/e2e/davinci-suites/src/form-fields.test.ts
@@ -10,9 +10,9 @@ import { asyncEvents } from './utils/async-events.js';
 
 test('Should render form fields', async ({ page }) => {
   const { navigate } = asyncEvents(page);
-  await navigate('/?clientId=60de77d5-dd2c-41ef-8c40-f8bb2381a359');
+  await navigate('/?clientId=e4ef2896-8d90-4abd-bf0f-7b8034995927');
 
-  await expect(page.getByText('Select Test Form')).toBeVisible();
+  await expect(page.getByText('Select Form Fields Test Form')).toBeVisible();
   await page.getByRole('button', { name: 'Form Fields' }).click();
 
   await expect(page.getByText('Form Fields Test')).toBeVisible();
@@ -34,6 +34,32 @@ test('Should render form fields', async ({ page }) => {
   await page.locator('#phone-number-input-1').fill('1234567890');
   await page.locator('#extension-input-1').fill('7890');
 
+  // Rich text should render a link
+  await expect(page.getByRole('link', { name: 'Ping Identity' })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Ping Identity' })).toHaveAttribute(
+    'href',
+    'https://www.pingidentity.com',
+  );
+
+  // Agreement title and content should be visible
+  await expect(page.getByRole('heading', { name: 'Terms of Service Agreement' })).toBeVisible();
+  await expect(
+    page.getByText(
+      'This is example agreement text, you can edit this text in the agreements section.',
+    ),
+  ).toBeVisible();
+
+  // Single checkbox default value
+  await expect(page.locator('#single-checkbox-field')).not.toBeChecked();
+  await expect(page.getByText('I agree to the Terms and Conditions')).toBeVisible();
+
+  // Toggle the single checkbox and assert that it is optional by the abscence of an error message
+  await page.locator('#single-checkbox-field').check();
+  await expect(page.locator('#single-checkbox-field')).toBeChecked();
+  await page.locator('#single-checkbox-field').uncheck();
+  await expect(page.locator('#single-checkbox-field')).not.toBeChecked();
+  await expect(page.locator('.single-checkbox-field-error')).not.toBeAttached();
+
   await expect(page.getByRole('button', { name: 'Flow Button' })).toBeVisible();
   await expect(page.getByRole('button', { name: 'Flow Link' })).toBeVisible();
 
@@ -53,20 +79,20 @@ test('Should render form fields', async ({ page }) => {
     'checkbox-field-key': ['option1 value', 'option2 value'],
     'dropdown-field-key': 'dropdown-option2-value',
     'radio-group-key': 'option2 value',
-    'single-checkbox-field': false,
     'combobox-field-key': ['option1 value', 'option3 value'],
     'phone-field': {
       phoneNumber: '1234567890',
       countryCode: 'GB',
       extension: '7890', // Tests PhoneNumberExtensionCollector
     },
+    'single-checkbox-field': false,
   });
 });
 
 test('should render form validation fields', async ({ page }) => {
-  await page.goto('http://localhost:5829/?clientId=60de77d5-dd2c-41ef-8c40-f8bb2381a359');
+  await page.goto('http://localhost:5829/?clientId=e4ef2896-8d90-4abd-bf0f-7b8034995927');
 
-  await expect(page.getByText('Select Test Form')).toBeVisible();
+  await expect(page.getByText('Select Form Fields Test Form')).toBeVisible();
 
   await page.getByRole('button', { name: 'Form Validation' }).click();
 
@@ -80,4 +106,9 @@ test('should render form validation fields', async ({ page }) => {
 
   await page.getByRole('textbox', { name: 'Email Address' }).fill('abc@email.com');
   await expect(page.getByText('Not a valid email')).not.toBeVisible();
+
+  // Toggle the single checkbox to assert error message
+  await page.locator('#single-checkbox-field').check();
+  await page.locator('#single-checkbox-field').uncheck();
+  await expect(page.getByText('Select the checkbox to continue.')).toBeVisible();
 });

--- a/e2e/davinci-suites/src/form-fields.test.ts
+++ b/e2e/davinci-suites/src/form-fields.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/e2e/davinci-suites/src/form-fields.test.ts
+++ b/e2e/davinci-suites/src/form-fields.test.ts
@@ -51,9 +51,16 @@ test('Should render form fields', async ({ page }) => {
 
   // Single checkbox default value
   await expect(page.locator('#single-checkbox-field')).not.toBeChecked();
-  await expect(page.getByText('I agree to the Terms and Conditions')).toBeVisible();
 
-  // Toggle the single checkbox and assert that it is optional by the abscence of an error message
+  // Single checkbox rich text
+  await expect(page.getByText('I agree to the Terms and Conditions')).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Terms and Conditions' })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Terms and Conditions' })).toHaveAttribute(
+    'href',
+    'https://www.pingidentity.com',
+  );
+
+  // Toggle the single checkbox and assert that it is optional by the absence of an error message
   await page.locator('#single-checkbox-field').check();
   await expect(page.locator('#single-checkbox-field')).toBeChecked();
   await page.locator('#single-checkbox-field').uncheck();
@@ -90,7 +97,8 @@ test('Should render form fields', async ({ page }) => {
 });
 
 test('should render form validation fields', async ({ page }) => {
-  await page.goto('http://localhost:5829/?clientId=e4ef2896-8d90-4abd-bf0f-7b8034995927');
+  const { navigate } = asyncEvents(page);
+  await navigate('/?clientId=e4ef2896-8d90-4abd-bf0f-7b8034995927');
 
   await expect(page.getByText('Select Form Fields Test Form')).toBeVisible();
 

--- a/packages/davinci-client/api-report/davinci-client.api.md
+++ b/packages/davinci-client/api-report/davinci-client.api.md
@@ -334,8 +334,6 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         eventName?: string;
         status: "continue";
     } | {
-        status: "start";
-    } | {
         _links?: Links;
         eventName?: string;
         id?: string;
@@ -394,14 +392,14 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         } & Omit<{
             requestId: string;
             data?: unknown;
-            error?: SerializedError | FetchBaseQueryError | undefined;
+            error?: FetchBaseQueryError | SerializedError | undefined;
             endpointName: string;
             startedTimeStamp: number;
             fulfilledTimeStamp?: number;
         }, "data" | "fulfilledTimeStamp"> & Required<Pick<{
             requestId: string;
             data?: unknown;
-            error?: SerializedError | FetchBaseQueryError | undefined;
+            error?: FetchBaseQueryError | SerializedError | undefined;
             endpointName: string;
             startedTimeStamp: number;
             fulfilledTimeStamp?: number;
@@ -418,7 +416,7 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         } & {
             requestId: string;
             data?: unknown;
-            error?: SerializedError | FetchBaseQueryError | undefined;
+            error?: FetchBaseQueryError | SerializedError | undefined;
             endpointName: string;
             startedTimeStamp: number;
             fulfilledTimeStamp?: number;
@@ -435,14 +433,14 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         } & Omit<{
             requestId: string;
             data?: unknown;
-            error?: SerializedError | FetchBaseQueryError | undefined;
+            error?: FetchBaseQueryError | SerializedError | undefined;
             endpointName: string;
             startedTimeStamp: number;
             fulfilledTimeStamp?: number;
         }, "error"> & Required<Pick<{
             requestId: string;
             data?: unknown;
-            error?: SerializedError | FetchBaseQueryError | undefined;
+            error?: FetchBaseQueryError | SerializedError | undefined;
             endpointName: string;
             startedTimeStamp: number;
             fulfilledTimeStamp?: number;
@@ -489,14 +487,14 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         } & Omit<{
             requestId: string;
             data?: unknown;
-            error?: SerializedError | FetchBaseQueryError | undefined;
+            error?: FetchBaseQueryError | SerializedError | undefined;
             endpointName: string;
             startedTimeStamp: number;
             fulfilledTimeStamp?: number;
         }, "data" | "fulfilledTimeStamp"> & Required<Pick<{
             requestId: string;
             data?: unknown;
-            error?: SerializedError | FetchBaseQueryError | undefined;
+            error?: FetchBaseQueryError | SerializedError | undefined;
             endpointName: string;
             startedTimeStamp: number;
             fulfilledTimeStamp?: number;
@@ -513,7 +511,7 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         } & {
             requestId: string;
             data?: unknown;
-            error?: SerializedError | FetchBaseQueryError | undefined;
+            error?: FetchBaseQueryError | SerializedError | undefined;
             endpointName: string;
             startedTimeStamp: number;
             fulfilledTimeStamp?: number;
@@ -530,14 +528,14 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         } & Omit<{
             requestId: string;
             data?: unknown;
-            error?: SerializedError | FetchBaseQueryError | undefined;
+            error?: FetchBaseQueryError | SerializedError | undefined;
             endpointName: string;
             startedTimeStamp: number;
             fulfilledTimeStamp?: number;
         }, "error"> & Required<Pick<{
             requestId: string;
             data?: unknown;
-            error?: SerializedError | FetchBaseQueryError | undefined;
+            error?: FetchBaseQueryError | SerializedError | undefined;
             endpointName: string;
             startedTimeStamp: number;
             fulfilledTimeStamp?: number;

--- a/packages/davinci-client/api-report/davinci-client.api.md
+++ b/packages/davinci-client/api-report/davinci-client.api.md
@@ -394,14 +394,14 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         } & Omit<{
             requestId: string;
             data?: unknown;
-            error?: FetchBaseQueryError | SerializedError | undefined;
+            error?: SerializedError | FetchBaseQueryError | undefined;
             endpointName: string;
             startedTimeStamp: number;
             fulfilledTimeStamp?: number;
         }, "data" | "fulfilledTimeStamp"> & Required<Pick<{
             requestId: string;
             data?: unknown;
-            error?: FetchBaseQueryError | SerializedError | undefined;
+            error?: SerializedError | FetchBaseQueryError | undefined;
             endpointName: string;
             startedTimeStamp: number;
             fulfilledTimeStamp?: number;
@@ -418,7 +418,7 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         } & {
             requestId: string;
             data?: unknown;
-            error?: FetchBaseQueryError | SerializedError | undefined;
+            error?: SerializedError | FetchBaseQueryError | undefined;
             endpointName: string;
             startedTimeStamp: number;
             fulfilledTimeStamp?: number;
@@ -435,14 +435,14 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         } & Omit<{
             requestId: string;
             data?: unknown;
-            error?: FetchBaseQueryError | SerializedError | undefined;
+            error?: SerializedError | FetchBaseQueryError | undefined;
             endpointName: string;
             startedTimeStamp: number;
             fulfilledTimeStamp?: number;
         }, "error"> & Required<Pick<{
             requestId: string;
             data?: unknown;
-            error?: FetchBaseQueryError | SerializedError | undefined;
+            error?: SerializedError | FetchBaseQueryError | undefined;
             endpointName: string;
             startedTimeStamp: number;
             fulfilledTimeStamp?: number;
@@ -489,14 +489,14 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         } & Omit<{
             requestId: string;
             data?: unknown;
-            error?: FetchBaseQueryError | SerializedError | undefined;
+            error?: SerializedError | FetchBaseQueryError | undefined;
             endpointName: string;
             startedTimeStamp: number;
             fulfilledTimeStamp?: number;
         }, "data" | "fulfilledTimeStamp"> & Required<Pick<{
             requestId: string;
             data?: unknown;
-            error?: FetchBaseQueryError | SerializedError | undefined;
+            error?: SerializedError | FetchBaseQueryError | undefined;
             endpointName: string;
             startedTimeStamp: number;
             fulfilledTimeStamp?: number;
@@ -513,7 +513,7 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         } & {
             requestId: string;
             data?: unknown;
-            error?: FetchBaseQueryError | SerializedError | undefined;
+            error?: SerializedError | FetchBaseQueryError | undefined;
             endpointName: string;
             startedTimeStamp: number;
             fulfilledTimeStamp?: number;
@@ -530,14 +530,14 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         } & Omit<{
             requestId: string;
             data?: unknown;
-            error?: FetchBaseQueryError | SerializedError | undefined;
+            error?: SerializedError | FetchBaseQueryError | undefined;
             endpointName: string;
             startedTimeStamp: number;
             fulfilledTimeStamp?: number;
         }, "error"> & Required<Pick<{
             requestId: string;
             data?: unknown;
-            error?: FetchBaseQueryError | SerializedError | undefined;
+            error?: SerializedError | FetchBaseQueryError | undefined;
             endpointName: string;
             startedTimeStamp: number;
             fulfilledTimeStamp?: number;
@@ -1683,6 +1683,8 @@ export type SingleCheckboxField = {
     label: string;
     required: boolean;
     errorMessage?: string;
+    appearance: string;
+    richContent?: RichContent;
 };
 
 // @public (undocumented)
@@ -1936,7 +1938,13 @@ index?: number;
 export type Updater<T = unknown> = (value: CollectorValueType<T>, index?: number) => InternalErrorResponse | null;
 
 // @public (undocumented)
-export type ValidatedBooleanCollector = ValidatedSingleValueCollectorWithValue<'ValidatedBooleanCollector', boolean>;
+export interface ValidatedBooleanCollector extends ValidatedSingleValueCollectorWithValue<'ValidatedBooleanCollector', boolean> {
+    // (undocumented)
+    output: ValidatedSingleValueCollectorWithValue<'ValidatedBooleanCollector', boolean>['output'] & {
+        appearance: string;
+        richContent?: CollectorRichContent;
+    };
+}
 
 // @public (undocumented)
 export type ValidatedField = {

--- a/packages/davinci-client/api-report/davinci-client.api.md
+++ b/packages/davinci-client/api-report/davinci-client.api.md
@@ -294,13 +294,11 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
     resume: (input: {
         continueToken: string;
     }) => Promise<InternalErrorResponse | NodeStates>;
-    start: <QueryParams extends OutgoingQueryParams = OutgoingQueryParams>(options?: StartOptions<QueryParams> | undefined) => Promise<ContinueNode | ErrorNode | StartNode | SuccessNode | FailureNode>;
+    start: <QueryParams extends OutgoingQueryParams = OutgoingQueryParams>(options?: StartOptions<QueryParams> | undefined) => Promise<ContinueNode | ErrorNode | FailureNode | StartNode | SuccessNode>;
     update: <T extends SingleValueCollectors | MultiSelectCollector | ObjectValueCollectors | AutoCollectors>(collector: T) => Updater<T>;
     validate: (collector: SingleValueCollectors | ObjectValueCollectors | MultiValueCollectors | AutoCollectors) => Validator;
     pollStatus: (collector: PollingCollector) => Poller;
     getClient: () => {
-        status: "start";
-    } | {
         action: string;
         collectors: Collectors[];
         description?: string;
@@ -313,18 +311,20 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         name?: string;
         status: "error";
     } | {
+        status: "failure";
+    } | {
+        status: "start";
+    } | {
         authorization?: {
             code?: string;
             state?: string;
         };
         status: "success";
-    } | {
-        status: "failure";
     } | null;
     getCollectors: () => Collectors[];
     getError: () => DaVinciError | null;
     getErrorCollectors: () => CollectorErrors[];
-    getNode: () => ContinueNode | ErrorNode | StartNode | SuccessNode | FailureNode;
+    getNode: () => ContinueNode | ErrorNode | FailureNode | StartNode | SuccessNode;
     getServer: () => {
         _links?: Links;
         id?: string;
@@ -345,20 +345,22 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
     } | {
         _links?: Links;
         eventName?: string;
+        href?: string;
+        id?: string;
+        interactionId?: string;
+        interactionToken?: string;
+        status: "failure";
+    } | {
+        status: "start";
+    } | {
+        _links?: Links;
+        eventName?: string;
         id?: string;
         interactionId?: string;
         interactionToken?: string;
         href?: string;
         session?: string;
         status: "success";
-    } | {
-        _links?: Links;
-        eventName?: string;
-        href?: string;
-        id?: string;
-        interactionId?: string;
-        interactionToken?: string;
-        status: "failure";
     } | null;
     cache: {
         getLatestResponse: () => ((state: RootState<    {
@@ -1680,9 +1682,7 @@ export type SingleCheckboxField = {
     key: string;
     label: string;
     required: boolean;
-    validation?: {
-        errorMessage: string;
-    };
+    errorMessage?: string;
 };
 
 // @public (undocumented)

--- a/packages/davinci-client/api-report/davinci-client.types.api.md
+++ b/packages/davinci-client/api-report/davinci-client.types.api.md
@@ -294,13 +294,11 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
     resume: (input: {
         continueToken: string;
     }) => Promise<InternalErrorResponse | NodeStates>;
-    start: <QueryParams extends OutgoingQueryParams = OutgoingQueryParams>(options?: StartOptions<QueryParams> | undefined) => Promise<ContinueNode | ErrorNode | StartNode | SuccessNode | FailureNode>;
+    start: <QueryParams extends OutgoingQueryParams = OutgoingQueryParams>(options?: StartOptions<QueryParams> | undefined) => Promise<ContinueNode | ErrorNode | FailureNode | StartNode | SuccessNode>;
     update: <T extends SingleValueCollectors | MultiSelectCollector | ObjectValueCollectors | AutoCollectors>(collector: T) => Updater<T>;
     validate: (collector: SingleValueCollectors | ObjectValueCollectors | MultiValueCollectors | AutoCollectors) => Validator;
     pollStatus: (collector: PollingCollector) => Poller;
     getClient: () => {
-        status: "start";
-    } | {
         action: string;
         collectors: Collectors[];
         description?: string;
@@ -313,18 +311,20 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         name?: string;
         status: "error";
     } | {
+        status: "failure";
+    } | {
+        status: "start";
+    } | {
         authorization?: {
             code?: string;
             state?: string;
         };
         status: "success";
-    } | {
-        status: "failure";
     } | null;
     getCollectors: () => Collectors[];
     getError: () => DaVinciError | null;
     getErrorCollectors: () => CollectorErrors[];
-    getNode: () => ContinueNode | ErrorNode | StartNode | SuccessNode | FailureNode;
+    getNode: () => ContinueNode | ErrorNode | FailureNode | StartNode | SuccessNode;
     getServer: () => {
         _links?: Links;
         id?: string;
@@ -345,20 +345,22 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
     } | {
         _links?: Links;
         eventName?: string;
+        href?: string;
+        id?: string;
+        interactionId?: string;
+        interactionToken?: string;
+        status: "failure";
+    } | {
+        status: "start";
+    } | {
+        _links?: Links;
+        eventName?: string;
         id?: string;
         interactionId?: string;
         interactionToken?: string;
         href?: string;
         session?: string;
         status: "success";
-    } | {
-        _links?: Links;
-        eventName?: string;
-        href?: string;
-        id?: string;
-        interactionId?: string;
-        interactionToken?: string;
-        status: "failure";
     } | null;
     cache: {
         getLatestResponse: () => ((state: RootState<    {
@@ -1677,9 +1679,7 @@ export type SingleCheckboxField = {
     key: string;
     label: string;
     required: boolean;
-    validation?: {
-        errorMessage: string;
-    };
+    errorMessage?: string;
 };
 
 // @public (undocumented)

--- a/packages/davinci-client/api-report/davinci-client.types.api.md
+++ b/packages/davinci-client/api-report/davinci-client.types.api.md
@@ -334,8 +334,6 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         eventName?: string;
         status: "continue";
     } | {
-        status: "start";
-    } | {
         _links?: Links;
         eventName?: string;
         id?: string;
@@ -394,14 +392,14 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         } & Omit<{
             requestId: string;
             data?: unknown;
-            error?: SerializedError | FetchBaseQueryError | undefined;
+            error?: FetchBaseQueryError | SerializedError | undefined;
             endpointName: string;
             startedTimeStamp: number;
             fulfilledTimeStamp?: number;
         }, "data" | "fulfilledTimeStamp"> & Required<Pick<{
             requestId: string;
             data?: unknown;
-            error?: SerializedError | FetchBaseQueryError | undefined;
+            error?: FetchBaseQueryError | SerializedError | undefined;
             endpointName: string;
             startedTimeStamp: number;
             fulfilledTimeStamp?: number;
@@ -418,7 +416,7 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         } & {
             requestId: string;
             data?: unknown;
-            error?: SerializedError | FetchBaseQueryError | undefined;
+            error?: FetchBaseQueryError | SerializedError | undefined;
             endpointName: string;
             startedTimeStamp: number;
             fulfilledTimeStamp?: number;
@@ -435,14 +433,14 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         } & Omit<{
             requestId: string;
             data?: unknown;
-            error?: SerializedError | FetchBaseQueryError | undefined;
+            error?: FetchBaseQueryError | SerializedError | undefined;
             endpointName: string;
             startedTimeStamp: number;
             fulfilledTimeStamp?: number;
         }, "error"> & Required<Pick<{
             requestId: string;
             data?: unknown;
-            error?: SerializedError | FetchBaseQueryError | undefined;
+            error?: FetchBaseQueryError | SerializedError | undefined;
             endpointName: string;
             startedTimeStamp: number;
             fulfilledTimeStamp?: number;
@@ -489,14 +487,14 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         } & Omit<{
             requestId: string;
             data?: unknown;
-            error?: SerializedError | FetchBaseQueryError | undefined;
+            error?: FetchBaseQueryError | SerializedError | undefined;
             endpointName: string;
             startedTimeStamp: number;
             fulfilledTimeStamp?: number;
         }, "data" | "fulfilledTimeStamp"> & Required<Pick<{
             requestId: string;
             data?: unknown;
-            error?: SerializedError | FetchBaseQueryError | undefined;
+            error?: FetchBaseQueryError | SerializedError | undefined;
             endpointName: string;
             startedTimeStamp: number;
             fulfilledTimeStamp?: number;
@@ -513,7 +511,7 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         } & {
             requestId: string;
             data?: unknown;
-            error?: SerializedError | FetchBaseQueryError | undefined;
+            error?: FetchBaseQueryError | SerializedError | undefined;
             endpointName: string;
             startedTimeStamp: number;
             fulfilledTimeStamp?: number;
@@ -530,14 +528,14 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         } & Omit<{
             requestId: string;
             data?: unknown;
-            error?: SerializedError | FetchBaseQueryError | undefined;
+            error?: FetchBaseQueryError | SerializedError | undefined;
             endpointName: string;
             startedTimeStamp: number;
             fulfilledTimeStamp?: number;
         }, "error"> & Required<Pick<{
             requestId: string;
             data?: unknown;
-            error?: SerializedError | FetchBaseQueryError | undefined;
+            error?: FetchBaseQueryError | SerializedError | undefined;
             endpointName: string;
             startedTimeStamp: number;
             fulfilledTimeStamp?: number;

--- a/packages/davinci-client/api-report/davinci-client.types.api.md
+++ b/packages/davinci-client/api-report/davinci-client.types.api.md
@@ -394,14 +394,14 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         } & Omit<{
             requestId: string;
             data?: unknown;
-            error?: FetchBaseQueryError | SerializedError | undefined;
+            error?: SerializedError | FetchBaseQueryError | undefined;
             endpointName: string;
             startedTimeStamp: number;
             fulfilledTimeStamp?: number;
         }, "data" | "fulfilledTimeStamp"> & Required<Pick<{
             requestId: string;
             data?: unknown;
-            error?: FetchBaseQueryError | SerializedError | undefined;
+            error?: SerializedError | FetchBaseQueryError | undefined;
             endpointName: string;
             startedTimeStamp: number;
             fulfilledTimeStamp?: number;
@@ -418,7 +418,7 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         } & {
             requestId: string;
             data?: unknown;
-            error?: FetchBaseQueryError | SerializedError | undefined;
+            error?: SerializedError | FetchBaseQueryError | undefined;
             endpointName: string;
             startedTimeStamp: number;
             fulfilledTimeStamp?: number;
@@ -435,14 +435,14 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         } & Omit<{
             requestId: string;
             data?: unknown;
-            error?: FetchBaseQueryError | SerializedError | undefined;
+            error?: SerializedError | FetchBaseQueryError | undefined;
             endpointName: string;
             startedTimeStamp: number;
             fulfilledTimeStamp?: number;
         }, "error"> & Required<Pick<{
             requestId: string;
             data?: unknown;
-            error?: FetchBaseQueryError | SerializedError | undefined;
+            error?: SerializedError | FetchBaseQueryError | undefined;
             endpointName: string;
             startedTimeStamp: number;
             fulfilledTimeStamp?: number;
@@ -489,14 +489,14 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         } & Omit<{
             requestId: string;
             data?: unknown;
-            error?: FetchBaseQueryError | SerializedError | undefined;
+            error?: SerializedError | FetchBaseQueryError | undefined;
             endpointName: string;
             startedTimeStamp: number;
             fulfilledTimeStamp?: number;
         }, "data" | "fulfilledTimeStamp"> & Required<Pick<{
             requestId: string;
             data?: unknown;
-            error?: FetchBaseQueryError | SerializedError | undefined;
+            error?: SerializedError | FetchBaseQueryError | undefined;
             endpointName: string;
             startedTimeStamp: number;
             fulfilledTimeStamp?: number;
@@ -513,7 +513,7 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         } & {
             requestId: string;
             data?: unknown;
-            error?: FetchBaseQueryError | SerializedError | undefined;
+            error?: SerializedError | FetchBaseQueryError | undefined;
             endpointName: string;
             startedTimeStamp: number;
             fulfilledTimeStamp?: number;
@@ -530,14 +530,14 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         } & Omit<{
             requestId: string;
             data?: unknown;
-            error?: FetchBaseQueryError | SerializedError | undefined;
+            error?: SerializedError | FetchBaseQueryError | undefined;
             endpointName: string;
             startedTimeStamp: number;
             fulfilledTimeStamp?: number;
         }, "error"> & Required<Pick<{
             requestId: string;
             data?: unknown;
-            error?: FetchBaseQueryError | SerializedError | undefined;
+            error?: SerializedError | FetchBaseQueryError | undefined;
             endpointName: string;
             startedTimeStamp: number;
             fulfilledTimeStamp?: number;
@@ -1680,6 +1680,8 @@ export type SingleCheckboxField = {
     label: string;
     required: boolean;
     errorMessage?: string;
+    appearance: string;
+    richContent?: RichContent;
 };
 
 // @public (undocumented)
@@ -1933,7 +1935,13 @@ index?: number;
 export type Updater<T = unknown> = (value: CollectorValueType<T>, index?: number) => InternalErrorResponse | null;
 
 // @public (undocumented)
-export type ValidatedBooleanCollector = ValidatedSingleValueCollectorWithValue<'ValidatedBooleanCollector', boolean>;
+export interface ValidatedBooleanCollector extends ValidatedSingleValueCollectorWithValue<'ValidatedBooleanCollector', boolean> {
+    // (undocumented)
+    output: ValidatedSingleValueCollectorWithValue<'ValidatedBooleanCollector', boolean>['output'] & {
+        appearance: string;
+        richContent?: CollectorRichContent;
+    };
+}
 
 // @public (undocumented)
 export type ValidatedField = {

--- a/packages/davinci-client/src/lib/collector.types.test-d.ts
+++ b/packages/davinci-client/src/lib/collector.types.test-d.ts
@@ -434,6 +434,7 @@ describe('Collector Types', () => {
           label: 'Accept terms',
           type: 'boolean',
           value: false,
+          appearance: 'CHECKBOX',
         },
       };
 

--- a/packages/davinci-client/src/lib/collector.types.test-d.ts
+++ b/packages/davinci-client/src/lib/collector.types.test-d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/packages/davinci-client/src/lib/collector.types.ts
+++ b/packages/davinci-client/src/lib/collector.types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/packages/davinci-client/src/lib/collector.types.ts
+++ b/packages/davinci-client/src/lib/collector.types.ts
@@ -93,6 +93,16 @@ export interface ValidatedSingleValueCollectorWithValue<
   };
 }
 
+export interface ValidatedBooleanCollector extends ValidatedSingleValueCollectorWithValue<
+  'ValidatedBooleanCollector',
+  boolean
+> {
+  output: ValidatedSingleValueCollectorWithValue<'ValidatedBooleanCollector', boolean>['output'] & {
+    appearance: string;
+    richContent?: CollectorRichContent;
+  };
+}
+
 export interface SingleSelectCollectorWithValue<T extends SingleValueCollectorTypes> {
   category: 'SingleValueCollector';
   error: string | null;
@@ -227,10 +237,6 @@ export interface ValidatedPasswordCollector {
 export type TextCollector = SingleValueCollectorWithValue<'TextCollector'>;
 export type SingleSelectCollector = SingleSelectCollectorWithValue<'SingleSelectCollector'>;
 export type ValidatedTextCollector = ValidatedSingleValueCollectorWithValue<'TextCollector'>;
-export type ValidatedBooleanCollector = ValidatedSingleValueCollectorWithValue<
-  'ValidatedBooleanCollector',
-  boolean
->;
 
 export type SingleValueCollectors =
   | ValidatedPasswordCollector

--- a/packages/davinci-client/src/lib/collector.utils.test.ts
+++ b/packages/davinci-client/src/lib/collector.utils.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/packages/davinci-client/src/lib/collector.utils.test.ts
+++ b/packages/davinci-client/src/lib/collector.utils.test.ts
@@ -26,6 +26,7 @@ import {
   returnQrCodeCollector,
   returnAgreementCollector,
   normalizeReplacements,
+  returnValidatedBooleanCollector,
 } from './collector.utils.js';
 import { returnPasswordPolicyValidator } from './password-policy.rules.js';
 import type {
@@ -43,6 +44,7 @@ import type {
   ReadOnlyField,
   RedirectField,
   RichContentReplacement,
+  SingleCheckboxField,
   StandardField,
   AgreementField,
 } from './davinci.types.js';
@@ -1779,5 +1781,55 @@ describe('returnPasswordPolicyValidator', () => {
     const result = validate('aaa');
     assert(Array.isArray(result));
     expect(result.length).toBeGreaterThanOrEqual(3);
+  });
+});
+
+describe('returnValidatedBooleanCollector', () => {
+  it('should include appearance on output', () => {
+    const field: SingleCheckboxField = {
+      type: 'SINGLE_CHECKBOX',
+      inputType: 'BOOLEAN',
+      key: 'accept-terms',
+      label: 'Accept Terms',
+      required: false,
+      appearance: 'checkbox',
+    };
+    const result = returnValidatedBooleanCollector(field, 0);
+    expect(result.output.appearance).toBe('checkbox');
+  });
+
+  it('should include richContent on output when field has richContent', () => {
+    const field: SingleCheckboxField = {
+      type: 'SINGLE_CHECKBOX',
+      inputType: 'BOOLEAN',
+      key: 'accept-terms',
+      label: 'Accept Terms',
+      required: false,
+      appearance: 'checkbox',
+      richContent: {
+        content: 'I agree to the {{link}}',
+        replacements: {
+          link: {
+            type: 'link',
+            value: 'terms and conditions',
+            href: 'https://example.com/terms',
+            target: '_blank',
+          },
+        },
+      },
+    };
+    const result = returnValidatedBooleanCollector(field, 0);
+    expect(result.output.richContent).toEqual({
+      content: 'I agree to the {{link}}',
+      replacements: [
+        {
+          key: 'link',
+          type: 'link',
+          value: 'terms and conditions',
+          href: 'https://example.com/terms',
+          target: '_blank',
+        },
+      ],
+    });
   });
 });

--- a/packages/davinci-client/src/lib/collector.utils.ts
+++ b/packages/davinci-client/src/lib/collector.utils.ts
@@ -64,6 +64,27 @@ import type {
 } from './davinci.types.js';
 
 /**
+ * @function normalizeReplacements - Flattens the API's keyed
+ * `Record<string, RichContentReplacement>` into an array of `RichContentLink`
+ * with the original key carried on each entry. Hrefs are passed through
+ * unmodified — consumers are responsible for sanitizing before rendering.
+ *
+ * @param {Record<string, RichContentReplacement>} replacements - The replacements map from the API.
+ * @returns {RichContentLink[]} The flattened array of replacement entries.
+ */
+export function normalizeReplacements(
+  replacements: Record<string, RichContentReplacement>,
+): RichContentLink[] {
+  return Object.entries(replacements).map(([key, replacement]) => ({
+    key,
+    type: replacement.type,
+    value: replacement.value,
+    href: replacement.href,
+    ...(replacement.target && { target: replacement.target }),
+  }));
+}
+
+/**
  * @function returnActionCollector - Creates an ActionCollector object based on the provided field and index.
  * @param {DaVinciField} field - The field object containing key, label, type, and links.
  * @param {number} idx - The index to be used in the id of the ActionCollector.
@@ -263,6 +284,14 @@ export function returnSingleValueCollector<
       });
     }
 
+    const richContent =
+      'richContent' in field && field.richContent
+        ? {
+            content: field.richContent.content,
+            replacements: normalizeReplacements(field.richContent.replacements ?? {}),
+          }
+        : undefined;
+
     return {
       category: 'ValidatedSingleValueCollector',
       error: error || null,
@@ -280,6 +309,8 @@ export function returnSingleValueCollector<
         label: field.label,
         type: field.type,
         value: false,
+        appearance: ('appearance' in field && field.appearance) || '',
+        ...(richContent && { richContent }),
       },
     } as InferSingleValueCollectorType<'ValidatedBooleanCollector'>;
   } else if ('validation' in field || 'required' in field) {
@@ -560,8 +591,15 @@ export function returnSingleSelectCollector(field: SingleSelectField, idx: numbe
  * @param {number} idx - The index to be used in the id of the ValidatedBooleanCollector.
  * @returns {ValidatedBooleanCollector} The constructed ValidatedBooleanCollector object.
  */
-export function returnValidatedBooleanCollector(field: SingleCheckboxField, idx: number) {
-  return returnSingleValueCollector(field, idx, 'ValidatedBooleanCollector');
+export function returnValidatedBooleanCollector(
+  field: SingleCheckboxField,
+  idx: number,
+): ValidatedBooleanCollector {
+  return returnSingleValueCollector(
+    field,
+    idx,
+    'ValidatedBooleanCollector',
+  ) as ValidatedBooleanCollector;
 }
 
 /**
@@ -853,27 +891,6 @@ export function returnObjectValueCollector(
     'PhoneNumberCollector',
     prefillData as PhoneNumberOutputValue,
   );
-}
-
-/**
- * @function normalizeReplacements - Flattens the API's keyed
- * `Record<string, RichContentReplacement>` into an array of `RichContentLink`
- * with the original key carried on each entry. Hrefs are passed through
- * unmodified — consumers are responsible for sanitizing before rendering.
- *
- * @param {Record<string, RichContentReplacement>} replacements - The replacements map from the API.
- * @returns {RichContentLink[]} The flattened array of replacement entries.
- */
-export function normalizeReplacements(
-  replacements: Record<string, RichContentReplacement>,
-): RichContentLink[] {
-  return Object.entries(replacements).map(([key, replacement]) => ({
-    key,
-    type: replacement.type,
-    value: replacement.value,
-    href: replacement.href,
-    ...(replacement.target && { target: replacement.target }),
-  }));
 }
 
 /**

--- a/packages/davinci-client/src/lib/collector.utils.ts
+++ b/packages/davinci-client/src/lib/collector.utils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/packages/davinci-client/src/lib/collector.utils.ts
+++ b/packages/davinci-client/src/lib/collector.utils.ts
@@ -258,8 +258,7 @@ export function returnSingleValueCollector<
     if ('required' in field && field.required === true) {
       validationArray.push({
         type: 'required',
-        message:
-          ('validation' in field && field.validation?.errorMessage) || 'Value cannot be empty',
+        message: ('errorMessage' in field && field.errorMessage) || 'Value cannot be empty',
         rule: true,
       });
     }

--- a/packages/davinci-client/src/lib/davinci.types.ts
+++ b/packages/davinci-client/src/lib/davinci.types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/packages/davinci-client/src/lib/davinci.types.ts
+++ b/packages/davinci-client/src/lib/davinci.types.ts
@@ -178,6 +178,8 @@ export type SingleCheckboxField = {
   label: string;
   required: boolean;
   errorMessage?: string;
+  appearance: string;
+  richContent?: RichContent;
 };
 
 export type SingleSelectField = {

--- a/packages/davinci-client/src/lib/davinci.types.ts
+++ b/packages/davinci-client/src/lib/davinci.types.ts
@@ -177,9 +177,7 @@ export type SingleCheckboxField = {
   key: string;
   label: string;
   required: boolean;
-  validation?: {
-    errorMessage: string;
-  };
+  errorMessage?: string;
 };
 
 export type SingleSelectField = {

--- a/packages/davinci-client/src/lib/node.reducer.test.ts
+++ b/packages/davinci-client/src/lib/node.reducer.test.ts
@@ -1699,7 +1699,7 @@ describe('The node collector reducer with ValidatedBooleanCollector', () => {
             key: 'accept-terms',
             label: 'Accept Terms',
             required: true,
-            validation: { errorMessage: 'You must accept the terms' },
+            errorMessage: 'You must accept the terms',
           },
         ],
         formData: {},

--- a/packages/davinci-client/src/lib/node.reducer.test.ts
+++ b/packages/davinci-client/src/lib/node.reducer.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/packages/davinci-client/src/lib/node.reducer.test.ts
+++ b/packages/davinci-client/src/lib/node.reducer.test.ts
@@ -1643,6 +1643,7 @@ describe('The node collector reducer with ValidatedBooleanCollector', () => {
           label: 'Accept Terms',
           type: 'SINGLE_CHECKBOX',
           value: false,
+          appearance: '',
         },
       } satisfies ValidatedBooleanCollector,
     ]);
@@ -1683,6 +1684,7 @@ describe('The node collector reducer with ValidatedBooleanCollector', () => {
           label: 'Accept Terms',
           type: 'SINGLE_CHECKBOX',
           value: false,
+          appearance: '',
         },
       } satisfies ValidatedBooleanCollector,
     ]);
@@ -1738,6 +1740,7 @@ describe('The node collector reducer with ValidatedBooleanCollector', () => {
           label: 'Accept Terms',
           type: 'SINGLE_CHECKBOX',
           value: false,
+          appearance: 'checkbox',
         },
       },
     ];
@@ -1759,8 +1762,74 @@ describe('The node collector reducer with ValidatedBooleanCollector', () => {
           label: 'Accept Terms',
           type: 'SINGLE_CHECKBOX',
           value: false,
+          appearance: 'checkbox',
         },
       },
+    ]);
+  });
+
+  it('should normalise richContent replacements from Record to RichContentLink[]', () => {
+    const action = {
+      type: 'node/next',
+      payload: {
+        fields: [
+          {
+            type: 'SINGLE_CHECKBOX',
+            inputType: 'BOOLEAN',
+            key: 'accept-terms',
+            label: 'Accept Terms',
+            required: false,
+            appearance: 'checkbox',
+            richContent: {
+              content: 'I agree to the {{tos}}',
+              replacements: {
+                tos: {
+                  type: 'link',
+                  value: 'Terms of Service',
+                  href: 'https://example.com/tos',
+                  target: '_blank',
+                },
+              },
+            },
+          },
+        ],
+        formData: {},
+      },
+    };
+    const result = nodeCollectorReducer(undefined, action);
+    expect(result).toEqual([
+      {
+        category: 'ValidatedSingleValueCollector',
+        error: null,
+        type: 'ValidatedBooleanCollector',
+        id: 'accept-terms-0',
+        name: 'accept-terms',
+        input: {
+          key: 'accept-terms',
+          value: false,
+          type: 'SINGLE_CHECKBOX',
+          validation: [],
+        },
+        output: {
+          key: 'accept-terms',
+          label: 'Accept Terms',
+          type: 'SINGLE_CHECKBOX',
+          value: false,
+          appearance: 'checkbox',
+          richContent: {
+            content: 'I agree to the {{tos}}',
+            replacements: [
+              {
+                key: 'tos',
+                type: 'link',
+                value: 'Terms of Service',
+                href: 'https://example.com/tos',
+                target: '_blank',
+              },
+            ],
+          },
+        },
+      } satisfies ValidatedBooleanCollector,
     ]);
   });
 });


### PR DESCRIPTION


# JIRA Ticket
https://pingidentity.atlassian.net/browse/SDKS-5000

## Description

- Extends e2e coverage for agreements, rich text, and single checkbox fields; fixes `SingleCheckboxField` type to match the actual server payload. 
- Moves Form Fields Test flow to new web tenant. 
- Adds `appearance: string` and optional `richContent` to `ValidatedBooleanCollector`, following the `RichTextCollector` pattern.

### Key Changes

- **`SingleCheckboxField` type** — flattened `validation.errorMessage` into a top-level `errorMessage?: string` to match the server shape. Updated `collector.utils.ts` and regenerated API reports.
- **`booleanComponent`** — wired in `Validator<ValidatedBooleanCollector>` so the checkbox runs client-side validation and renders inline errors on change.
- **`server-configs.ts`** — swapped client ID to a PingOne environment that includes the updated form fields flow.
- **`form-fields.test.ts`** — added assertions for rich text link rendering, agreement visibility, single checkbox default state, and required-field error on uncheck.
- **SDK** — `SingleCheckboxField` extended with the new properties for `appearance` and rich text. `ValidatedBooleanCollector` refactored to an interface extending `ValidatedSingleValueCollectorWithValue`, intersecting `output` with the new fields. Factory logic updated to populate them via `normalizeReplacements`. API reports regenerated.
- **Tests** — Unit tests for `returnValidatedBooleanCollector` (5 cases), a reducer-level `richContent` round-trip test, and updated existing assertions to include `appearance`.
- **E2E app** — `richContentInterpolation` extracted as a shared helper. `boolean.ts` renders rich text labels via safe DOM node moves and fixes the error display to only call `updater` on valid input.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ForgeRock/ping-javascript-sdk/pull/638?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added single-checkbox fields with required validation, customizable error messages, appearance options, and rich-text/link rendering.

* **Tests**
  * Expanded end-to-end and unit tests to cover checkbox behavior, validation messaging, rich-text interpolation, and form submission data.

* **Chores**
  * Updated TypeScript API/typing surfaces for checkbox/validation shapes and added local ignore rules for development artifacts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ForgeRock/ping-javascript-sdk/pull/638?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for single checkbox form fields with validation
  * Implemented form field validation with customizable error messages
  * Introduced rich text content rendering in form fields, including link support

* **Tests**
  * Enhanced form validation test coverage for checkbox fields and validation messaging

* **Chores**
  * Updated Git configuration to ignore local artifacts

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ForgeRock/ping-javascript-sdk/pull/638?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->