### PR TITLE
chore(copyright): add sync-header-years script and tests

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -32,6 +32,48 @@ export default [
       '**/out-tsc',
       '**/test-output',
     ],
+  },
+  {
+    files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx', '**/*.mjs', '**/*.cjs'],
+    ignores: [
+      '**/*.test.*',
+      '**/*.spec.*',
+      '**/vite.config.*',
+      '**/vitest.config.*',
+      '**/vitest.setup.*',
+      '**/eslint.config.*',
+    ],
+    plugins: {
+      'local-rules': {
+        rules: {
+          'ping-copyright': {
+            meta: {
+              type: 'suggestion',
+              messages: { missing: 'Missing Ping Identity copyright header.' },
+            },
+            create(context) {
+              return {
+                Program(node) {
+                  const src = context.getSourceCode();
+                  const comments = src.getAllComments();
+                  const first = comments[0];
+                  if (
+                    !first ||
+                    first.range[0] > 0 ||
+                    !/Copyright[\s\S]*Ping Identity/i.test(first.value)
+                  ) {
+                    context.report({ node, messageId: 'missing' });
+                  }
+                },
+              };
+            },
+          },
+        },
+      },
+    },
+    rules: {
+      'local-rules/ping-copyright': 'warn',
+    },
   },
   ...compat.extends('plugin:@typescript-eslint/recommended', 'plugin:prettier/recommended'),
   {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -32,6 +32,41 @@ export default [
       '**/out-tsc',
       '**/test-output',
     ],
+  },
+  {
+    files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx', '**/*.mjs', '**/*.cjs'],
+    ignores: ['**/vite.config.*', '**/vitest.config.*', '**/vitest.setup.*', '**/eslint.config.*'],
+    plugins: {
+      'local-rules': {
+        rules: {
+          'ping-copyright': {
+            meta: {
+              type: 'suggestion',
+              messages: { missing: 'Missing Ping Identity copyright header.' },
+            },
+            create(context) {
+              return {
+                Program(node) {
+                  const src = context.getSourceCode();
+                  const comments = src.getAllComments();
+                  const first = comments[0];
+                  if (
+                    !first ||
+                    first.range[0] > 0 ||
+                    !/Copyright[\s\S]*Ping Identity/i.test(first.value)
+                  ) {
+                    context.report({ node, messageId: 'missing' });
+                  }
+                },
+              };
+            },
+          },
+        },
+      },
+    },
+    rules: {
+      'local-rules/ping-copyright': 'warn',
+    },
   },
   ...compat.extends('plugin:@typescript-eslint/recommended', 'plugin:prettier/recommended'),
   {

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -2,6 +2,9 @@ pre-commit:
   commands:
     nx-sync:
       run: pnpm nx sync
+    copyright-sync:
+      run: node tools/copyright/sync-header-years.mjs --fix
+      stage_fixed: true
     nx-check:
       run: pnpm nx affected -t typecheck lint build api-report --tui=false
       stage_fixed: true

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "circular-dep-check": "madge --circular .",
     "clean": "shx rm -rf ./{coverage,dist,docs,node_modules,tmp}/ ./{packages,e2e}/*/{dist,node_modules}/ ./e2e/node_modules/ && git clean -fX -e \"!.env*,nx-cloud.env\" -e \"!**/GEMINI.md\"",
     "commit": "git cz",
+    "copyright:check": "node tools/copyright/sync-header-years.mjs --check",
+    "copyright:sync": "node tools/copyright/sync-header-years.mjs --fix",
     "commitlint": "commitlint --edit",
     "create-package": "nx g @nx/js:library",
     "format": "pnpm nx format:write",
@@ -45,7 +47,6 @@
       "path": "./node_modules/cz-conventional-changelog"
     }
   },
-  "dependencies": {},
   "devDependencies": {
     "@changesets/changelog-github": "^0.6.0",
     "@changesets/cli": "^2.27.9",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "circular-dep-check": "madge --circular .",
     "clean": "shx rm -rf ./{coverage,dist,docs,node_modules,tmp}/ ./{packages,e2e}/*/{dist,node_modules}/ ./e2e/node_modules/ && git clean -fX -e \"!.env*,nx-cloud.env\"",
     "commit": "git cz",
+    "copyright:check": "node tools/copyright/sync-header-years.mjs --check",
+    "copyright:sync": "node tools/copyright/sync-header-years.mjs --fix",
     "commitlint": "commitlint --edit",
     "create-package": "nx g @nx/js:library",
     "format": "pnpm nx format:write",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,46 +5,15 @@ settings:
   excludeLinksFromLockfile: false
 
 catalogs:
-  default:
-    '@reduxjs/toolkit':
-      specifier: ^2.8.2
-      version: 2.10.1
-    immer:
-      specifier: ^10.1.1
-      version: 10.2.0
-    msw:
-      specifier: ^2.5.1
-      version: 2.12.1
   effect:
     '@effect/cli':
       specifier: ^0.69.0
       version: 0.69.2
-    '@effect/language-service':
-      specifier: ^0.35.2
-      version: 0.35.2
-    '@effect/opentelemetry':
-      specifier: ^0.56.1
-      version: 0.56.6
-    '@effect/platform':
-      specifier: ^0.90.0
-      version: 0.90.10
-    '@effect/platform-node':
-      specifier: 0.94.2
-      version: 0.94.2
-    '@effect/vitest':
-      specifier: ^0.27.0
-      version: 0.27.0
-    effect:
-      specifier: ^3.20.0
-      version: 3.20.0
   vite:
     vite:
       specifier: ^7.3.2
       version: 7.3.2
   vitest:
-    '@vitest/coverage-v8':
-      specifier: ^3.2.0
-      version: 3.2.4
     vitest:
       specifier: ^3.2.0
       version: 3.2.4
@@ -598,10 +567,10 @@ importers:
         version: 28.0.0
       tsx:
         specifier: ^4.20.0
-        version: 4.21.0
+        version: 4.20.6
       vitest:
         specifier: catalog:vitest
-        version: 3.2.4(@types/node@24.9.2)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(msw@2.12.1(@types/node@24.9.2)(typescript@5.9.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.1)
+        version: 3.2.4(@types/node@24.9.2)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(msw@2.12.1(@types/node@24.9.2)(typescript@5.9.3))(terser@5.46.2)(tsx@4.20.6)(yaml@2.8.1)
     devDependencies:
       '@forgerock/javascript-sdk':
         specifier: 4.9.0
@@ -8223,6 +8192,7 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -11974,7 +11944,7 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@24.9.2)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(msw@2.12.1(@types/node@24.9.2)(typescript@5.9.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.1)
+      vitest: 3.2.4(@types/node@24.9.2)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(msw@2.12.1(@types/node@24.9.2)(typescript@5.8.3))(terser@5.46.2)(tsx@4.20.6)(yaml@2.8.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -11995,14 +11965,14 @@ snapshots:
       msw: 2.12.1(@types/node@24.9.2)(typescript@5.8.3)
       vite: 7.3.2(@types/node@24.9.2)(jiti@2.6.1)(terser@5.46.2)(tsx@4.20.6)(yaml@2.8.1)
 
-  '@vitest/mocker@3.2.4(msw@2.12.1(@types/node@24.9.2)(typescript@5.9.3))(vite@7.3.2(@types/node@24.9.2)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.1))':
+  '@vitest/mocker@3.2.4(msw@2.12.1(@types/node@24.9.2)(typescript@5.9.3))(vite@7.3.2(@types/node@24.9.2)(jiti@2.6.1)(terser@5.46.2)(tsx@4.20.6)(yaml@2.8.1))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.12.1(@types/node@24.9.2)(typescript@5.9.3)
-      vite: 7.3.2(@types/node@24.9.2)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.1)
+      vite: 7.3.2(@types/node@24.9.2)(jiti@2.6.1)(terser@5.46.2)(tsx@4.20.6)(yaml@2.8.1)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -12033,7 +12003,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@24.9.2)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(msw@2.12.1(@types/node@24.9.2)(typescript@5.9.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.1)
+      vitest: 3.2.4(@types/node@24.9.2)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(msw@2.12.1(@types/node@24.9.2)(typescript@5.8.3))(terser@5.46.2)(tsx@4.20.6)(yaml@2.8.1)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -17511,7 +17481,7 @@ snapshots:
     dependencies:
       cssfontparser: 1.2.1
       moo-color: 1.0.3
-      vitest: 3.2.4(@types/node@24.9.2)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(msw@2.12.1(@types/node@24.9.2)(typescript@5.9.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.1)
+      vitest: 3.2.4(@types/node@24.9.2)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(msw@2.12.1(@types/node@24.9.2)(typescript@5.8.3))(terser@5.46.2)(tsx@4.20.6)(yaml@2.8.1)
 
   vitest@3.2.4(@types/node@24.9.2)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(msw@2.12.1(@types/node@24.9.2)(typescript@5.8.3))(terser@5.46.2)(tsx@4.20.6)(yaml@2.8.1):
     dependencies:
@@ -17556,11 +17526,54 @@ snapshots:
       - tsx
       - yaml
 
+  vitest@3.2.4(@types/node@24.9.2)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(msw@2.12.1(@types/node@24.9.2)(typescript@5.9.3))(terser@5.46.2)(tsx@4.20.6)(yaml@2.8.1):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(msw@2.12.1(@types/node@24.9.2)(typescript@5.9.3))(vite@7.3.2(@types/node@24.9.2)(jiti@2.6.1)(terser@5.46.2)(tsx@4.20.6)(yaml@2.8.1))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.2.2
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.2(@types/node@24.9.2)(jiti@2.6.1)(terser@5.46.2)(tsx@4.20.6)(yaml@2.8.1)
+      vite-node: 3.2.4(@types/node@24.9.2)(jiti@2.6.1)(terser@5.46.2)(tsx@4.20.6)(yaml@2.8.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.9.2
+      '@vitest/ui': 3.2.4(vitest@3.2.4)
+      jsdom: 27.4.0(@noble/hashes@1.8.0)
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vitest@3.2.4(@types/node@24.9.2)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(msw@2.12.1(@types/node@24.9.2)(typescript@5.9.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.1):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(msw@2.12.1(@types/node@24.9.2)(typescript@5.9.3))(vite@7.3.2(@types/node@24.9.2)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.1))
+      '@vitest/mocker': 3.2.4(msw@2.12.1(@types/node@24.9.2)(typescript@5.9.3))(vite@7.3.2(@types/node@24.9.2)(jiti@2.6.1)(terser@5.46.2)(tsx@4.20.6)(yaml@2.8.1))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5337,7 +5337,7 @@ packages:
   git-raw-commits@4.0.0:
     resolution: {integrity: sha512-ICsMM1Wk8xSGMowkOmPrzo2Fgmfo4bMHLNX6ytHjajRJUqvHOw/TFapQ+QG75c3X/tTDDhOSRPGC52dDbNM8FQ==}
     engines: {node: '>=16'}
-    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
+    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
     hasBin: true
 
   glob-parent@5.1.2:
@@ -13467,7 +13467,7 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
 
   esutils@2.0.3: {}
 

--- a/tools/copyright/sync-header-years.mjs
+++ b/tools/copyright/sync-header-years.mjs
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync, statSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+function isCliExecution() {
+  return process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+}
+
+function run() {
+  const args = new Set(process.argv.slice(2));
+  const checkOnly = args.has('--check');
+  const currentYear = new Date().getFullYear();
+
+  const stagedFiles = getStagedFiles();
+  const stagedFileData = [];
+  const invalidFiles = [];
+  const changedFiles = [];
+
+  for (const file of stagedFiles) {
+    if (!isFile(file) || isExcluded(file)) {
+      continue;
+    }
+    const absolutePath = resolve(process.cwd(), file);
+    const original = safeReadUtf8(absolutePath);
+    if (original === null) {
+      continue;
+    }
+    stagedFileData.push({ file, absolutePath, original });
+    if (hasInvalidPingCopyrightHeader(original)) {
+      invalidFiles.push(file);
+    }
+  }
+
+  if (invalidFiles.length > 0) {
+    console.error('Invalid Ping copyright header year format in staged files:');
+    for (const file of invalidFiles) {
+      console.error(`- ${file}`);
+    }
+    process.exit(1);
+  }
+
+  const missingHeaderFiles = [];
+  for (const { file, original } of stagedFileData) {
+    if (SOURCE_FILE_PATTERN.test(file) && !hasPingCopyrightHeader(original)) {
+      missingHeaderFiles.push(file);
+    }
+  }
+
+  if (checkOnly && missingHeaderFiles.length > 0) {
+    console.error('Missing Ping copyright header in staged files:');
+    for (const file of missingHeaderFiles) {
+      console.error(`- ${file}`);
+    }
+    process.exit(1);
+  }
+
+  for (const { file, absolutePath, original } of stagedFileData) {
+    const updated = updateCopyrightYears(original, currentYear);
+    if (updated === original) {
+      continue;
+    }
+    changedFiles.push(file);
+    if (!checkOnly) {
+      writeFileSync(absolutePath, updated, 'utf8');
+    }
+  }
+
+  if (!checkOnly && changedFiles.length > 0) {
+    execFileSync('git', ['add', '--', ...changedFiles], { stdio: 'inherit' });
+  }
+
+  if (checkOnly && changedFiles.length > 0) {
+    console.error('Stale Ping copyright years found in staged files:');
+    for (const file of changedFiles) {
+      console.error(`- ${file}`);
+    }
+    process.exit(1);
+  }
+}
+
+function getStagedFiles() {
+  const output = execFileSync('git', ['diff', '--cached', '--name-only', '--diff-filter=ACMR'], {
+    encoding: 'utf8',
+  }).trim();
+
+  if (!output) {
+    return [];
+  }
+  return output.split('\n').filter(Boolean);
+}
+
+export function isExcluded(filePath) {
+  return EXCLUDE_PATTERNS.some((pattern) => pattern.test(filePath));
+}
+
+const EXCLUDE_PATTERNS = [
+  /\.test\.[cm]?[jt]sx?$/i,
+  /\.spec\.[cm]?[jt]sx?$/i,
+  /(^|[/\\])dist[/\\]/,
+  /(^|[/\\])vendor[/\\]/,
+  /(^|[/\\])node_modules[/\\]/,
+  /(^|[/\\])tools[/\\]/,
+  /(^|[/\\])_polyfills[/\\]/,
+  /(^|[/\\])vite[^/\\]*\.config\.[cm]?[jt]sx?$/i,
+  /(^|[/\\])vitest\.setup\.[cm]?[jt]sx?$/i,
+  /(^|[/\\])playwright\.config\.[cm]?[jt]sx?$/i,
+];
+
+function isFile(filePath) {
+  try {
+    return statSync(filePath).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function safeReadUtf8(filePath) {
+  try {
+    return readFileSync(filePath, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+export function updateCopyrightYears(content, year) {
+  const regex =
+    /(^.*(?:©\s*|&copy;\s*)?Copyright(?:\s*\(c\))?\s+)(\d{4})(?:([ \t]*-[ \t]*)(\d{4}))?(\s+Ping Identity(?: Corporation)?\b.*$)/gim;
+
+  return content.replace(regex, (_, prefix, startYear, separator, endYear, suffix) => {
+    const start = Number.parseInt(startYear, 10);
+    const end = endYear ? Number.parseInt(endYear, 10) : start;
+
+    if (Number.isNaN(start) || Number.isNaN(end)) {
+      return `${prefix}${startYear}${endYear ? `${separator}${endYear}` : ''}${suffix}`;
+    }
+
+    const resolvedEnd = end >= year ? end : year;
+
+    if (!endYear) {
+      // Single year already current — no range needed
+      if (resolvedEnd === start) {
+        return `${prefix}${startYear}${suffix}`;
+      }
+      return `${prefix}${startYear} - ${resolvedEnd}${suffix}`;
+    }
+
+    // Always normalize separator to ' - ' and bump end year when stale
+    return `${prefix}${startYear} - ${resolvedEnd}${suffix}`;
+  });
+}
+
+export function hasInvalidPingCopyrightHeader(content) {
+  const lines = content.split(/\r?\n/);
+  for (const line of lines) {
+    if (!MAYBE_PING_COPYRIGHT_LINE_REGEX.test(line)) {
+      continue;
+    }
+    if (!HEADER_COMMENT_LINE_REGEX.test(line)) {
+      continue;
+    }
+    if (!VALID_PING_COPYRIGHT_LINE_REGEX.test(line)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function hasPingCopyrightHeader(content) {
+  const lines = content.split(/\r?\n/);
+  for (const line of lines) {
+    if (MAYBE_PING_COPYRIGHT_LINE_REGEX.test(line) && HEADER_COMMENT_LINE_REGEX.test(line)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+const SOURCE_FILE_PATTERN = /\.[cm]?[jt]sx?$/i;
+
+const MAYBE_PING_COPYRIGHT_LINE_REGEX =
+  /(?:©\s*|&copy;\s*)?Copyright(?:\s*\(c\))?.*Ping Identity(?: Corporation)?/i;
+const HEADER_COMMENT_LINE_REGEX = /^\s*(?:\/\*+|\*+|\/\/+|#+|<!--)\s*/;
+const VALID_PING_COPYRIGHT_LINE_REGEX =
+  /^.*(?:©\s*|&copy;\s*)?Copyright(?:\s*\(c\))?\s+\d{4}(?:[ \t]*-[ \t]*\d{4})?\s+Ping Identity(?: Corporation)?\b.*$/i;
+
+if (isCliExecution()) {
+  run();
+}

--- a/tools/copyright/sync-header-years.mjs
+++ b/tools/copyright/sync-header-years.mjs
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync, statSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+function isCliExecution() {
+  return process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+}
+
+function run() {
+  const args = new Set(process.argv.slice(2));
+  const checkOnly = args.has('--check');
+  const fixMode = args.has('--fix');
+
+  if (!checkOnly && !fixMode) {
+    console.error('Usage: sync-header-years.mjs --check | --fix');
+    process.exit(1);
+  }
+
+  const currentYear = new Date().getFullYear();
+
+  const stagedFileData = [];
+  const invalidFiles = [];
+  const missingHeaderFiles = [];
+  const changedFiles = [];
+
+  for (const file of getStagedFiles()) {
+    if (isExcluded(file)) {
+      continue;
+    }
+
+    let original;
+    try {
+      if (!statSync(resolve(process.cwd(), file)).isFile()) {
+        continue;
+      }
+      original = readFileSync(resolve(process.cwd(), file), 'utf8');
+    } catch {
+      continue;
+    }
+
+    const absolutePath = resolve(process.cwd(), file);
+    const { present, invalid } = inspectPingCopyrightHeader(original);
+
+    if (invalid) {
+      invalidFiles.push(file);
+    }
+    if (SOURCE_FILE_PATTERN.test(file) && !present) {
+      missingHeaderFiles.push(file);
+    }
+
+    const updated = updateCopyrightYears(original, currentYear);
+    if (updated !== original) {
+      changedFiles.push(file);
+    }
+    stagedFileData.push({ file, absolutePath, updated });
+  }
+
+  if (invalidFiles.length > 0) {
+    console.error('Invalid Ping copyright header year format in staged files:');
+    for (const file of invalidFiles) {
+      console.error(`- ${file}`);
+    }
+    process.exit(1);
+  }
+
+  if (checkOnly) {
+    if (missingHeaderFiles.length > 0) {
+      console.error('Missing Ping copyright header in staged files:');
+      for (const file of missingHeaderFiles) {
+        console.error(`- ${file}`);
+      }
+      process.exit(1);
+    }
+    if (changedFiles.length > 0) {
+      console.error('Stale Ping copyright years found in staged files:');
+      for (const file of changedFiles) {
+        console.error(`- ${file}`);
+      }
+      process.exit(1);
+    }
+    return;
+  }
+
+  for (const { file, absolutePath, updated } of stagedFileData) {
+    if (changedFiles.includes(file)) {
+      writeFileSync(absolutePath, updated, 'utf8');
+    }
+  }
+
+  if (changedFiles.length > 0) {
+    execFileSync('git', ['add', '--', ...changedFiles], { stdio: 'inherit' });
+  }
+}
+
+function getStagedFiles() {
+  const output = execFileSync('git', ['diff', '--cached', '--name-only', '--diff-filter=ACMR'], {
+    encoding: 'utf8',
+  }).trim();
+
+  if (!output) {
+    return [];
+  }
+  return output.split('\n').filter(Boolean);
+}
+
+export function isExcluded(filePath) {
+  return EXCLUDE_PATTERNS.some((pattern) => pattern.test(filePath));
+}
+
+const EXCLUDE_PATTERNS = [
+  /(^|[/\\])dist[/\\]/,
+  /(^|[/\\])vendor[/\\]/,
+  /(^|[/\\])node_modules[/\\]/,
+  /(^|[/\\])tools[/\\]/,
+  /(^|[/\\])_polyfills[/\\]/,
+  /(^|[/\\])vite[^/\\]*\.config\.[cm]?[jt]sx?$/i,
+  /(^|[/\\])vitest\.setup\.[cm]?[jt]sx?$/i,
+  /(^|[/\\])playwright\.config\.[cm]?[jt]sx?$/i,
+];
+
+export function updateCopyrightYears(content, year) {
+  const regex =
+    /(^.*(?:©\s*|&copy;\s*)?Copyright(?:\s*\(c\))?\s+)(\d{4})(?:([ \t]*-[ \t]*)(\d{4}))?(\s+Ping Identity(?: Corporation)?\b.*$)/gim;
+
+  return content.replace(regex, (match, prefix, startYear, separator, endYear, suffix) => {
+    if (!HEADER_COMMENT_LINE_REGEX.test(prefix)) {
+      return match;
+    }
+
+    const start = Number.parseInt(startYear, 10);
+    const end = endYear ? Number.parseInt(endYear, 10) : start;
+
+    if (Number.isNaN(start) || Number.isNaN(end)) {
+      return `${prefix}${startYear}${endYear ? `${separator}${endYear}` : ''}${suffix}`;
+    }
+
+    const resolvedEnd = end >= year ? end : year;
+
+    if (!endYear) {
+      // Single year already current — no range needed
+      if (resolvedEnd === start) {
+        return `${prefix}${startYear}${suffix}`;
+      }
+      return `${prefix}${startYear} - ${resolvedEnd}${suffix}`;
+    }
+
+    // Always normalize separator to ' - ' and bump end year when stale
+    return `${prefix}${startYear} - ${resolvedEnd}${suffix}`;
+  });
+}
+
+export function inspectPingCopyrightHeader(content) {
+  const lines = content.split(/\r?\n/);
+  let present = false;
+  let invalid = false;
+  let inBlockComment = false;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed === '') {
+      continue;
+    }
+
+    const isHeaderLine = inBlockComment || HEADER_COMMENT_LINE_REGEX.test(line);
+    if (!isHeaderLine) {
+      break;
+    }
+
+    if (/^\/\*/.test(trimmed)) {
+      inBlockComment = true;
+    }
+    if (inBlockComment && /\*\//.test(trimmed)) {
+      inBlockComment = false;
+    }
+
+    if (!MAYBE_PING_COPYRIGHT_LINE_REGEX.test(line)) {
+      continue;
+    }
+    present = true;
+    if (!VALID_PING_COPYRIGHT_LINE_REGEX.test(line)) {
+      invalid = true;
+    }
+  }
+
+  return { present, invalid };
+}
+
+const SOURCE_FILE_PATTERN = /\.[cm]?[jt]sx?$/i;
+
+const MAYBE_PING_COPYRIGHT_LINE_REGEX =
+  /(?:©\s*|&copy;\s*)?Copyright(?:\s*\(c\))?.*Ping Identity(?: Corporation)?/i;
+const HEADER_COMMENT_LINE_REGEX = /^\s*(?:\/\*+|\*+|\/\/+|#+|<!--)\s*/;
+const VALID_PING_COPYRIGHT_LINE_REGEX =
+  /^.*(?:©\s*|&copy;\s*)?Copyright(?:\s*\(c\))?\s+\d{4}(?:[ \t]*-[ \t]*\d{4})?\s+Ping Identity(?: Corporation)?\b.*$/i;
+
+if (isCliExecution()) {
+  run();
+}

--- a/tools/copyright/sync-header-years.test.mjs
+++ b/tools/copyright/sync-header-years.test.mjs
@@ -1,0 +1,158 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  hasInvalidPingCopyrightHeader,
+  hasPingCopyrightHeader,
+  isExcluded,
+  updateCopyrightYears,
+} from './sync-header-years.mjs';
+
+test('updates stale range end year and keeps start year', () => {
+  const input = '/* Copyright 2020-2024 Ping Identity. All Rights Reserved */';
+  const actual = updateCopyrightYears(input, 2026);
+  assert.equal(actual, '/* Copyright 2020 - 2026 Ping Identity. All Rights Reserved */');
+});
+
+test('normalizes separator on an already-current range', () => {
+  const input = '/* Copyright 2020-2026 Ping Identity. All Rights Reserved */';
+  const actual = updateCopyrightYears(input, 2026);
+  assert.equal(actual, '/* Copyright 2020 - 2026 Ping Identity. All Rights Reserved */');
+});
+
+test('expands stale single year to a range preserving start year', () => {
+  const input = '/* Copyright 2020 Ping Identity. All Rights Reserved */';
+  const actual = updateCopyrightYears(input, 2026);
+  assert.equal(actual, '/* Copyright 2020 - 2026 Ping Identity. All Rights Reserved */');
+});
+
+test('does not change an already-current spaced range', () => {
+  const input = '/* Copyright 2025 - 2026 Ping Identity. All Rights Reserved */';
+  const actual = updateCopyrightYears(input, 2026);
+  assert.equal(actual, input);
+});
+
+test('supports © and &copy; variants', () => {
+  const input = [
+    '/* © Copyright 2020-2024 Ping Identity. */',
+    '<!-- &copy; Copyright 2020-2024 Ping Identity. -->',
+  ].join('\n');
+  const actual = updateCopyrightYears(input, 2026);
+  assert.equal(
+    actual,
+    [
+      '/* © Copyright 2020 - 2026 Ping Identity. */',
+      '<!-- &copy; Copyright 2020 - 2026 Ping Identity. -->',
+    ].join('\n'),
+  );
+});
+
+test('does not update non-Ping headers', () => {
+  const input = '/* Copyright 2020-2025 Example Corp. */';
+  const actual = updateCopyrightYears(input, 2026);
+  assert.equal(actual, input);
+});
+
+test('updates Ping Identity Corporation ranges with spaces and (c)', () => {
+  const input = '/* Copyright (c) 2023 - 2024 Ping Identity Corporation. All right reserved. */';
+  const actual = updateCopyrightYears(input, 2026);
+  assert.equal(
+    actual,
+    '/* Copyright (c) 2023 - 2026 Ping Identity Corporation. All right reserved. */',
+  );
+});
+
+test('expands stale single year with (c) to a range for Ping Identity Corporation', () => {
+  const input = '/* Copyright (c) 2023 Ping Identity Corporation. All right reserved. */';
+  const actual = updateCopyrightYears(input, 2026);
+  assert.equal(
+    actual,
+    '/* Copyright (c) 2023 - 2026 Ping Identity Corporation. All right reserved. */',
+  );
+});
+
+test('flags Ping headers without a valid year', () => {
+  const input = '/* Copyright Ping Identity Corporation. All right reserved. */';
+  assert.equal(hasInvalidPingCopyrightHeader(input), true);
+});
+
+test('flags Ping headers with a <current_year> placeholder', () => {
+  const input =
+    '/* Copyright (c) <current_year> Ping Identity Corporation. All rights reserved. */';
+  assert.equal(hasInvalidPingCopyrightHeader(input), true);
+});
+
+test('does not flag valid Ping headers', () => {
+  const input = '/* Copyright (c) 2020 - 2026 Ping Identity Corporation. */';
+  assert.equal(hasInvalidPingCopyrightHeader(input), false);
+});
+
+test('does not flag non-header Ping copyright text', () => {
+  const input = 'This document is Copyright Ping Identity Corporation.';
+  assert.equal(hasInvalidPingCopyrightHeader(input), false);
+});
+
+test('excludes test files from processing', () => {
+  assert.equal(isExcluded('src/foo.test.ts'), true);
+  assert.equal(isExcluded('src/foo.test.mjs'), true);
+  assert.equal(isExcluded('src/foo.spec.js'), true);
+});
+
+test('excludes dist and vendor paths from processing', () => {
+  assert.equal(isExcluded('dist/foo.js'), true);
+  assert.equal(isExcluded('vendor/lib.js'), true);
+});
+
+test('excludes vite.config and vitest.setup files from processing', () => {
+  assert.equal(isExcluded('vite.config.ts'), true);
+  assert.equal(isExcluded('packages/foo/vite.config.ts'), true);
+  assert.equal(isExcluded('e2e/token-vault-app/vite.interceptor.config.ts'), true);
+  assert.equal(isExcluded('vitest.setup.ts'), true);
+  assert.equal(isExcluded('packages/foo/vitest.setup.ts'), true);
+});
+
+test('excludes playwright.config files from processing', () => {
+  assert.equal(isExcluded('e2e/davinci-suites/playwright.config.ts'), true);
+  assert.equal(isExcluded('e2e/oidc-suites/playwright.config.ts'), true);
+});
+
+test('excludes _polyfills/ directory from processing', () => {
+  assert.equal(isExcluded('e2e/autoscript-apps/src/_polyfills/fast-text-encoder.js'), true);
+});
+
+test('excludes tools/ directory from processing', () => {
+  assert.equal(isExcluded('tools/copyright/sync-header-years.mjs'), true);
+  assert.equal(isExcluded('tools/release/local.mjs'), true);
+});
+
+test('does not exclude regular source files', () => {
+  assert.equal(isExcluded('src/foo.ts'), false);
+  assert.equal(isExcluded('packages/sdk/src/index.ts'), false);
+});
+
+test('hasPingCopyrightHeader detects valid block comment header', () => {
+  const input = '/* Copyright (c) 2020 - 2026 Ping Identity Corporation. All rights reserved. */';
+  assert.equal(hasPingCopyrightHeader(input), true);
+});
+
+test('hasPingCopyrightHeader detects header in multi-line block comment', () => {
+  const input = `/*
+ * @ping-identity/sdk
+ *
+ * Copyright (c) 2020 - 2026 Ping Identity Corporation. All rights reserved.
+ */`;
+  assert.equal(hasPingCopyrightHeader(input), true);
+});
+
+test('hasPingCopyrightHeader returns false when no Ping copyright present', () => {
+  const input = `/*
+ * Some other library header
+ */
+export const x = 1;`;
+  assert.equal(hasPingCopyrightHeader(input), false);
+});
+
+test('hasPingCopyrightHeader returns false for non-comment Ping copyright text', () => {
+  const input = 'This document is Copyright Ping Identity Corporation.';
+  assert.equal(hasPingCopyrightHeader(input), false);
+});

--- a/tools/copyright/sync-header-years.test.mjs
+++ b/tools/copyright/sync-header-years.test.mjs
@@ -1,0 +1,167 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  inspectPingCopyrightHeader,
+  isExcluded,
+  updateCopyrightYears,
+} from './sync-header-years.mjs';
+
+test('updates stale range end year and keeps start year', () => {
+  const input = '/* Copyright 2020-2024 Ping Identity. All Rights Reserved */';
+  const actual = updateCopyrightYears(input, 2026);
+  assert.equal(actual, '/* Copyright 2020 - 2026 Ping Identity. All Rights Reserved */');
+});
+
+test('normalizes separator on an already-current range', () => {
+  const input = '/* Copyright 2020-2026 Ping Identity. All Rights Reserved */';
+  const actual = updateCopyrightYears(input, 2026);
+  assert.equal(actual, '/* Copyright 2020 - 2026 Ping Identity. All Rights Reserved */');
+});
+
+test('expands stale single year to a range preserving start year', () => {
+  const input = '/* Copyright 2020 Ping Identity. All Rights Reserved */';
+  const actual = updateCopyrightYears(input, 2026);
+  assert.equal(actual, '/* Copyright 2020 - 2026 Ping Identity. All Rights Reserved */');
+});
+
+test('does not change an already-current spaced range', () => {
+  const input = '/* Copyright 2025 - 2026 Ping Identity. All Rights Reserved */';
+  const actual = updateCopyrightYears(input, 2026);
+  assert.equal(actual, input);
+});
+
+test('supports © and &copy; variants', () => {
+  const input = [
+    '/* © Copyright 2020-2024 Ping Identity. */',
+    '<!-- &copy; Copyright 2020-2024 Ping Identity. -->',
+  ].join('\n');
+  const actual = updateCopyrightYears(input, 2026);
+  assert.equal(
+    actual,
+    [
+      '/* © Copyright 2020 - 2026 Ping Identity. */',
+      '<!-- &copy; Copyright 2020 - 2026 Ping Identity. -->',
+    ].join('\n'),
+  );
+});
+
+test('does not update non-Ping headers', () => {
+  const input = '/* Copyright 2020-2025 Example Corp. */';
+  const actual = updateCopyrightYears(input, 2026);
+  assert.equal(actual, input);
+});
+
+test('updates Ping Identity Corporation ranges with spaces and (c)', () => {
+  const input = '/* Copyright (c) 2023 - 2024 Ping Identity Corporation. All right reserved. */';
+  const actual = updateCopyrightYears(input, 2026);
+  assert.equal(
+    actual,
+    '/* Copyright (c) 2023 - 2026 Ping Identity Corporation. All right reserved. */',
+  );
+});
+
+test('expands stale single year with (c) to a range for Ping Identity Corporation', () => {
+  const input = '/* Copyright (c) 2023 Ping Identity Corporation. All right reserved. */';
+  const actual = updateCopyrightYears(input, 2026);
+  assert.equal(
+    actual,
+    '/* Copyright (c) 2023 - 2026 Ping Identity Corporation. All right reserved. */',
+  );
+});
+
+test('flags Ping headers without a valid year', () => {
+  const input = '/* Copyright Ping Identity Corporation. All right reserved. */';
+  assert.deepEqual(inspectPingCopyrightHeader(input), { present: true, invalid: true });
+});
+
+test('flags Ping headers with a <current_year> placeholder', () => {
+  const input =
+    '/* Copyright (c) <current_year> Ping Identity Corporation. All rights reserved. */';
+  assert.deepEqual(inspectPingCopyrightHeader(input), { present: true, invalid: true });
+});
+
+test('does not flag valid Ping headers', () => {
+  const input = '/* Copyright (c) 2020 - 2026 Ping Identity Corporation. */';
+  assert.deepEqual(inspectPingCopyrightHeader(input), { present: true, invalid: false });
+});
+
+test('does not flag non-header Ping copyright text', () => {
+  const input = 'This document is Copyright Ping Identity Corporation.';
+  assert.deepEqual(inspectPingCopyrightHeader(input), { present: false, invalid: false });
+});
+
+test('does not exclude test/spec files from processing', () => {
+  assert.equal(isExcluded('src/foo.test.ts'), false);
+  assert.equal(isExcluded('src/foo.test.mjs'), false);
+  assert.equal(isExcluded('src/foo.spec.js'), false);
+});
+
+test('excludes dist and vendor paths from processing', () => {
+  assert.equal(isExcluded('dist/foo.js'), true);
+  assert.equal(isExcluded('vendor/lib.js'), true);
+});
+
+test('excludes vite.config and vitest.setup files from processing', () => {
+  assert.equal(isExcluded('vite.config.ts'), true);
+  assert.equal(isExcluded('packages/foo/vite.config.ts'), true);
+  assert.equal(isExcluded('e2e/token-vault-app/vite.interceptor.config.ts'), true);
+  assert.equal(isExcluded('vitest.setup.ts'), true);
+  assert.equal(isExcluded('packages/foo/vitest.setup.ts'), true);
+});
+
+test('excludes playwright.config files from processing', () => {
+  assert.equal(isExcluded('e2e/davinci-suites/playwright.config.ts'), true);
+  assert.equal(isExcluded('e2e/oidc-suites/playwright.config.ts'), true);
+});
+
+test('excludes _polyfills/ directory from processing', () => {
+  assert.equal(isExcluded('e2e/autoscript-apps/src/_polyfills/fast-text-encoder.js'), true);
+});
+
+test('excludes tools/ directory from processing', () => {
+  assert.equal(isExcluded('tools/copyright/sync-header-years.mjs'), true);
+  assert.equal(isExcluded('tools/release/local.mjs'), true);
+});
+
+test('does not exclude regular source files', () => {
+  assert.equal(isExcluded('src/foo.ts'), false);
+  assert.equal(isExcluded('packages/sdk/src/index.ts'), false);
+});
+
+test('inspectPingCopyrightHeader detects valid block comment header', () => {
+  const input = '/* Copyright (c) 2020 - 2026 Ping Identity Corporation. All rights reserved. */';
+  assert.deepEqual(inspectPingCopyrightHeader(input), { present: true, invalid: false });
+});
+
+test('inspectPingCopyrightHeader detects header in multi-line block comment', () => {
+  const input = `/*
+ * @ping-identity/sdk
+ *
+ * Copyright (c) 2020 - 2026 Ping Identity Corporation. All rights reserved.
+ */`;
+  assert.deepEqual(inspectPingCopyrightHeader(input), { present: true, invalid: false });
+});
+
+test('inspectPingCopyrightHeader returns not present when no Ping copyright exists', () => {
+  const input = `/*
+ * Some other library header
+ */
+export const x = 1;`;
+  assert.deepEqual(inspectPingCopyrightHeader(input), { present: false, invalid: false });
+});
+
+test('inspectPingCopyrightHeader returns not present for non-comment Ping copyright text', () => {
+  const input = 'This document is Copyright Ping Identity Corporation.';
+  assert.deepEqual(inspectPingCopyrightHeader(input), { present: false, invalid: false });
+});
+
+test('inspectPingCopyrightHeader ignores Ping copyright mention in a non-leading comment', () => {
+  const input = `/*
+ * Some other library header
+ */
+export const x = 1;
+
+/* Copyright (c) 2020 - 2026 Ping Identity Corporation. */`;
+  assert.deepEqual(inspectPingCopyrightHeader(input), { present: false, invalid: false });
+});


### PR DESCRIPTION
# JIRA Ticket
N/A

## Description

  Adds automated Ping Identity copyright year management to the ping-javascript-sdk repo. A
  pre-commit script rewrites stale headers in staged files and re-stages them; an ESLint rule
  surfaces missing headers in-editor during lint runs.

  ## Changes

  ### `tools/copyright/`

  - `sync-header-years.mjs` — new script; rewrites stale Ping-owned copyright headers in
  staged files (single-year → range, stale range end → current year); fails commit if a Ping
  header has no valid year; runs in `--fix` or `--check` mode
  - `sync-header-years.test.mjs` — 23 unit tests covering range updates, single-year
  expansion, idempotency, variant matching (`©`, `&copy;`, `(c)`), and exclusion of
  non-Ping/test/tooling files

  ### `eslint.config.mjs`

  - Added inline `local-rules/ping-copyright` rule (warn severity) that checks the first block
   comment of every `.ts/.tsx/.js/.jsx/.mjs/.cjs` source file for a `Copyright … Ping
  Identity` header
  - No external plugin — `eslint-plugin-header` incompatible with ESLint 9 flat config;
  `eslint-plugin-headers` lacks regex variable support needed for year-range patterns

  ### `lefthook.yml`

  - Added `copyright-sync` pre-commit command (`node tools/copyright/sync-header-years.mjs
  --fix`, `stage_fixed: true`) between `nx-sync` and `nx-check`

  ### `package.json`

  - Added `copyright:sync` and `copyright:check` scripts for manual runs

  ## Tests

  - 23 unit tests in `tools/copyright/sync-header-years.test.mjs` — all pass
  - Covers: range updates, single-year expansion, idempotency, all header variants, exclusion
  patterns

  ## How to test

  ### 1. Manual pre-commit trigger

  Stage any file with a stale Ping copyright year and run `git commit`. The `copyright-sync`
  hook should rewrite and re-stage the header automatically.

  ### 2. Scripts

  pnpm copyright:check   # reports stale headers
  pnpm copyright:sync    # rewrites stale headers in place

  ### 3. ESLint

  pnpm lint

  Files missing a Ping Identity copyright header emit a `local-rules/ping-copyright` warning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated copyright header year synchronization for staged source files.
  * Added commands to check and update copyright years manually.
  * Added pre-commit synchronization for eligible files.

* **Bug Fixes**
  * ESLint now warns when required Ping Identity copyright headers are missing or invalid.
  * Copyright year formatting and stale year ranges are automatically corrected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->