### PR TITLE
fix(davinci-client): invoke RTK Query selectors with state for cache lookups

### DIFF
--- a/e2e/davinci-app/server-configs.ts
+++ b/e2e/davinci-app/server-configs.ts
@@ -92,4 +92,23 @@ export const serverConfigs: Record<string, DaVinciConfig> = {
         'https://auth.pingone.ca/356a254c-cba3-4ade-be1a-860136e8df01/as/.well-known/openid-configuration',
     },
   },
+  /**
+   * ValidatedPasswordCollector / Password Policy
+   * Flow: Andy - MFA Device Registration/Authentication (PingOne Forms)
+   * Policy ID (acr_values): 769eecb92f8e66f88005a85e8b939a01
+   * Environment: 356a254c-cba3-4ade-be1a-860136e8df01
+   *
+   * New client created 2026-05-28 with:
+   * - http://localhost:5829 in Redirect URIs
+   * - http://localhost:5829 in CORS Allowed Origins
+   */
+  'fb456db5-2e08-46d3-adf0-05bf8d26ad60': {
+    clientId: 'fb456db5-2e08-46d3-adf0-05bf8d26ad60',
+    redirectUri: window.location.origin + '/',
+    scope: 'openid profile email revoke',
+    serverConfig: {
+      wellknown:
+        'https://auth.pingone.ca/356a254c-cba3-4ade-be1a-860136e8df01/as/.well-known/openid-configuration',
+    },
+  },
 };

--- a/e2e/davinci-suites/playwright.config.ts
+++ b/e2e/davinci-suites/playwright.config.ts
@@ -29,7 +29,7 @@ const config: PlaywrightTestConfig = {
           command: 'pnpm watch @forgerock/davinci-app',
           port: 5829,
           ignoreHTTPSErrors: true,
-          reuseExistingServer: !process.env.CI,
+          reuseExistingServer: true,
           cwd: workspaceRoot,
         }
       : undefined,
@@ -37,7 +37,7 @@ const config: PlaywrightTestConfig = {
       command: 'pnpm nx serve @forgerock/davinci-app',
       port: 5829,
       ignoreHTTPSErrors: true,
-      reuseExistingServer: !process.env.CI,
+      reuseExistingServer: true,
       cwd: workspaceRoot,
     },
   ].filter(Boolean),

--- a/e2e/davinci-suites/src/password-policy.test.ts
+++ b/e2e/davinci-suites/src/password-policy.test.ts
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+import { expect, test } from '@playwright/test';
+import { asyncEvents } from './utils/async-events.js';
+import { password } from './utils/demo-user.js';
+
+/**
+ * DaVinci flow: Andy - MFA Device Registration/Authentication (PingOne Forms)
+ * Client ID: fb456db5-2e08-46d3-adf0-05bf8d26ad60
+ * Flow ID (acr_values): 769eecb92f8e66f88005a85e8b939a01
+ * Wellknown: https://auth.pingone.ca/356a254c-cba3-4ade-be1a-860136e8df01/as/.well-known/openid-configuration
+ */
+const CLIENT_ID = 'fb456db5-2e08-46d3-adf0-05bf8d26ad60';
+const FLOW_ID = '769eecb92f8e66f88005a85e8b939a01';
+
+/**
+ * A unique email per test run to avoid conflicts with existing accounts.
+ * The USER_DELETE cleanup step removes the account regardless.
+ */
+function uniqueEmail() {
+  return `pwpolicy+${Date.now()}@user.com`;
+}
+
+async function navigateToRegistration(page: Parameters<typeof asyncEvents>[0]) {
+  const { navigate } = asyncEvents(page);
+  await navigate(`/?clientId=${CLIENT_ID}&acr_values=${FLOW_ID}`);
+
+  // Wait for flow buttons to render (they have class 'flow-link')
+  await page.waitForSelector('button.flow-link', { timeout: 10000 });
+
+  // Click USER_REGISTRATION button
+  await page.getByRole('button', { name: 'USER_REGISTRATION' }).click();
+
+  /**
+   * The registration form is the PingOne Forms 'Example - Registration 1' form.
+   * It renders: heading 'Example - Registration 1', username, email, password +
+   * requirements list, verify password, and a Submit button.
+   */
+  await expect(page.getByRole('heading', { name: /Example - Registration/i })).toBeVisible({
+    timeout: 10000,
+  });
+}
+
+async function deleteTestUser(page: Parameters<typeof asyncEvents>[0], email: string) {
+  await page.goto(`/?clientId=${CLIENT_ID}&acr_values=${FLOW_ID}`);
+
+  // Wait for flow buttons to render
+  await page.waitForSelector('button.flow-link', { timeout: 10000 });
+
+  // Click USER_LOGIN button
+  await page.getByRole('button', { name: 'USER_LOGIN' }).click();
+
+  // Fill login credentials
+  await page.getByRole('textbox', { name: /Username/i }).fill(email);
+  await page.getByRole('textbox', { name: 'Password' }).fill(password);
+  await page.getByRole('button', { name: 'Sign On' }).click();
+
+  // Wait for next set of flow buttons (delete option)
+  await page.waitForSelector('button.flow-link', { timeout: 10000 });
+
+  // Click USER_DELETE button
+  await page.getByRole('button', { name: 'USER_DELETE' }).click();
+
+  await expect(page.getByRole('heading', { name: /Success/i })).toBeVisible();
+}
+
+test.describe('ValidatedPasswordCollector — password policy (Example - Registration form)', () => {
+  let createdEmail: string | null = null;
+
+  test.afterEach(async ({ page }) => {
+    if (createdEmail) {
+      const email = createdEmail;
+      createdEmail = null;
+      try {
+        await deleteTestUser(page, email);
+      } catch (err) {
+        console.error(`[cleanup] Failed to delete test user ${email}:`, err);
+      }
+    }
+  });
+
+  test('renders password requirements list from the PingOne password policy', async ({ page }) => {
+    await navigateToRegistration(page);
+
+    /**
+     * The SDK maps the PASSWORD_VERIFY field (with showPasswordRequirements=true)
+     * to a ValidatedPasswordCollector. passwordComponent renders a
+     * <ul class="password-requirements"> with one <li> per policy rule.
+     *
+     * The field key is 'user.password', so:
+     *   dotToCamelCase('user.password') => 'userPassword'
+     *   input id => #userPassword
+     */
+    await expect(page.locator('.password-requirements')).toBeVisible();
+    const items = page.locator('.password-requirements li');
+    expect(await items.count()).toBeGreaterThan(0);
+  });
+
+  test('validate() shows inline errors when password is too short', async ({ page }) => {
+    await navigateToRegistration(page);
+
+    // A single character will trigger the length rule violation
+    await page.locator('#userPassword').fill('a');
+
+    /**
+     * passwordComponent creates a <ul class="{key}-error"> when validate()
+     * returns errors. For field key 'user.password' that is class 'userPassword-error'.
+     */
+    await expect(page.locator('.userPassword-error')).toBeVisible();
+    const errors = page.locator('.userPassword-error li');
+    expect(await errors.count()).toBeGreaterThan(0);
+  });
+
+  test('validate() clears errors once all password policy requirements are satisfied', async ({
+    page,
+  }) => {
+    await navigateToRegistration(page);
+
+    // Trigger an error first
+    await page.locator('#userPassword').fill('a');
+    await expect(page.locator('.userPassword-error')).toBeVisible();
+
+    /**
+     * The existing demo password satisfies any reasonable PingOne password
+     * policy: it is long, contains uppercase (D), digits, and a special char (@).
+     */
+    await page.locator('#userPassword').fill(password);
+    await expect(page.locator('.userPassword-error')).not.toBeAttached();
+  });
+
+  test('submits registration form successfully with a policy-compliant password', async ({
+    page,
+  }) => {
+    createdEmail = uniqueEmail();
+    const email = createdEmail;
+
+    await navigateToRegistration(page);
+
+    // Fill all required fields
+    await page.locator('#userUsername').fill(email);
+    await page.locator('#userEmail').fill(email);
+    await page.locator('#userPassword').fill(password);
+
+    // Submit the form by calling submit() on the form element
+    await page.locator('form').evaluate((form: HTMLFormElement) => form.submit());
+
+    // Wait for the page to navigate to the next step
+    // The heading should change from "Example - Registration 1" to something else
+    await page.waitForFunction(
+      () => {
+        const heading = document.querySelector('h2');
+        return heading && !heading.textContent?.includes('Example - Registration');
+      },
+      { timeout: 10000 },
+    );
+
+    // Verify we've moved to the next step
+    const heading = page.locator('h2').first();
+    await expect(heading).toBeVisible();
+
+    // If the flow shows a "Continue" button, click through to complete it
+    const continueBtn = page.getByRole('button', { name: 'Continue' });
+    if (await continueBtn.isVisible()) {
+      await continueBtn.click();
+    }
+  });
+});

--- a/e2e/mock-api-v2/tsconfig.app.json
+++ b/e2e/mock-api-v2/tsconfig.app.json
@@ -10,8 +10,7 @@
     "noErrorTruncation": true,
     "plugins": [
       {
-        "name": "@effect/language-service",
-        "transform": "@effect/language-service/transform"
+        "name": "@effect/language-service"
       }
     ]
   },

--- a/packages/davinci-client/api-report/davinci-client.api.md
+++ b/packages/davinci-client/api-report/davinci-client.api.md
@@ -7,20 +7,15 @@
 import { ActionCreatorWithPayload } from '@reduxjs/toolkit';
 import { ActionTypes } from '@forgerock/sdk-request-middleware';
 import type { AsyncLegacyConfigOptions } from '@forgerock/sdk-types';
-import { BaseQueryFn } from '@reduxjs/toolkit/query';
 import { CustomLogger } from '@forgerock/sdk-logger';
-import { FetchArgs } from '@reduxjs/toolkit/query';
 import { FetchBaseQueryError } from '@reduxjs/toolkit/query';
-import { FetchBaseQueryMeta } from '@reduxjs/toolkit/query';
+import type { FetchBaseQueryMeta } from '@reduxjs/toolkit/query';
 import { GenericError } from '@forgerock/sdk-types';
 import { LogLevel } from '@forgerock/sdk-logger';
-import { MutationDefinition } from '@reduxjs/toolkit/query';
 import type { MutationResultSelectorResult } from '@reduxjs/toolkit/query';
-import { QueryDefinition } from '@reduxjs/toolkit/query';
 import { QueryStatus } from '@reduxjs/toolkit/query';
 import { Reducer } from '@reduxjs/toolkit';
 import { RequestMiddleware } from '@forgerock/sdk-request-middleware';
-import { RootState } from '@reduxjs/toolkit/query';
 import { SerializedError } from '@reduxjs/toolkit';
 import { Unsubscribe } from '@reduxjs/toolkit';
 
@@ -361,33 +356,7 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         status: "success";
     } | null;
     cache: {
-        getLatestResponse: () => ((state: RootState<    {
-        flow: MutationDefinition<any, BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError, {}, FetchBaseQueryMeta>, never, unknown, "davinci", any>;
-        next: MutationDefinition<any, BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError, {}, FetchBaseQueryMeta>, never, unknown, "davinci", any>;
-        start: MutationDefinition<StartOptions<OutgoingQueryParams> | undefined, BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError, {}, FetchBaseQueryMeta>, never, unknown, "davinci", unknown>;
-        resume: QueryDefinition<    {
-        serverInfo: ContinueNode["server"];
-        continueToken: string;
-        }, BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError, {}, FetchBaseQueryMeta>, never, unknown, "davinci", unknown>;
-        poll: MutationDefinition<    {
-        endpoint: string;
-        interactionId: string;
-        }, BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError, {}, FetchBaseQueryMeta>, never, unknown, "davinci", unknown>;
-        }, never, "davinci">) => ({
-            requestId?: undefined;
-            status: QueryStatus.uninitialized;
-            data?: undefined;
-            error?: undefined;
-            endpointName?: string;
-            startedTimeStamp?: undefined;
-            fulfilledTimeStamp?: undefined;
-        } & {
-            status: QueryStatus.uninitialized;
-            isUninitialized: true;
-            isLoading: false;
-            isSuccess: false;
-            isError: false;
-        }) | ({
+        getLatestResponse: () => ({
             status: QueryStatus.fulfilled;
         } & Omit<{
             requestId: string;
@@ -412,23 +381,6 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
             isSuccess: true;
             isError: false;
         }) | ({
-            status: QueryStatus.pending;
-        } & {
-            requestId: string;
-            data?: unknown;
-            error?: FetchBaseQueryError | SerializedError | undefined;
-            endpointName: string;
-            startedTimeStamp: number;
-            fulfilledTimeStamp?: number;
-        } & {
-            data?: undefined;
-        } & {
-            status: QueryStatus.pending;
-            isUninitialized: false;
-            isLoading: true;
-            isSuccess: false;
-            isError: false;
-        }) | ({
             status: QueryStatus.rejected;
         } & Omit<{
             requestId: string;
@@ -450,39 +402,13 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
             isLoading: false;
             isSuccess: false;
             isError: true;
-        })) | {
+        }) | {
             error: {
                 message: string;
                 type: string;
             };
         };
-        getResponseWithId: (requestId: string) => ((state: RootState<    {
-        flow: MutationDefinition<any, BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError, {}, FetchBaseQueryMeta>, never, unknown, "davinci", any>;
-        next: MutationDefinition<any, BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError, {}, FetchBaseQueryMeta>, never, unknown, "davinci", any>;
-        start: MutationDefinition<StartOptions<OutgoingQueryParams> | undefined, BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError, {}, FetchBaseQueryMeta>, never, unknown, "davinci", unknown>;
-        resume: QueryDefinition<    {
-        serverInfo: ContinueNode["server"];
-        continueToken: string;
-        }, BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError, {}, FetchBaseQueryMeta>, never, unknown, "davinci", unknown>;
-        poll: MutationDefinition<    {
-        endpoint: string;
-        interactionId: string;
-        }, BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError, {}, FetchBaseQueryMeta>, never, unknown, "davinci", unknown>;
-        }, never, "davinci">) => ({
-            requestId?: undefined;
-            status: QueryStatus.uninitialized;
-            data?: undefined;
-            error?: undefined;
-            endpointName?: string;
-            startedTimeStamp?: undefined;
-            fulfilledTimeStamp?: undefined;
-        } & {
-            status: QueryStatus.uninitialized;
-            isUninitialized: true;
-            isLoading: false;
-            isSuccess: false;
-            isError: false;
-        }) | ({
+        getResponseWithId: (requestId: string) => ({
             status: QueryStatus.fulfilled;
         } & Omit<{
             requestId: string;
@@ -507,23 +433,6 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
             isSuccess: true;
             isError: false;
         }) | ({
-            status: QueryStatus.pending;
-        } & {
-            requestId: string;
-            data?: unknown;
-            error?: FetchBaseQueryError | SerializedError | undefined;
-            endpointName: string;
-            startedTimeStamp: number;
-            fulfilledTimeStamp?: number;
-        } & {
-            data?: undefined;
-        } & {
-            status: QueryStatus.pending;
-            isUninitialized: false;
-            isLoading: true;
-            isSuccess: false;
-            isError: false;
-        }) | ({
             status: QueryStatus.rejected;
         } & Omit<{
             requestId: string;
@@ -545,7 +454,7 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
             isLoading: false;
             isSuccess: false;
             isError: true;
-        })) | {
+        }) | {
             error: {
                 message: string;
                 type: string;

--- a/packages/davinci-client/api-report/davinci-client.types.api.md
+++ b/packages/davinci-client/api-report/davinci-client.types.api.md
@@ -7,20 +7,15 @@
 import { ActionCreatorWithPayload } from '@reduxjs/toolkit';
 import { ActionTypes } from '@forgerock/sdk-request-middleware';
 import type { AsyncLegacyConfigOptions } from '@forgerock/sdk-types';
-import { BaseQueryFn } from '@reduxjs/toolkit/query';
 import { CustomLogger } from '@forgerock/sdk-logger';
-import { FetchArgs } from '@reduxjs/toolkit/query';
 import { FetchBaseQueryError } from '@reduxjs/toolkit/query';
-import { FetchBaseQueryMeta } from '@reduxjs/toolkit/query';
+import type { FetchBaseQueryMeta } from '@reduxjs/toolkit/query';
 import { GenericError } from '@forgerock/sdk-types';
 import { LogLevel } from '@forgerock/sdk-logger';
-import { MutationDefinition } from '@reduxjs/toolkit/query';
 import type { MutationResultSelectorResult } from '@reduxjs/toolkit/query';
-import { QueryDefinition } from '@reduxjs/toolkit/query';
 import { QueryStatus } from '@reduxjs/toolkit/query';
 import { Reducer } from '@reduxjs/toolkit';
 import { RequestMiddleware } from '@forgerock/sdk-request-middleware';
-import { RootState } from '@reduxjs/toolkit/query';
 import { SerializedError } from '@reduxjs/toolkit';
 import { Unsubscribe } from '@reduxjs/toolkit';
 
@@ -361,33 +356,7 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         status: "success";
     } | null;
     cache: {
-        getLatestResponse: () => ((state: RootState<    {
-        flow: MutationDefinition<any, BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError, {}, FetchBaseQueryMeta>, never, unknown, "davinci", any>;
-        next: MutationDefinition<any, BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError, {}, FetchBaseQueryMeta>, never, unknown, "davinci", any>;
-        start: MutationDefinition<StartOptions<OutgoingQueryParams> | undefined, BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError, {}, FetchBaseQueryMeta>, never, unknown, "davinci", unknown>;
-        resume: QueryDefinition<    {
-        serverInfo: ContinueNode["server"];
-        continueToken: string;
-        }, BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError, {}, FetchBaseQueryMeta>, never, unknown, "davinci", unknown>;
-        poll: MutationDefinition<    {
-        endpoint: string;
-        interactionId: string;
-        }, BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError, {}, FetchBaseQueryMeta>, never, unknown, "davinci", unknown>;
-        }, never, "davinci">) => ({
-            requestId?: undefined;
-            status: QueryStatus.uninitialized;
-            data?: undefined;
-            error?: undefined;
-            endpointName?: string;
-            startedTimeStamp?: undefined;
-            fulfilledTimeStamp?: undefined;
-        } & {
-            status: QueryStatus.uninitialized;
-            isUninitialized: true;
-            isLoading: false;
-            isSuccess: false;
-            isError: false;
-        }) | ({
+        getLatestResponse: () => ({
             status: QueryStatus.fulfilled;
         } & Omit<{
             requestId: string;
@@ -412,23 +381,6 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
             isSuccess: true;
             isError: false;
         }) | ({
-            status: QueryStatus.pending;
-        } & {
-            requestId: string;
-            data?: unknown;
-            error?: FetchBaseQueryError | SerializedError | undefined;
-            endpointName: string;
-            startedTimeStamp: number;
-            fulfilledTimeStamp?: number;
-        } & {
-            data?: undefined;
-        } & {
-            status: QueryStatus.pending;
-            isUninitialized: false;
-            isLoading: true;
-            isSuccess: false;
-            isError: false;
-        }) | ({
             status: QueryStatus.rejected;
         } & Omit<{
             requestId: string;
@@ -450,39 +402,13 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
             isLoading: false;
             isSuccess: false;
             isError: true;
-        })) | {
+        }) | {
             error: {
                 message: string;
                 type: string;
             };
         };
-        getResponseWithId: (requestId: string) => ((state: RootState<    {
-        flow: MutationDefinition<any, BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError, {}, FetchBaseQueryMeta>, never, unknown, "davinci", any>;
-        next: MutationDefinition<any, BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError, {}, FetchBaseQueryMeta>, never, unknown, "davinci", any>;
-        start: MutationDefinition<StartOptions<OutgoingQueryParams> | undefined, BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError, {}, FetchBaseQueryMeta>, never, unknown, "davinci", unknown>;
-        resume: QueryDefinition<    {
-        serverInfo: ContinueNode["server"];
-        continueToken: string;
-        }, BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError, {}, FetchBaseQueryMeta>, never, unknown, "davinci", unknown>;
-        poll: MutationDefinition<    {
-        endpoint: string;
-        interactionId: string;
-        }, BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError, {}, FetchBaseQueryMeta>, never, unknown, "davinci", unknown>;
-        }, never, "davinci">) => ({
-            requestId?: undefined;
-            status: QueryStatus.uninitialized;
-            data?: undefined;
-            error?: undefined;
-            endpointName?: string;
-            startedTimeStamp?: undefined;
-            fulfilledTimeStamp?: undefined;
-        } & {
-            status: QueryStatus.uninitialized;
-            isUninitialized: true;
-            isLoading: false;
-            isSuccess: false;
-            isError: false;
-        }) | ({
+        getResponseWithId: (requestId: string) => ({
             status: QueryStatus.fulfilled;
         } & Omit<{
             requestId: string;
@@ -507,23 +433,6 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
             isSuccess: true;
             isError: false;
         }) | ({
-            status: QueryStatus.pending;
-        } & {
-            requestId: string;
-            data?: unknown;
-            error?: FetchBaseQueryError | SerializedError | undefined;
-            endpointName: string;
-            startedTimeStamp: number;
-            fulfilledTimeStamp?: number;
-        } & {
-            data?: undefined;
-        } & {
-            status: QueryStatus.pending;
-            isUninitialized: false;
-            isLoading: true;
-            isSuccess: false;
-            isError: false;
-        }) | ({
             status: QueryStatus.rejected;
         } & Omit<{
             requestId: string;
@@ -545,7 +454,7 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
             isLoading: false;
             isSuccess: false;
             isError: true;
-        })) | {
+        }) | {
             error: {
                 message: string;
                 type: string;

--- a/packages/davinci-client/src/lib/client.store.test.ts
+++ b/packages/davinci-client/src/lib/client.store.test.ts
@@ -1,0 +1,183 @@
+// @vitest-environment node
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { davinci } from './client.store.js';
+import type { DaVinciConfig } from './config.types.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const TEST_WELLKNOWN_URL =
+  'https://example.pingone.com/test-env/as/.well-known/openid-configuration';
+
+const mockConfig: DaVinciConfig = {
+  clientId: 'test-client-id',
+  scope: 'openid profile',
+  redirectUri: 'http://localhost/callback',
+  serverConfig: {
+    wellknown: TEST_WELLKNOWN_URL,
+  },
+};
+
+const mockWellknownResponse = {
+  issuer: 'https://example.pingone.com/test-env/as',
+  authorization_endpoint: 'https://example.pingone.com/test-env/as/authorize',
+  token_endpoint: 'https://example.pingone.com/test-env/as/token',
+  userinfo_endpoint: 'https://example.pingone.com/test-env/as/userinfo',
+  jwks_uri: 'https://example.pingone.com/test-env/as/jwks',
+};
+
+/**
+ * Minimal DaVinci continue-node response.
+ * Must have _links.next.href so handleResponse dispatches nodeSlice.next.
+ */
+const mockContinueResponse = {
+  id: 'mock-node-id',
+  interactionId: 'mock-interaction-id',
+  interactionToken: 'mock-interaction-token',
+  eventName: 'continue',
+  form: {
+    name: 'Login',
+    description: '',
+    components: {
+      fields: [
+        { type: 'TEXT', key: 'username', label: 'Username' },
+        { type: 'PASSWORD', key: 'password', label: 'Password' },
+        { type: 'SUBMIT_BUTTON', key: 'SIGNON', label: 'Sign On' },
+      ],
+    },
+  },
+  _links: {
+    next: { href: 'https://example.pingone.com/test-env/davinci/flow/next' },
+    self: { href: 'https://example.pingone.com/test-env/davinci/flow/self' },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns a minimal Web Storage API stub backed by a Map.
+ * createStorage() references sessionStorage/localStorage at call time,
+ * so both must be present in the Node.js environment before davinci() runs.
+ */
+function makeStorageStub() {
+  const store = new Map<string, string>();
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => store.set(key, value),
+    removeItem: (key: string) => store.delete(key),
+    clear: () => store.clear(),
+    get length() {
+      return store.size;
+    },
+    key: (i: number) => [...store.keys()][i] ?? null,
+  };
+}
+
+function mockFetchImplementation() {
+  return vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+    const url = typeof input === 'string' ? input : (input as Request).url;
+
+    if (url.includes('.well-known')) {
+      return new Response(JSON.stringify(mockWellknownResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    return new Response(JSON.stringify(mockContinueResponse), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('davinci client — cache', () => {
+  beforeEach(() => {
+    // Provide browser storage APIs in the Node.js test environment
+    vi.stubGlobal('localStorage', makeStorageStub());
+    vi.stubGlobal('sessionStorage', makeStorageStub());
+    mockFetchImplementation();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  describe('cache.getLatestResponse()', () => {
+    it('returns a state_error when no flow has been started (no cache key)', async () => {
+      const client = await davinci({ config: mockConfig });
+
+      // Node is in start status — cache.key is null before any start() call
+      const result = client.cache.getLatestResponse();
+
+      expect(result).toHaveProperty('error.type', 'state_error');
+    });
+
+    it('returns the raw DaVinci response object — NOT a selector function — after start()', async () => {
+      const client = await davinci({ config: mockConfig });
+      await client.start();
+
+      const result = client.cache.getLatestResponse();
+
+      // Bug guard: unfixed code returns a selector factory (typeof === 'function')
+      expect(typeof result).not.toBe('function');
+      expect(result).toBeDefined();
+      // RTK Query fulfilled entry: has data with the original DaVinci response
+      expect(result).toHaveProperty('data');
+      expect(result).toHaveProperty('data.interactionId', 'mock-interaction-id');
+      expect(result).toHaveProperty('data.id', 'mock-node-id');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('cache.getResponseWithId()', () => {
+    it('returns an argument_error when called with an empty string', async () => {
+      const client = await davinci({ config: mockConfig });
+
+      const result = client.cache.getResponseWithId('');
+
+      expect(result).toHaveProperty('error.type', 'argument_error');
+    });
+
+    it('returns the raw DaVinci response object — NOT a selector function — for a valid request ID', async () => {
+      const client = await davinci({ config: mockConfig });
+      await client.start();
+
+      const node = client.getNode();
+      const requestId = node.cache?.key;
+      expect(requestId).toBeDefined();
+
+      const result = client.cache.getResponseWithId(requestId!);
+
+      // Bug guard: unfixed code returns a selector factory (typeof === 'function')
+      expect(typeof result).not.toBe('function');
+      expect(result).toBeDefined();
+      expect(result).toHaveProperty('data');
+      expect(result).toHaveProperty('data.interactionId', 'mock-interaction-id');
+    });
+
+    it('returns a state_error for a requestId not present in cache', async () => {
+      const client = await davinci({ config: mockConfig });
+
+      const result = client.cache.getResponseWithId('non-existent-id');
+
+      expect(result).toHaveProperty('error.type', 'state_error');
+    });
+  });
+});

--- a/packages/davinci-client/src/lib/client.store.ts
+++ b/packages/davinci-client/src/lib/client.store.ts
@@ -522,11 +522,18 @@ export async function davinci<ActionType extends ActionTypes = ActionTypes>({
           return { error: { message: 'Cannot find current node', type: 'state_error' } };
         }
 
-        const flowItem = davinciApi.endpoints.flow.select(node.cache.key);
-        const nextItem = davinciApi.endpoints.next.select(node.cache.key);
-        const startItem = davinciApi.endpoints.start.select(node.cache.key);
+        const state = store.getState();
+        const key = node.cache.key;
 
-        return flowItem || nextItem || startItem;
+        const flowResult = davinciApi.endpoints.flow.select(key)(state);
+        const nextResult = davinciApi.endpoints.next.select(key)(state);
+        const startResult = davinciApi.endpoints.start.select(key)(state);
+
+        if (flowResult.data !== undefined) return flowResult;
+        if (nextResult.data !== undefined) return nextResult;
+        if (startResult.data !== undefined) return startResult;
+
+        return { error: { message: `No cache entry found for key: ${key}`, type: 'state_error' } };
       },
       getResponseWithId: (requestId: string) => {
         if (!requestId) {
@@ -534,11 +541,22 @@ export async function davinci<ActionType extends ActionTypes = ActionTypes>({
           return { error: { message: 'Please provide the cache key', type: 'argument_error' } };
         }
 
-        const flowItem = davinciApi.endpoints.flow.select(requestId);
-        const nextItem = davinciApi.endpoints.next.select(requestId);
-        const startItem = davinciApi.endpoints.start.select(requestId);
+        const state = store.getState();
 
-        return flowItem || nextItem || startItem;
+        const flowResult = davinciApi.endpoints.flow.select(requestId)(state);
+        const nextResult = davinciApi.endpoints.next.select(requestId)(state);
+        const startResult = davinciApi.endpoints.start.select(requestId)(state);
+
+        if (flowResult.data !== undefined) return flowResult;
+        if (nextResult.data !== undefined) return nextResult;
+        if (startResult.data !== undefined) return startResult;
+
+        return {
+          error: {
+            message: `No cache entry found for request ID: ${requestId}`,
+            type: 'state_error',
+          },
+        };
       },
     },
   };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -614,9 +614,6 @@ importers:
       ts-morph:
         specifier: ^28.0.0
         version: 28.0.0
-      tsx:
-        specifier: 'catalog:'
-        version: 4.21.0
       vitest:
         specifier: catalog:vitest
         version: 3.2.4(@types/node@24.9.2)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(msw@2.12.1(@types/node@24.9.2)(typescript@5.9.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.1)

--- a/tools/api-report/src/fixer.ts
+++ b/tools/api-report/src/fixer.ts
@@ -46,6 +46,13 @@ export function resolveSourcePackage(sourceFilePath: string, workspaceRoot: stri
 }
 
 /**
+ * Escapes special regex characters in a string.
+ */
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
  * Finds the module specifier for a symbol's import in a .d.ts file.
  * Given `import { ForgottenType } from '@forgerock/sdk-types'`, returns '@forgerock/sdk-types'.
  */
@@ -105,10 +112,6 @@ export function buildReExportStatement(
 ): string {
   const keyword = kind === 'type' ? 'export type' : 'export';
   return keyword + ' { ' + symbolName + " } from '" + sourcePackage + "';";
-}
-
-function escapeRegex(str: string): string {
-  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 /**

--- a/tools/interface-mapping-validator/package.json
+++ b/tools/interface-mapping-validator/package.json
@@ -15,7 +15,6 @@
   },
   "dependencies": {
     "ts-morph": "^28.0.0",
-    "tsx": "catalog:",
     "vitest": "catalog:vitest"
   },
   "devDependencies": {


### PR DESCRIPTION
## JIRA
https://pingidentity.atlassian.net/browse/SDKS-3816

## Summary

- `cache.getLatestResponse()` and `cache.getResponseWithId()` were returning RTK Query selector factory functions instead of query result objects — `endpoints.*.select(key)` returns `(state) => result` and must be called with the current state snapshot
- Fixed both methods to call the selector with `store.getState()` and check `.data !== undefined` to find the correct cache slot
- Added unit tests covering all cache API paths: no-key error, fulfilled result, not-found, and empty-string argument error
- Added `password-policy.test.ts` e2e suite for `ValidatedPasswordCollector` registration flow
- Added PingOne client config entry for the password-policy flow in `server-configs.ts`
- Set `reuseExistingServer: true` in Playwright config so a running dev server is reused instead of double-launching

## Test plan

- [ ] `pnpm nx run @forgerock/davinci-client:test` — 353 tests pass
- [ ] `pnpm nx affected -t typecheck lint build` — all clean
- [ ] e2e: `pnpm nx run @forgerock/davinci-suites:e2e` against live PingOne environment with client `fb456db5-2e08-46d3-adf0-05bf8d26ad60`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for an additional DaVinci/PingOne authentication server configuration.

* **Tests**
  * Added end-to-end tests covering password policy and validated-password flows.
  * Added unit tests verifying client cache behavior and error handling.

* **Chores**
  * Regenerated API type reports to simplify cache return shapes.
  * Enabled test server reuse in CI and local test runs.
  * Minor tooling/package updates and internal helper reorganization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ForgeRock/ping-javascript-sdk/pull/657?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->