### PR TITLE
fix: build all packages before snapshot publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -126,6 +126,9 @@ jobs:
         with:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+      - name: Build all packages
+        run: pnpm nx run-many -t build --no-agents --skip-nx-cache
+
       - name: Version Packages for snapshot
         run: pnpm changeset version --snapshot ${{ inputs.snapshot_tag }}
         env:


### PR DESCRIPTION
## Summary

- The `snapshot` job was calling `pnpm publish -r` without first building all packages, causing packages to be published without `dist/` directories
- Added `pnpm nx run-many -t build --no-agents --skip-nx-cache` before the version step, matching the pattern already used by `ci:release` in the `publish-or-pr` job
- `--skip-nx-cache` ensures builds use the freshly-versioned `package.json` rather than a stale cached artifact

## Test plan

- [ ] Trigger the snapshot workflow on a branch and confirm packages include `dist/` directories

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Snapshot publishing workflow now includes an explicit build-all step before snapshot versioning and publishing.
  * Ensures all packages are built prior to snapshot publication, reducing publish errors and improving overall release reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->