### PR TITLE
feat(oidc-client): add oidc session check with response type of id_token and none

### DIFF
--- a/.changeset/brave-foxes-dance.md
+++ b/.changeset/brave-foxes-dance.md
@@ -1,0 +1,6 @@
+---
+'@forgerock/iframe-manager': minor
+'@forgerock/oidc-client': minor
+---
+
+Add `session.check()` method to oidc client for OIDC prompt=none session verification, with `response_type=none` and `response_type=id_token` support.

--- a/.changeset/brave-foxes-dance.md
+++ b/.changeset/brave-foxes-dance.md
@@ -3,4 +3,4 @@
 '@forgerock/oidc-client': minor
 ---
 
-Add `session.check()` method to oidc client for OIDC prompt=none session verification, with `response_type=none` and `response_type=id_token` support.
+Add `user.session()` method to oidc client for OIDC prompt=none session verification, with `response_type=none` and `response_type=id_token` support.

--- a/e2e/oidc-app/src/ping-am/index.html
+++ b/e2e/oidc-app/src/ping-am/index.html
@@ -21,7 +21,8 @@
       <button id="logout">Logout</button>
       <button id="user-info-btn">User Info</button>
       <button id="revoke">Revoke Token</button>
-      <button id="session-check-btn">Session Check (none)</button>
+      <button id="session-check-btn">Session Check (none, iframe)</button>
+      <button id="session-check-no-redirect-btn">Session Check (none, no redirect)</button>
       <button id="session-check-id-token-btn">Session Check (id_token)</button>
       <a href="/ping-am/">Start Over</a>
     </div>

--- a/e2e/oidc-app/src/ping-am/index.html
+++ b/e2e/oidc-app/src/ping-am/index.html
@@ -21,6 +21,8 @@
       <button id="logout">Logout</button>
       <button id="user-info-btn">User Info</button>
       <button id="revoke">Revoke Token</button>
+      <button id="session-check-btn">Session Check (none)</button>
+      <button id="session-check-id-token-btn">Session Check (id_token)</button>
       <a href="/ping-am/">Start Over</a>
     </div>
     <script type="module" src="./main.ts"></script>

--- a/e2e/oidc-app/src/ping-one/index.html
+++ b/e2e/oidc-app/src/ping-one/index.html
@@ -21,7 +21,6 @@
       <button id="logout">Logout</button>
       <button id="user-info-btn">User Info</button>
       <button id="revoke">Revoke Token</button>
-      <button id="session-check-btn">Session Check (none)</button>
       <button id="session-check-id-token-btn">Session Check (id_token)</button>
       <a href="/ping-one/">Start Over</a>
     </div>

--- a/e2e/oidc-app/src/ping-one/index.html
+++ b/e2e/oidc-app/src/ping-one/index.html
@@ -21,6 +21,8 @@
       <button id="logout">Logout</button>
       <button id="user-info-btn">User Info</button>
       <button id="revoke">Revoke Token</button>
+      <button id="session-check-btn">Session Check (none)</button>
+      <button id="session-check-id-token-btn">Session Check (id_token)</button>
       <a href="/ping-one/">Start Over</a>
     </div>
     <script type="module" src="./main.ts"></script>

--- a/e2e/oidc-app/src/utils/oidc-app.ts
+++ b/e2e/oidc-app/src/utils/oidc-app.ts
@@ -215,7 +215,7 @@ export async function oidcApp({
   });
 
   document.getElementById('session-check-btn')?.addEventListener('click', async () => {
-    const result = await oidcClient.session?.check();
+    const result = await oidcClient.user?.session();
     const appEl = document.getElementById('app');
     const el = document.createElement('div');
     el.innerHTML = `<p><strong>Session Check (none):</strong></p><pre id="session-check-result">${JSON.stringify(result, null, 2)}</pre>`;
@@ -224,7 +224,7 @@ export async function oidcApp({
 
   document.getElementById('session-check-id-token-btn')?.addEventListener('click', async () => {
     const options: SessionCheckOptions = { responseType: 'id_token' };
-    const result = await oidcClient.session?.check(options);
+    const result = await oidcClient.user?.session(options);
     const appEl = document.getElementById('app');
     const el = document.createElement('div');
     el.innerHTML = `<p><strong>Session Check (id_token):</strong></p><pre id="session-check-id-token-result">${JSON.stringify(result, null, 2)}</pre>`;

--- a/e2e/oidc-app/src/utils/oidc-app.ts
+++ b/e2e/oidc-app/src/utils/oidc-app.ts
@@ -21,7 +21,14 @@ let tokenIndex = 0;
 
 function displayError(error: unknown) {
   const errorEl = document.createElement('div');
-  errorEl.innerHTML = `<p><strong>Error:</strong> <span class="error">${JSON.stringify(error, null, 2)}</span></p>`;
+  const p = document.createElement('p');
+  const strong = document.createElement('strong');
+  strong.textContent = 'Error:';
+  const span = document.createElement('span');
+  span.className = 'error';
+  span.textContent = JSON.stringify(error, null, 2);
+  p.append(strong, document.createTextNode(' '), span);
+  errorEl.appendChild(p);
   document.body.appendChild(errorEl);
 }
 
@@ -53,7 +60,14 @@ function displayTokenResponse(
     }
 
     const tokenInfoEl = document.createElement('div');
-    tokenInfoEl.innerHTML = `<p><strong>Access Token:</strong> <span id="accessToken-${tokenIndex}">${response.accessToken}</span></p>`;
+    const tokenP = document.createElement('p');
+    const tokenStrong = document.createElement('strong');
+    tokenStrong.textContent = 'Access Token:';
+    const tokenSpan = document.createElement('span');
+    tokenSpan.id = `accessToken-${tokenIndex}`;
+    tokenSpan.textContent = response.accessToken;
+    tokenP.append(tokenStrong, document.createTextNode(' '), tokenSpan);
+    tokenInfoEl.appendChild(tokenP);
     appEl?.appendChild(tokenInfoEl);
     tokenIndex++;
   }
@@ -162,7 +176,14 @@ export async function oidcApp({
 
       const appEl = document.getElementById('app');
       const userInfoEl = document.createElement('div');
-      userInfoEl.innerHTML = `<p><strong>User Info:</strong> <span id="userInfo">${JSON.stringify(userInfo, null, 2)}</span></p>`;
+      const userInfoP = document.createElement('p');
+      const userInfoStrong = document.createElement('strong');
+      userInfoStrong.textContent = 'User Info:';
+      const userInfoSpan = document.createElement('span');
+      userInfoSpan.id = 'userInfo';
+      userInfoSpan.textContent = JSON.stringify(userInfo, null, 2);
+      userInfoP.append(userInfoStrong, document.createTextNode(' '), userInfoSpan);
+      userInfoEl.appendChild(userInfoP);
       appEl?.appendChild(userInfoEl);
     }
   });
@@ -178,7 +199,9 @@ export async function oidcApp({
     } else {
       const appEl = document.getElementById('app');
       const revokeEl = document.createElement('div');
-      revokeEl.innerHTML = `<p>Token successfully revoked</p>`;
+      const revokeP = document.createElement('p');
+      revokeP.textContent = 'Token successfully revoked';
+      revokeEl.appendChild(revokeP);
       appEl?.appendChild(revokeEl);
     }
   });
@@ -218,7 +241,30 @@ export async function oidcApp({
     const result = await oidcClient.user?.session();
     const appEl = document.getElementById('app');
     const el = document.createElement('div');
-    el.innerHTML = `<p><strong>Session Check (none):</strong></p><pre id="session-check-result">${JSON.stringify(result, null, 2)}</pre>`;
+    const title = document.createElement('p');
+    const titleStrong = document.createElement('strong');
+    titleStrong.textContent = 'Session Check (none, iframe):';
+    title.appendChild(titleStrong);
+    const pre = document.createElement('pre');
+    pre.id = 'session-check-result';
+    pre.textContent = JSON.stringify(result, null, 2);
+    el.append(title, pre);
+    appEl?.appendChild(el);
+  });
+
+  document.getElementById('session-check-no-redirect-btn')?.addEventListener('click', async () => {
+    const options: SessionCheckOptions = { redirectUri: '' };
+    const result = await oidcClient.user?.session(options);
+    const appEl = document.getElementById('app');
+    const el = document.createElement('div');
+    const title = document.createElement('p');
+    const titleStrong = document.createElement('strong');
+    titleStrong.textContent = 'Session Check (none, no redirect):';
+    title.appendChild(titleStrong);
+    const pre = document.createElement('pre');
+    pre.id = 'session-check-no-redirect-result';
+    pre.textContent = JSON.stringify(result, null, 2);
+    el.append(title, pre);
     appEl?.appendChild(el);
   });
 
@@ -227,7 +273,14 @@ export async function oidcApp({
     const result = await oidcClient.user?.session(options);
     const appEl = document.getElementById('app');
     const el = document.createElement('div');
-    el.innerHTML = `<p><strong>Session Check (id_token):</strong></p><pre id="session-check-id-token-result">${JSON.stringify(result, null, 2)}</pre>`;
+    const title = document.createElement('p');
+    const titleStrong = document.createElement('strong');
+    titleStrong.textContent = 'Session Check (id_token):';
+    title.appendChild(titleStrong);
+    const pre = document.createElement('pre');
+    pre.id = 'session-check-id-token-result';
+    pre.textContent = JSON.stringify(result, null, 2);
+    el.append(title, pre);
     appEl?.appendChild(el);
   });
 

--- a/e2e/oidc-app/src/utils/oidc-app.ts
+++ b/e2e/oidc-app/src/utils/oidc-app.ts
@@ -10,15 +10,16 @@ import { oidc } from '@forgerock/oidc-client';
 import type {
   AuthorizationError,
   GenericError,
-  GetAuthorizationUrlOptions,
   OauthTokens,
   OidcClient,
+  OidcConfig,
+  SessionCheckOptions,
   TokenExchangeErrorResponse,
 } from '@forgerock/oidc-client/types';
 
 let tokenIndex = 0;
 
-function displayError(error) {
+function displayError(error: unknown) {
   const errorEl = document.createElement('div');
   errorEl.innerHTML = `<p><strong>Error:</strong> <span class="error">${JSON.stringify(error, null, 2)}</span></p>`;
   document.body.appendChild(errorEl);
@@ -27,25 +28,44 @@ function displayError(error) {
 function displayTokenResponse(
   response: OauthTokens | TokenExchangeErrorResponse | GenericError | AuthorizationError,
 ) {
-  const appEl = document.getElementById('app');
   if ('error' in response || !('accessToken' in response)) {
     console.error('Token Error:', response);
     displayError(response);
   } else {
     console.log('Token Response:', response);
-    document.getElementById('logout').style.display = 'block';
-    document.getElementById('user-info-btn').style.display = 'block';
-    document.getElementById('login-background').style.display = 'none';
-    document.getElementById('login-redirect').style.display = 'none';
+    const appEl = document.getElementById('app');
+    const logoutEl = document.getElementById('logout');
+    const userInfoBtnEl = document.getElementById('user-info-btn');
+    const loginBackgroundEl = document.getElementById('login-background');
+    const loginRedirectEl = document.getElementById('login-redirect');
+
+    if (logoutEl) {
+      logoutEl.style.display = 'block';
+    }
+    if (userInfoBtnEl) {
+      userInfoBtnEl.style.display = 'block';
+    }
+    if (loginBackgroundEl) {
+      loginBackgroundEl.style.display = 'none';
+    }
+    if (loginRedirectEl) {
+      loginRedirectEl.style.display = 'none';
+    }
 
     const tokenInfoEl = document.createElement('div');
     tokenInfoEl.innerHTML = `<p><strong>Access Token:</strong> <span id="accessToken-${tokenIndex}">${response.accessToken}</span></p>`;
-    appEl.appendChild(tokenInfoEl);
+    appEl?.appendChild(tokenInfoEl);
     tokenIndex++;
   }
 }
 
-export async function oidcApp({ config, urlParams }) {
+export async function oidcApp({
+  config,
+  urlParams,
+}: {
+  config: OidcConfig;
+  urlParams: URLSearchParams;
+}) {
   const code = urlParams.get('code');
   const state = urlParams.get('state');
   const piflow = urlParams.get('piflow');
@@ -56,20 +76,23 @@ export async function oidcApp({ config, urlParams }) {
   });
   if ('error' in oidcClient) {
     displayError(oidcClient);
+    return;
   }
 
-  document.getElementById('login-background').addEventListener('click', async () => {
-    const authorizeOptions: GetAuthorizationUrlOptions =
+  document.getElementById('login-background')?.addEventListener('click', async () => {
+    const authorizeOptions =
       piflow === 'true'
         ? {
             clientId: config.clientId,
             redirectUri: config.redirectUri,
             scope: config.scope,
             responseType: config.responseType ?? 'code',
-            responseMode: 'pi.flow',
+            responseMode: 'pi.flow' as const,
           }
         : undefined;
-    const response = await oidcClient.authorize.background(authorizeOptions);
+    const response = await oidcClient.authorize?.background(authorizeOptions);
+
+    if (!response) return;
 
     if ('error' in response) {
       console.error('Authorization Error:', response);
@@ -85,13 +108,16 @@ export async function oidcApp({ config, urlParams }) {
       // Handle success response from background authorization
     } else if ('code' in response) {
       console.log('Authorization Code:', response.code);
-      const tokenResponse = await oidcClient.token.exchange(response.code, response.state);
-      displayTokenResponse(tokenResponse);
+      const tokenResponse = await oidcClient.token?.exchange(response.code, response.state);
+      if (tokenResponse) {
+        displayTokenResponse(tokenResponse);
+      }
     }
   });
 
-  document.getElementById('login-redirect').addEventListener('click', async () => {
-    const authorizeUrl = await oidcClient.authorize.url();
+  document.getElementById('login-redirect')?.addEventListener('click', async () => {
+    const authorizeUrl = await oidcClient.authorize?.url();
+    if (!authorizeUrl) return;
     if (typeof authorizeUrl !== 'string' && 'error' in authorizeUrl) {
       console.error('Authorization URL Error:', authorizeUrl);
       displayError(authorizeUrl);
@@ -102,23 +128,31 @@ export async function oidcApp({ config, urlParams }) {
     }
   });
 
-  document.getElementById('get-tokens').addEventListener('click', async () => {
-    const response = await oidcClient.token.get();
-    displayTokenResponse(response);
+  document.getElementById('get-tokens')?.addEventListener('click', async () => {
+    const response = await oidcClient.token?.get();
+    if (response) {
+      displayTokenResponse(response);
+    }
   });
 
-  document.getElementById('get-tokens-background').addEventListener('click', async () => {
-    const response = await oidcClient.token.get({ backgroundRenew: true });
-    displayTokenResponse(response);
+  document.getElementById('get-tokens-background')?.addEventListener('click', async () => {
+    const response = await oidcClient.token?.get({ backgroundRenew: true });
+    if (response) {
+      displayTokenResponse(response);
+    }
   });
 
-  document.getElementById('renew-tokens').addEventListener('click', async () => {
-    const response = await oidcClient.token.get({ backgroundRenew: true, forceRenew: true });
-    displayTokenResponse(response);
+  document.getElementById('renew-tokens')?.addEventListener('click', async () => {
+    const response = await oidcClient.token?.get({ backgroundRenew: true, forceRenew: true });
+    if (response) {
+      displayTokenResponse(response);
+    }
   });
 
-  document.getElementById('user-info-btn').addEventListener('click', async () => {
-    const userInfo = await oidcClient.user.info();
+  document.getElementById('user-info-btn')?.addEventListener('click', async () => {
+    const userInfo = await oidcClient.user?.info();
+
+    if (!userInfo) return;
 
     if ('error' in userInfo) {
       console.error('User Info Error:', userInfo);
@@ -129,42 +163,78 @@ export async function oidcApp({ config, urlParams }) {
       const appEl = document.getElementById('app');
       const userInfoEl = document.createElement('div');
       userInfoEl.innerHTML = `<p><strong>User Info:</strong> <span id="userInfo">${JSON.stringify(userInfo, null, 2)}</span></p>`;
-      appEl.appendChild(userInfoEl);
+      appEl?.appendChild(userInfoEl);
     }
   });
 
-  document.getElementById('revoke').addEventListener('click', async () => {
-    const response = await oidcClient.token.revoke();
+  document.getElementById('revoke')?.addEventListener('click', async () => {
+    const response = await oidcClient.token?.revoke();
+
+    if (!response) return;
 
     if ('error' in response) {
       console.error('Token Revocation Error:', response);
       displayError(response);
     } else {
       const appEl = document.getElementById('app');
-      const userInfoEl = document.createElement('div');
-      userInfoEl.innerHTML = `<p>Token successfully revoked</p>`;
-      appEl.appendChild(userInfoEl);
+      const revokeEl = document.createElement('div');
+      revokeEl.innerHTML = `<p>Token successfully revoked</p>`;
+      appEl?.appendChild(revokeEl);
     }
   });
 
-  document.getElementById('logout').addEventListener('click', async () => {
-    const response = await oidcClient.user.logout();
+  document.getElementById('logout')?.addEventListener('click', async () => {
+    const response = await oidcClient.user?.logout();
+
+    if (!response) return;
 
     if ('error' in response) {
       console.error('Logout Error:', response);
       displayError(response);
     } else {
       console.log('Logout successful');
-      document.getElementById('logout').style.display = 'none';
-      document.getElementById('user-info-btn').style.display = 'none';
-      document.getElementById('login-background').style.display = 'block';
-      document.getElementById('login-redirect').style.display = 'block';
+      const logoutEl = document.getElementById('logout');
+      const userInfoBtnEl = document.getElementById('user-info-btn');
+      const loginBackgroundEl = document.getElementById('login-background');
+      const loginRedirectEl = document.getElementById('login-redirect');
+
+      if (logoutEl) {
+        logoutEl.style.display = 'none';
+      }
+      if (userInfoBtnEl) {
+        userInfoBtnEl.style.display = 'none';
+      }
+      if (loginBackgroundEl) {
+        loginBackgroundEl.style.display = 'block';
+      }
+      if (loginRedirectEl) {
+        loginRedirectEl.style.display = 'block';
+      }
       window.location.assign(window.location.origin + window.location.pathname);
     }
   });
 
+  document.getElementById('session-check-btn')?.addEventListener('click', async () => {
+    const result = await oidcClient.session?.check();
+    const appEl = document.getElementById('app');
+    const el = document.createElement('div');
+    el.innerHTML = `<p><strong>Session Check (none):</strong></p><pre id="session-check-result">${JSON.stringify(result, null, 2)}</pre>`;
+    appEl?.appendChild(el);
+  });
+
+  document.getElementById('session-check-id-token-btn')?.addEventListener('click', async () => {
+    const options: SessionCheckOptions = { responseType: 'id_token' };
+    const result = await oidcClient.session?.check(options);
+    const appEl = document.getElementById('app');
+    const el = document.createElement('div');
+    el.innerHTML = `<p><strong>Session Check (id_token):</strong></p><pre id="session-check-id-token-result">${JSON.stringify(result, null, 2)}</pre>`;
+    appEl?.appendChild(el);
+  });
+
   if (code && state) {
-    const response = await oidcClient.token.exchange(code, state);
-    displayTokenResponse(response);
+    const response = await oidcClient.token?.exchange(code, state);
+    if (response) {
+      displayTokenResponse(response);
+    }
   }
 }

--- a/e2e/oidc-suites/src/session.spec.ts
+++ b/e2e/oidc-suites/src/session.spec.ts
@@ -29,7 +29,7 @@ function makeFakeJwt(payload: Record<string, unknown>): string {
   return `${header}.${body}.fakesignature`;
 }
 
-test.describe('session.check() tests', () => {
+test.describe('user.session() tests', () => {
   test('session check (none) succeeds after login', async ({ page }) => {
     const { navigate } = asyncEvents(page);
     await navigate('/ping-am/');
@@ -126,6 +126,7 @@ test.describe('session.check() tests', () => {
     await page.getByRole('button', { name: 'Session Check (id_token)' }).click();
     await expect(page.locator('#session-check-id-token-result')).not.toBeEmpty();
     const resultText = await page.locator('#session-check-id-token-result').textContent();
+    expect(resultText).toContain('"mode"');
     expect(resultText).toContain('"claims"');
     expect(resultText).not.toContain('"error"');
   });

--- a/e2e/oidc-suites/src/session.spec.ts
+++ b/e2e/oidc-suites/src/session.spec.ts
@@ -1,0 +1,246 @@
+/*
+ * Copyright © 2026 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+import { test, expect } from '@playwright/test';
+import { pingAmUsername, pingAmPassword } from './utils/demo-users.js';
+import { asyncEvents } from './utils/async-events.js';
+import { loginPingAm } from './utils/login.js';
+
+// The redirect URI the SDK is configured with for the PingAM app
+const REDIRECT_URI = 'http://localhost:8443/ping-am/';
+
+/**
+ * Build a minimal, syntactically valid JWT with the given payload.
+ * The signature segment is fake — this JWT is only used for nonce/sub validation
+ * in tests where the SDK's own logic reads the payload, not a real IdP.
+ */
+function makeFakeJwt(payload: Record<string, unknown>): string {
+  const header = btoa(JSON.stringify({ alg: 'RS256', typ: 'JWT' }))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=/g, '');
+  const body = btoa(JSON.stringify(payload))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=/g, '');
+  return `${header}.${body}.fakesignature`;
+}
+
+test.describe('session.check() tests', () => {
+  test('session check (none) succeeds after login', async ({ page }) => {
+    const { navigate } = asyncEvents(page);
+    await navigate('/ping-am/');
+
+    // Log in to obtain tokens in storage
+    await loginPingAm(page, pingAmUsername, pingAmPassword);
+
+    // Intercept the prompt=none authorize request and redirect back to the redirect URI
+    await page.route('**/authorize**', async (route, request) => {
+      const url = new URL(request.url());
+      if (url.searchParams.get('prompt') === 'none') {
+        await route.fulfill({
+          status: 302,
+          headers: { Location: REDIRECT_URI },
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await page.getByRole('button', { name: 'Session Check (none)', exact: true }).click();
+    await expect(page.locator('#session-check-result')).not.toBeEmpty();
+    const resultText = await page.locator('#session-check-result').textContent();
+    expect(resultText).not.toContain('"error"');
+  });
+
+  test('session check (none) fails with login_required', async ({ page }) => {
+    const { navigate } = asyncEvents(page);
+    await navigate('/ping-am/');
+
+    // Log in to obtain tokens (id_token_hint requires stored tokens)
+    await loginPingAm(page, pingAmUsername, pingAmPassword);
+
+    // Intercept and return an error response
+    await page.route('**/authorize**', async (route, request) => {
+      const url = new URL(request.url());
+      if (url.searchParams.get('prompt') === 'none') {
+        const redirectUri = url.searchParams.get('redirect_uri') ?? REDIRECT_URI;
+        await route.fulfill({
+          status: 302,
+          headers: {
+            Location: `${redirectUri}?error=login_required&error_description=User+not+authenticated`,
+          },
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await page.getByRole('button', { name: 'Session Check (none)', exact: true }).click();
+    await expect(page.locator('#session-check-result')).not.toBeEmpty();
+    const resultText = await page.locator('#session-check-result').textContent();
+    expect(resultText).toContain('"error": "login_required"');
+  });
+
+  test('session check (none) fails when no session exists', async ({ page }) => {
+    const { navigate } = asyncEvents(page);
+    // Navigate without logging in — no tokens in storage, no browser session
+    await navigate('/ping-am/');
+
+    await page.getByRole('button', { name: 'Session Check (none)', exact: true }).click();
+    await expect(page.locator('#session-check-result')).not.toBeEmpty();
+    const resultText = await page.locator('#session-check-result').textContent();
+    // PingAM returns login_required or interaction_required when there is no session
+    expect(resultText).toMatch(/"error": "(login_required|interaction_required)"/);
+  });
+
+  test('session check (id_token) succeeds with valid JWT in hash', async ({ page }) => {
+    const { navigate } = asyncEvents(page);
+    await navigate('/ping-am/');
+
+    // Log in to obtain tokens
+    await loginPingAm(page, pingAmUsername, pingAmPassword);
+
+    // Intercept the prompt=none authorize request; extract nonce and return synthetic JWT
+    await page.route('**/authorize**', async (route, request) => {
+      const url = new URL(request.url());
+      if (url.searchParams.get('prompt') === 'none') {
+        const nonce = url.searchParams.get('nonce') ?? '';
+        const state = url.searchParams.get('state') ?? '';
+        const redirectUri = url.searchParams.get('redirect_uri') ?? REDIRECT_URI;
+        const jwt = makeFakeJwt({ nonce, sub: 'test-user', iat: Math.floor(Date.now() / 1000) });
+        await route.fulfill({
+          status: 302,
+          headers: {
+            Location: `${redirectUri}#id_token=${jwt}&state=${state}`,
+          },
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await page.getByRole('button', { name: 'Session Check (id_token)' }).click();
+    await expect(page.locator('#session-check-id-token-result')).not.toBeEmpty();
+    const resultText = await page.locator('#session-check-id-token-result').textContent();
+    expect(resultText).toContain('"claims"');
+    expect(resultText).not.toContain('"error"');
+  });
+
+  test('session check (id_token) fails with login_required', async ({ page }) => {
+    const { navigate } = asyncEvents(page);
+    await navigate('/ping-am/');
+
+    // Log in to obtain tokens
+    await loginPingAm(page, pingAmUsername, pingAmPassword);
+
+    // Intercept and return an error response
+    await page.route('**/authorize**', async (route, request) => {
+      const url = new URL(request.url());
+      if (url.searchParams.get('prompt') === 'none') {
+        const redirectUri = url.searchParams.get('redirect_uri') ?? REDIRECT_URI;
+        await route.fulfill({
+          status: 302,
+          headers: {
+            Location: `${redirectUri}?error=login_required&error_description=Session+expired`,
+          },
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await page.getByRole('button', { name: 'Session Check (id_token)' }).click();
+    await expect(page.locator('#session-check-id-token-result')).not.toBeEmpty();
+    const resultText = await page.locator('#session-check-id-token-result').textContent();
+    expect(resultText).toContain('"error": "login_required"');
+  });
+
+  test('session check (none) succeeds even when redirect URI has extra query params', async ({
+    page,
+  }) => {
+    const { navigate } = asyncEvents(page);
+    await navigate('/ping-am/');
+
+    await loginPingAm(page, pingAmUsername, pingAmPassword);
+
+    // none mode resolves by recognising the redirect URI — extra params on the redirect are allowed
+    await page.route('**/authorize**', async (route, request) => {
+      const url = new URL(request.url());
+      if (url.searchParams.get('prompt') === 'none') {
+        await route.fulfill({
+          status: 302,
+          headers: {
+            Location: `${REDIRECT_URI}?session_state=some-opaque-value`,
+          },
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await page.getByRole('button', { name: 'Session Check (none)', exact: true }).click();
+    await expect(page.locator('#session-check-result')).not.toBeEmpty();
+    const resultText = await page.locator('#session-check-result').textContent();
+    expect(resultText).not.toContain('"error"');
+  });
+
+  test('session check (id_token) fails with nonce_mismatch when JWT contains wrong nonce', async ({
+    page,
+  }) => {
+    const { navigate } = asyncEvents(page);
+    await navigate('/ping-am/');
+
+    await loginPingAm(page, pingAmUsername, pingAmPassword);
+
+    await page.route('**/authorize**', async (route, request) => {
+      const url = new URL(request.url());
+      if (url.searchParams.get('prompt') === 'none') {
+        const state = url.searchParams.get('state') ?? '';
+        const redirectUri = url.searchParams.get('redirect_uri') ?? REDIRECT_URI;
+        // JWT has a different nonce than what the SDK generated
+        const jwt = makeFakeJwt({ nonce: 'wrong-nonce', sub: 'test-user' });
+        await route.fulfill({
+          status: 302,
+          headers: {
+            Location: `${redirectUri}#id_token=${jwt}&state=${state}`,
+          },
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await page.getByRole('button', { name: 'Session Check (id_token)' }).click();
+    await expect(page.locator('#session-check-id-token-result')).not.toBeEmpty();
+    const resultText = await page.locator('#session-check-id-token-result').textContent();
+    expect(resultText).toContain('"error": "nonce_mismatch"');
+  });
+
+  test('session check (none) fails with iframe_timeout when AS does not respond', async ({
+    page,
+  }) => {
+    const { navigate } = asyncEvents(page);
+    await navigate('/ping-am/');
+
+    await loginPingAm(page, pingAmUsername, pingAmPassword);
+
+    // Never fulfill the authorize request — let the iframe time out
+    await page.route('**/authorize**', async (route, request) => {
+      const url = new URL(request.url());
+      if (url.searchParams.get('prompt') === 'none') {
+        // intentionally do not call route.fulfill or route.continue
+      } else {
+        await route.continue();
+      }
+    });
+
+    await page.getByRole('button', { name: 'Session Check (none)', exact: true }).click();
+    await expect(page.locator('#session-check-result')).not.toBeEmpty();
+    const resultText = await page.locator('#session-check-result').textContent();
+    expect(resultText).toContain('"error": "iframe_timeout"');
+  });
+});

--- a/e2e/oidc-suites/src/session.spec.ts
+++ b/e2e/oidc-suites/src/session.spec.ts
@@ -50,7 +50,7 @@ test.describe('user.session() tests', () => {
       }
     });
 
-    await page.getByRole('button', { name: 'Session Check (none)', exact: true }).click();
+    await page.getByRole('button', { name: 'Session Check (none, iframe)', exact: true }).click();
     await expect(page.locator('#session-check-result')).not.toBeEmpty();
     const resultText = await page.locator('#session-check-result').textContent();
     expect(resultText).not.toContain('"error"');
@@ -79,22 +79,22 @@ test.describe('user.session() tests', () => {
       }
     });
 
-    await page.getByRole('button', { name: 'Session Check (none)', exact: true }).click();
+    await page.getByRole('button', { name: 'Session Check (none, iframe)', exact: true }).click();
     await expect(page.locator('#session-check-result')).not.toBeEmpty();
     const resultText = await page.locator('#session-check-result').textContent();
     expect(resultText).toContain('"error": "login_required"');
   });
 
-  test('session check (none) fails when no session exists', async ({ page }) => {
+  test('session check (none) fails with no_id_token_hint when not logged in', async ({ page }) => {
     const { navigate } = asyncEvents(page);
-    // Navigate without logging in — no tokens in storage, no browser session
+    // Navigate without logging in — no tokens in storage means no id_token_hint to send
     await navigate('/ping-am/');
 
-    await page.getByRole('button', { name: 'Session Check (none)', exact: true }).click();
+    await page.getByRole('button', { name: 'Session Check (none, iframe)', exact: true }).click();
     await expect(page.locator('#session-check-result')).not.toBeEmpty();
     const resultText = await page.locator('#session-check-result').textContent();
-    // PingAM returns login_required or interaction_required when there is no session
-    expect(resultText).toMatch(/"error": "(login_required|interaction_required)"/);
+    // response_type=none requires a stored id_token; fails early before reaching the AS
+    expect(resultText).toContain('"error": "no_id_token_hint"');
   });
 
   test('session check (id_token) succeeds with valid JWT in hash', async ({ page }) => {
@@ -126,7 +126,7 @@ test.describe('user.session() tests', () => {
     await page.getByRole('button', { name: 'Session Check (id_token)' }).click();
     await expect(page.locator('#session-check-id-token-result')).not.toBeEmpty();
     const resultText = await page.locator('#session-check-id-token-result').textContent();
-    expect(resultText).toContain('"mode"');
+    expect(resultText).toContain('"responseType"');
     expect(resultText).toContain('"claims"');
     expect(resultText).not.toContain('"error"');
   });
@@ -183,7 +183,7 @@ test.describe('user.session() tests', () => {
       }
     });
 
-    await page.getByRole('button', { name: 'Session Check (none)', exact: true }).click();
+    await page.getByRole('button', { name: 'Session Check (none, iframe)', exact: true }).click();
     await expect(page.locator('#session-check-result')).not.toBeEmpty();
     const resultText = await page.locator('#session-check-result').textContent();
     expect(resultText).not.toContain('"error"');
@@ -221,6 +221,67 @@ test.describe('user.session() tests', () => {
     expect(resultText).toContain('"error": "nonce_mismatch"');
   });
 
+  test('session check (none, no redirect) succeeds after login', async ({ page }) => {
+    const { navigate } = asyncEvents(page);
+    await navigate('/ping-am/');
+
+    await loginPingAm(page, pingAmUsername, pingAmPassword);
+
+    await page.route('**/authorize**', async (route, request) => {
+      const url = new URL(request.url());
+      if (url.searchParams.get('prompt') === 'none' && !url.searchParams.has('redirect_uri')) {
+        await route.fulfill({ status: 204 });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await page.getByRole('button', { name: 'Session Check (none, no redirect)' }).click();
+    await expect(page.locator('#session-check-no-redirect-result')).not.toBeEmpty();
+    const resultText = await page.locator('#session-check-no-redirect-result').textContent();
+    expect(resultText).not.toContain('"error"');
+  });
+
+  test('session check (none, no redirect) fails with login_required', async ({ page }) => {
+    const { navigate } = asyncEvents(page);
+    await navigate('/ping-am/');
+
+    await loginPingAm(page, pingAmUsername, pingAmPassword);
+
+    await page.route('**/authorize**', async (route, request) => {
+      const url = new URL(request.url());
+      if (url.searchParams.get('prompt') === 'none' && !url.searchParams.has('redirect_uri')) {
+        await route.fulfill({
+          status: 400,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            error: 'login_required',
+            error_description: 'User not authenticated',
+          }),
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await page.getByRole('button', { name: 'Session Check (none, no redirect)' }).click();
+    await expect(page.locator('#session-check-no-redirect-result')).not.toBeEmpty();
+    const resultText = await page.locator('#session-check-no-redirect-result').textContent();
+    expect(resultText).toContain('"error": "login_required"');
+  });
+
+  test('session check (none, no redirect) fails with no_id_token_hint when not logged in', async ({
+    page,
+  }) => {
+    const { navigate } = asyncEvents(page);
+    await navigate('/ping-am/');
+
+    await page.getByRole('button', { name: 'Session Check (none, no redirect)' }).click();
+    await expect(page.locator('#session-check-no-redirect-result')).not.toBeEmpty();
+    const resultText = await page.locator('#session-check-no-redirect-result').textContent();
+    expect(resultText).toContain('"error": "no_id_token_hint"');
+  });
+
   test('session check (none) fails with iframe_timeout when AS does not respond', async ({
     page,
   }) => {
@@ -239,7 +300,7 @@ test.describe('user.session() tests', () => {
       }
     });
 
-    await page.getByRole('button', { name: 'Session Check (none)', exact: true }).click();
+    await page.getByRole('button', { name: 'Session Check (none, iframe)', exact: true }).click();
     await expect(page.locator('#session-check-result')).not.toBeEmpty();
     const resultText = await page.locator('#session-check-result').textContent();
     expect(resultText).toContain('"error": "iframe_timeout"');

--- a/e2e/oidc-suites/src/utils/login.ts
+++ b/e2e/oidc-suites/src/utils/login.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright © 2026 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+import { expect, type Page } from '@playwright/test';
+import { asyncEvents } from './async-events.js';
+
+export async function loginPingAm(page: Page, username: string, password: string) {
+  const { clickWithRedirect } = asyncEvents(page);
+  await clickWithRedirect('Login (Background)', '**/am/XUI/**');
+  await page.getByLabel('User Name').fill(username);
+  await page.getByRole('textbox', { name: 'Password' }).fill(password);
+  await clickWithRedirect('Next', 'http://localhost:8443/ping-am/**');
+  await expect(page.locator('#accessToken-0')).not.toBeEmpty();
+}

--- a/packages/davinci-client/api-report/davinci-client.api.md
+++ b/packages/davinci-client/api-report/davinci-client.api.md
@@ -289,11 +289,13 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
     resume: (input: {
         continueToken: string;
     }) => Promise<InternalErrorResponse | NodeStates>;
-    start: <QueryParams extends OutgoingQueryParams = OutgoingQueryParams>(options?: StartOptions<QueryParams> | undefined) => Promise<ContinueNode | ErrorNode | FailureNode | StartNode | SuccessNode>;
+    start: <QueryParams extends OutgoingQueryParams = OutgoingQueryParams>(options?: StartOptions<QueryParams> | undefined) => Promise<ContinueNode | StartNode | ErrorNode | FailureNode | SuccessNode>;
     update: <T extends SingleValueCollectors | MultiSelectCollector | ObjectValueCollectors | AutoCollectors>(collector: T) => Updater<T>;
     validate: (collector: SingleValueCollectors | ObjectValueCollectors | MultiValueCollectors | AutoCollectors) => Validator;
     pollStatus: (collector: PollingCollector) => Poller;
     getClient: () => {
+        status: "start";
+    } | {
         action: string;
         collectors: Collectors[];
         description?: string;
@@ -307,8 +309,6 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         status: "error";
     } | {
         status: "failure";
-    } | {
-        status: "start";
     } | {
         authorization?: {
             code?: string;
@@ -319,7 +319,7 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
     getCollectors: () => Collectors[];
     getError: () => DaVinciError | null;
     getErrorCollectors: () => CollectorErrors[];
-    getNode: () => ContinueNode | ErrorNode | FailureNode | StartNode | SuccessNode;
+    getNode: () => ContinueNode | StartNode | ErrorNode | FailureNode | SuccessNode;
     getServer: () => {
         _links?: Links;
         id?: string;
@@ -328,6 +328,8 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         href?: string;
         eventName?: string;
         status: "continue";
+    } | {
+        status: "start";
     } | {
         _links?: Links;
         eventName?: string;
@@ -343,8 +345,6 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         interactionId?: string;
         interactionToken?: string;
         status: "failure";
-    } | {
-        status: "start";
     } | {
         _links?: Links;
         eventName?: string;

--- a/packages/davinci-client/api-report/davinci-client.types.api.md
+++ b/packages/davinci-client/api-report/davinci-client.types.api.md
@@ -289,11 +289,13 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
     resume: (input: {
         continueToken: string;
     }) => Promise<InternalErrorResponse | NodeStates>;
-    start: <QueryParams extends OutgoingQueryParams = OutgoingQueryParams>(options?: StartOptions<QueryParams> | undefined) => Promise<ContinueNode | ErrorNode | FailureNode | StartNode | SuccessNode>;
+    start: <QueryParams extends OutgoingQueryParams = OutgoingQueryParams>(options?: StartOptions<QueryParams> | undefined) => Promise<ContinueNode | StartNode | ErrorNode | FailureNode | SuccessNode>;
     update: <T extends SingleValueCollectors | MultiSelectCollector | ObjectValueCollectors | AutoCollectors>(collector: T) => Updater<T>;
     validate: (collector: SingleValueCollectors | ObjectValueCollectors | MultiValueCollectors | AutoCollectors) => Validator;
     pollStatus: (collector: PollingCollector) => Poller;
     getClient: () => {
+        status: "start";
+    } | {
         action: string;
         collectors: Collectors[];
         description?: string;
@@ -307,8 +309,6 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         status: "error";
     } | {
         status: "failure";
-    } | {
-        status: "start";
     } | {
         authorization?: {
             code?: string;
@@ -319,7 +319,7 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
     getCollectors: () => Collectors[];
     getError: () => DaVinciError | null;
     getErrorCollectors: () => CollectorErrors[];
-    getNode: () => ContinueNode | ErrorNode | FailureNode | StartNode | SuccessNode;
+    getNode: () => ContinueNode | StartNode | ErrorNode | FailureNode | SuccessNode;
     getServer: () => {
         _links?: Links;
         id?: string;
@@ -328,6 +328,8 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         href?: string;
         eventName?: string;
         status: "continue";
+    } | {
+        status: "start";
     } | {
         _links?: Links;
         eventName?: string;
@@ -343,8 +345,6 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         interactionId?: string;
         interactionToken?: string;
         status: "failure";
-    } | {
-        status: "start";
     } | {
         _links?: Links;
         eventName?: string;

--- a/packages/oidc-client/README.md
+++ b/packages/oidc-client/README.md
@@ -180,6 +180,59 @@ Logs out the user by revoking tokens and clearing the storage. Uses the end sess
 const logoutResponse = await oidcClient.user.logout();
 ```
 
+#### `user.session(options?)`
+
+Checks whether the user has an active session at the AS without prompting for login (`prompt=none`).
+
+- **Parameters**: `SessionCheckOptions` (optional)
+- **Returns**: `Promise<SessionCheckSuccess | GenericError>`
+
+```js
+const session = await oidcClient.user.session();
+if ('error' in session) {
+  // No active session
+}
+```
+
+##### `responseType: 'none'` (default)
+
+Use when you only need to know if a session is alive — no claims are returned.
+
+Requires a stored `id_token` to send as `id_token_hint`. Fails immediately with `no_id_token_hint` if storage is empty.
+
+How the check runs depends on `redirectUri`:
+
+- **With `redirectUri`** (iframe): a hidden iframe loads the authorization URL. The AS redirects to `redirectUri` on success or appends error params on failure. The `redirectUri` must be same-origin — the browser blocks cross-origin iframe content access.
+- **Without `redirectUri`** (fetch): a plain GET to the authorization endpoint — no iframe. The AS returns `204` on success or `400` on failure. Use this when no same-origin callback page is available.
+
+Returns `{ responseType: 'none' }` on success.
+
+##### `responseType: 'id_token'`
+
+Use when you need the user's claims back from the session. The AS issues a fresh `id_token` whose decoded claims are returned on success.
+
+Always uses the iframe path — `redirectUri` is required. A stored `id_token` is sent as `id_token_hint` if available but is not required.
+
+`state` and `nonce` are validated before claims are returned. If `subject` is provided, the `sub` claim must also match — otherwise any active session's claims are returned.
+
+```js
+const session = await oidcClient.user.session({
+  responseType: 'id_token',
+  subject: knownUserId, // optional — omit to get claims for whoever is logged in
+});
+if (!('error' in session)) {
+  console.log(session.claims); // JWTPayload
+}
+```
+
+Returns `{ responseType: 'id_token', claims: JWTPayload }` on success.
+
+##### PingOne compatibility note
+
+PingOne SaaS does not support `response_type=none`. Its authorization server only accepts `code`, `token`, and `id_token` as response types — `none` is not listed as an option in the [PingOne application configuration](https://docs.pingidentity.com/pingone/applications/p1_edit_application_oidc.html), the [PingOne response types reference](https://docs.pingidentity.com/pingone/applications/p1_responsetypes.html), the [PingOne Platform API reference](https://developer.pingidentity.com/pingone-api/auth/openid-connect-oauth-2.html), or the [PingOne support for response_mode options](https://developer.pingidentity.com/pingone-api/auth/auth-config-options/browserless-authentication-flow-options.html#pingone-support-for-response_mode-options).
+
+Use `responseType: 'id_token'` when connecting to PingOne.
+
 ## Usage Examples
 
 ### Redirect-Based Login (`authorize.url()`)

--- a/packages/oidc-client/api-report/oidc-client.api.md
+++ b/packages/oidc-client/api-report/oidc-client.api.md
@@ -135,6 +135,11 @@ responseType: SessionCheckResponseType;
 }, BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError, {}, FetchBaseQueryMeta>, never, {
 params: Record<string, string>;
 }, "oidc", unknown>;
+sessionCheckFetch: MutationDefinition<    {
+url: string;
+}, BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError, {}, FetchBaseQueryMeta>, never, {
+status: 204;
+}, "oidc", unknown>;
 authorizeIframe: MutationDefinition<    {
 url: string;
 }, BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError, {}, FetchBaseQueryMeta>, never, AuthorizationSuccess, "oidc", unknown>;
@@ -176,6 +181,11 @@ url: string;
 responseType: SessionCheckResponseType;
 }, BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError, {}, FetchBaseQueryMeta>, never, {
 params: Record<string, string>;
+}, "oidc", unknown>;
+sessionCheckFetch: MutationDefinition<    {
+url: string;
+}, BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError, {}, FetchBaseQueryMeta>, never, {
+status: 204;
 }, "oidc", unknown>;
 authorizeIframe: MutationDefinition<    {
 url: string;
@@ -364,10 +374,8 @@ export type SessionCheckResponseType = 'id_token' | 'none';
 
 // @public (undocumented)
 export type SessionCheckSuccess = {
-    mode: 'none';
-} | {
-    mode: 'id_token';
-    claims: JWTPayload;
+    responseType: SessionCheckResponseType;
+    claims?: JWTPayload;
 };
 
 export { StorageConfig }

--- a/packages/oidc-client/api-report/oidc-client.api.md
+++ b/packages/oidc-client/api-report/oidc-client.api.md
@@ -128,6 +128,12 @@ par: MutationDefinition<    {
 endpoint: string;
 body: URLSearchParams;
 }, BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError, {}, FetchBaseQueryMeta>, never, PushAuthorizationResponse, "oidc", unknown>;
+sessionCheckIframe: MutationDefinition<    {
+url: string;
+responseType: SessionCheckResponseType;
+}, BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError, {}, FetchBaseQueryMeta>, never, {
+params: Record<string, string>;
+}, "oidc", unknown>;
 authorizeIframe: MutationDefinition<    {
 url: string;
 }, BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError, {}, FetchBaseQueryMeta>, never, AuthorizationSuccess, "oidc", unknown>;
@@ -164,6 +170,12 @@ par: MutationDefinition<    {
 endpoint: string;
 body: URLSearchParams;
 }, BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError, {}, FetchBaseQueryMeta>, never, PushAuthorizationResponse, "oidc", unknown>;
+sessionCheckIframe: MutationDefinition<    {
+url: string;
+responseType: SessionCheckResponseType;
+}, BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError, {}, FetchBaseQueryMeta>, never, {
+params: Record<string, string>;
+}, "oidc", unknown>;
 authorizeIframe: MutationDefinition<    {
 url: string;
 }, BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError, {}, FetchBaseQueryMeta>, never, AuthorizationSuccess, "oidc", unknown>;
@@ -265,6 +277,7 @@ export function oidc<ActionType extends ActionTypes = ActionTypes>(input: {
     authorize?: undefined;
     token?: undefined;
     user?: undefined;
+    session?: undefined;
 } | {
     subscribe: (listener: () => void) => Unsubscribe;
     authorize: {
@@ -279,6 +292,9 @@ export function oidc<ActionType extends ActionTypes = ActionTypes>(input: {
     user: {
         info: () => Promise<GenericError | UserInfoResponse>;
         logout: () => Promise<GenericError | LogoutSuccessResult | LogoutErrorResult>;
+    };
+    session: {
+        check: (options?: SessionCheckOptions) => Promise<SessionCheckSuccess | GenericError>;
     };
     error?: undefined;
     type?: undefined;
@@ -336,6 +352,28 @@ export type RevokeSuccessResult = {
 
 // @public (undocumented)
 export type RootState = ReturnType<ClientStore['getState']>;
+
+// @public
+export interface SessionCheckOptions {
+    redirectUri?: string;
+    responseType?: SessionCheckResponseType;
+    scope?: string;
+    subject?: string;
+}
+
+// @public (undocumented)
+export const SessionCheckResponseType: {
+    readonly IdToken: "id_token";
+    readonly None: "none";
+};
+
+// @public (undocumented)
+export type SessionCheckResponseType = (typeof SessionCheckResponseType)[keyof typeof SessionCheckResponseType];
+
+// @public (undocumented)
+export interface SessionCheckSuccess {
+    claims?: Record<string, unknown>;
+}
 
 export { StorageConfig }
 

--- a/packages/oidc-client/api-report/oidc-client.api.md
+++ b/packages/oidc-client/api-report/oidc-client.api.md
@@ -15,6 +15,7 @@ import type { FetchBaseQueryError } from '@reduxjs/toolkit/query';
 import { FetchBaseQueryMeta } from '@reduxjs/toolkit/query';
 import { GenericError } from '@forgerock/sdk-types';
 import { GetAuthorizationUrlOptions } from '@forgerock/sdk-types';
+import type { JWTPayload } from 'jose';
 import { logger } from '@forgerock/sdk-logger';
 import { LogLevel } from '@forgerock/sdk-logger';
 import { LogMessage } from '@forgerock/sdk-logger';
@@ -277,7 +278,6 @@ export function oidc<ActionType extends ActionTypes = ActionTypes>(input: {
     authorize?: undefined;
     token?: undefined;
     user?: undefined;
-    session?: undefined;
 } | {
     subscribe: (listener: () => void) => Unsubscribe;
     authorize: {
@@ -292,9 +292,7 @@ export function oidc<ActionType extends ActionTypes = ActionTypes>(input: {
     user: {
         info: () => Promise<GenericError | UserInfoResponse>;
         logout: () => Promise<GenericError | LogoutSuccessResult | LogoutErrorResult>;
-    };
-    session: {
-        check: (options?: SessionCheckOptions) => Promise<SessionCheckSuccess | GenericError>;
+        session: (options?: SessionCheckOptions) => Promise<SessionCheckSuccess | GenericError>;
     };
     error?: undefined;
     type?: undefined;
@@ -362,18 +360,15 @@ export interface SessionCheckOptions {
 }
 
 // @public (undocumented)
-export const SessionCheckResponseType: {
-    readonly IdToken: "id_token";
-    readonly None: "none";
+export type SessionCheckResponseType = 'id_token' | 'none';
+
+// @public (undocumented)
+export type SessionCheckSuccess = {
+    mode: 'none';
+} | {
+    mode: 'id_token';
+    claims: JWTPayload;
 };
-
-// @public (undocumented)
-export type SessionCheckResponseType = (typeof SessionCheckResponseType)[keyof typeof SessionCheckResponseType];
-
-// @public (undocumented)
-export interface SessionCheckSuccess {
-    claims?: Record<string, unknown>;
-}
 
 export { StorageConfig }
 

--- a/packages/oidc-client/api-report/oidc-client.types.api.md
+++ b/packages/oidc-client/api-report/oidc-client.types.api.md
@@ -135,6 +135,11 @@ responseType: SessionCheckResponseType;
 }, BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError, {}, FetchBaseQueryMeta>, never, {
 params: Record<string, string>;
 }, "oidc", unknown>;
+sessionCheckFetch: MutationDefinition<    {
+url: string;
+}, BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError, {}, FetchBaseQueryMeta>, never, {
+status: 204;
+}, "oidc", unknown>;
 authorizeIframe: MutationDefinition<    {
 url: string;
 }, BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError, {}, FetchBaseQueryMeta>, never, AuthorizationSuccess, "oidc", unknown>;
@@ -176,6 +181,11 @@ url: string;
 responseType: SessionCheckResponseType;
 }, BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError, {}, FetchBaseQueryMeta>, never, {
 params: Record<string, string>;
+}, "oidc", unknown>;
+sessionCheckFetch: MutationDefinition<    {
+url: string;
+}, BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError, {}, FetchBaseQueryMeta>, never, {
+status: 204;
 }, "oidc", unknown>;
 authorizeIframe: MutationDefinition<    {
 url: string;
@@ -364,10 +374,8 @@ export type SessionCheckResponseType = 'id_token' | 'none';
 
 // @public (undocumented)
 export type SessionCheckSuccess = {
-    mode: 'none';
-} | {
-    mode: 'id_token';
-    claims: JWTPayload;
+    responseType: SessionCheckResponseType;
+    claims?: JWTPayload;
 };
 
 export { StorageConfig }

--- a/packages/oidc-client/api-report/oidc-client.types.api.md
+++ b/packages/oidc-client/api-report/oidc-client.types.api.md
@@ -128,6 +128,12 @@ par: MutationDefinition<    {
 endpoint: string;
 body: URLSearchParams;
 }, BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError, {}, FetchBaseQueryMeta>, never, PushAuthorizationResponse, "oidc", unknown>;
+sessionCheckIframe: MutationDefinition<    {
+url: string;
+responseType: SessionCheckResponseType;
+}, BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError, {}, FetchBaseQueryMeta>, never, {
+params: Record<string, string>;
+}, "oidc", unknown>;
 authorizeIframe: MutationDefinition<    {
 url: string;
 }, BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError, {}, FetchBaseQueryMeta>, never, AuthorizationSuccess, "oidc", unknown>;
@@ -164,6 +170,12 @@ par: MutationDefinition<    {
 endpoint: string;
 body: URLSearchParams;
 }, BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError, {}, FetchBaseQueryMeta>, never, PushAuthorizationResponse, "oidc", unknown>;
+sessionCheckIframe: MutationDefinition<    {
+url: string;
+responseType: SessionCheckResponseType;
+}, BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError, {}, FetchBaseQueryMeta>, never, {
+params: Record<string, string>;
+}, "oidc", unknown>;
 authorizeIframe: MutationDefinition<    {
 url: string;
 }, BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError, {}, FetchBaseQueryMeta>, never, AuthorizationSuccess, "oidc", unknown>;
@@ -265,6 +277,7 @@ export function oidc<ActionType extends ActionTypes = ActionTypes>(input: {
     authorize?: undefined;
     token?: undefined;
     user?: undefined;
+    session?: undefined;
 } | {
     subscribe: (listener: () => void) => Unsubscribe;
     authorize: {
@@ -279,6 +292,9 @@ export function oidc<ActionType extends ActionTypes = ActionTypes>(input: {
     user: {
         info: () => Promise<GenericError | UserInfoResponse>;
         logout: () => Promise<GenericError | LogoutSuccessResult | LogoutErrorResult>;
+    };
+    session: {
+        check: (options?: SessionCheckOptions) => Promise<SessionCheckSuccess | GenericError>;
     };
     error?: undefined;
     type?: undefined;
@@ -336,6 +352,28 @@ export type RevokeSuccessResult = {
 
 // @public (undocumented)
 export type RootState = ReturnType<ClientStore['getState']>;
+
+// @public
+export interface SessionCheckOptions {
+    redirectUri?: string;
+    responseType?: SessionCheckResponseType;
+    scope?: string;
+    subject?: string;
+}
+
+// @public (undocumented)
+export const SessionCheckResponseType: {
+    readonly IdToken: "id_token";
+    readonly None: "none";
+};
+
+// @public (undocumented)
+export type SessionCheckResponseType = (typeof SessionCheckResponseType)[keyof typeof SessionCheckResponseType];
+
+// @public (undocumented)
+export interface SessionCheckSuccess {
+    claims?: Record<string, unknown>;
+}
 
 export { StorageConfig }
 

--- a/packages/oidc-client/api-report/oidc-client.types.api.md
+++ b/packages/oidc-client/api-report/oidc-client.types.api.md
@@ -15,6 +15,7 @@ import type { FetchBaseQueryError } from '@reduxjs/toolkit/query';
 import { FetchBaseQueryMeta } from '@reduxjs/toolkit/query';
 import { GenericError } from '@forgerock/sdk-types';
 import { GetAuthorizationUrlOptions } from '@forgerock/sdk-types';
+import type { JWTPayload } from 'jose';
 import { logger } from '@forgerock/sdk-logger';
 import { LogLevel } from '@forgerock/sdk-logger';
 import { LogMessage } from '@forgerock/sdk-logger';
@@ -277,7 +278,6 @@ export function oidc<ActionType extends ActionTypes = ActionTypes>(input: {
     authorize?: undefined;
     token?: undefined;
     user?: undefined;
-    session?: undefined;
 } | {
     subscribe: (listener: () => void) => Unsubscribe;
     authorize: {
@@ -292,9 +292,7 @@ export function oidc<ActionType extends ActionTypes = ActionTypes>(input: {
     user: {
         info: () => Promise<GenericError | UserInfoResponse>;
         logout: () => Promise<GenericError | LogoutSuccessResult | LogoutErrorResult>;
-    };
-    session: {
-        check: (options?: SessionCheckOptions) => Promise<SessionCheckSuccess | GenericError>;
+        session: (options?: SessionCheckOptions) => Promise<SessionCheckSuccess | GenericError>;
     };
     error?: undefined;
     type?: undefined;
@@ -362,18 +360,15 @@ export interface SessionCheckOptions {
 }
 
 // @public (undocumented)
-export const SessionCheckResponseType: {
-    readonly IdToken: "id_token";
-    readonly None: "none";
+export type SessionCheckResponseType = 'id_token' | 'none';
+
+// @public (undocumented)
+export type SessionCheckSuccess = {
+    mode: 'none';
+} | {
+    mode: 'id_token';
+    claims: JWTPayload;
 };
-
-// @public (undocumented)
-export type SessionCheckResponseType = (typeof SessionCheckResponseType)[keyof typeof SessionCheckResponseType];
-
-// @public (undocumented)
-export interface SessionCheckSuccess {
-    claims?: Record<string, unknown>;
-}
 
 export { StorageConfig }
 

--- a/packages/oidc-client/package.json
+++ b/packages/oidc-client/package.json
@@ -35,7 +35,8 @@
     "@forgerock/sdk-utilities": "workspace:*",
     "@forgerock/storage": "workspace:*",
     "@reduxjs/toolkit": "catalog:",
-    "effect": "catalog:effect"
+    "effect": "catalog:effect",
+    "jose": "catalog:"
   },
   "devDependencies": {
     "@effect/vitest": "catalog:effect",

--- a/packages/oidc-client/src/lib/client.store.test.ts
+++ b/packages/oidc-client/src/lib/client.store.test.ts
@@ -719,7 +719,7 @@ describe('authorize.url() with PAR enabled on non-pi.flow server', async () => {
   });
 });
 
-describe('session.check()', async () => {
+describe('user.session()', async () => {
   const config: OidcConfig = {
     clientId: '123456789',
     redirectUri: 'https://example.com/callback.html',
@@ -740,7 +740,7 @@ describe('session.check()', async () => {
     const oidcClient = await oidc({ config, storage: customStorageConfig });
     if ('error' in oidcClient) throw new Error('Error creating OIDC Client');
 
-    const result = await oidcClient.session.check();
+    const result = await oidcClient.user.session();
 
     if (!('error' in result)) {
       expect.fail('Expected SessionCheckError, got success');

--- a/packages/oidc-client/src/lib/client.store.test.ts
+++ b/packages/oidc-client/src/lib/client.store.test.ts
@@ -734,9 +734,8 @@ describe('user.session()', async () => {
     customStorage.remove(storageKey);
   });
 
-  it('returns a GenericError when no tokens are stored (best-effort: dispatch is attempted)', async () => {
-    // No tokens in storage — best-effort: id_token_hint is omitted, dispatch still runs.
-    // In Vitest (no real DOM), the iframe manager cannot run and surfaces a session_check_error.
+  it('returns a GenericError when no tokens are stored', async () => {
+    // response_type=none requires a stored id_token; failing before dispatch.
     const oidcClient = await oidc({ config, storage: customStorageConfig });
     if ('error' in oidcClient) throw new Error('Error creating OIDC Client');
 
@@ -745,8 +744,8 @@ describe('user.session()', async () => {
     if (!('error' in result)) {
       expect.fail('Expected SessionCheckError, got success');
     }
-    expect(result.error).toBe('session_check_error');
-    expect(result.type).toBe('network_error');
+    expect(result.error).toBe('no_id_token_hint');
+    expect(result.type).toBe('argument_error');
   });
 
   it('returns wellknown_error when authorization_endpoint is missing from the wellknown config', async () => {

--- a/packages/oidc-client/src/lib/client.store.test.ts
+++ b/packages/oidc-client/src/lib/client.store.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright © 2025 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -716,5 +716,61 @@ describe('authorize.url() with PAR enabled on non-pi.flow server', async () => {
     expect(parsed.searchParams.has('scope')).toBe(false);
     expect(parsed.searchParams.has('code_challenge')).toBe(false);
     expect(parsed.searchParams.has('redirect_uri')).toBe(false);
+  });
+});
+
+describe('session.check()', async () => {
+  const config: OidcConfig = {
+    clientId: '123456789',
+    redirectUri: 'https://example.com/callback.html',
+    scope: 'openid profile',
+    serverConfig: {
+      wellknown: 'https://api.example.com/wellknown',
+    },
+    responseType: 'code',
+  };
+
+  beforeEach(() => {
+    customStorage.remove(storageKey);
+  });
+
+  it('returns a GenericError when no tokens are stored (best-effort: dispatch is attempted)', async () => {
+    // No tokens in storage — best-effort: id_token_hint is omitted, dispatch still runs.
+    // In Vitest (no real DOM), the iframe manager cannot run and surfaces a session_check_error.
+    const oidcClient = await oidc({ config, storage: customStorageConfig });
+    if ('error' in oidcClient) throw new Error('Error creating OIDC Client');
+
+    const result = await oidcClient.session.check();
+
+    if (!('error' in result)) {
+      expect.fail('Expected SessionCheckError, got success');
+    }
+    expect(result.error).toBe('session_check_error');
+    expect(result.type).toBe('network_error');
+  });
+
+  it('returns wellknown_error when authorization_endpoint is missing from the wellknown config', async () => {
+    // When authorization_endpoint is missing, initWellknownQuery validates and returns an error,
+    // so oidc() itself returns a wellknown_error at factory initialization time.
+    server.use(
+      http.get('*/wellknown', async () =>
+        HttpResponse.json({
+          issuer: 'https://api.example.com/as/issuer',
+          // authorization_endpoint deliberately omitted — causes wellknown validation to fail
+          token_endpoint: 'https://api.example.com/as/token',
+          userinfo_endpoint: 'https://api.example.com/as/userinfo',
+          introspection_endpoint: 'https://api.example.com/as/introspect',
+          revocation_endpoint: 'https://api.example.com/as/revoke',
+        }),
+      ),
+    );
+
+    const result = await oidc({ config, storage: customStorageConfig });
+
+    // The factory itself surfaces a wellknown_error when the wellknown response is invalid
+    if (!('error' in result)) {
+      expect.fail('Expected wellknown_error, got client');
+    }
+    expect(result.type).toBe('wellknown_error');
   });
 });

--- a/packages/oidc-client/src/lib/client.store.ts
+++ b/packages/oidc-client/src/lib/client.store.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright © 2025 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -13,7 +13,10 @@ import { causeIsDie, exitIsFail, exitIsSuccess } from 'effect/Micro';
 import { authorizeµ, createParAuthorizeUrlµ } from './authorize.request.js';
 import { buildTokenExchangeµ } from './exchange.request.js';
 import { createClientStore, createTokenError } from './client.store.utils.js';
+import { isExpiryWithinThreshold } from './token.utils.js';
+import { logoutµ } from './logout.request.js';
 import { oidcApi } from './oidc.api.js';
+import { sessionCheckNoneµ, sessionCheckIdTokenµ } from './session.micros.js';
 import { wellknownApi, wellknownSelector } from './wellknown.api.js';
 
 import type { ActionTypes, RequestMiddleware } from '@forgerock/sdk-request-middleware';
@@ -32,8 +35,8 @@ import type {
 import type { OauthTokens, OidcConfig } from './config.types.js';
 import type { AuthorizationError, AuthorizationSuccess } from './authorize.request.types.js';
 import type { TokenExchangeErrorResponse } from './exchange.types.js';
-import { isExpiryWithinThreshold } from './token.utils.js';
-import { logoutµ } from './logout.request.js';
+import { SessionCheckResponseType } from './session.types.js';
+import type { SessionCheckOptions, SessionCheckSuccess } from './session.types.js';
 
 /**
  * @function oidc
@@ -598,6 +601,52 @@ export async function oidc<ActionType extends ActionTypes = ActionTypes>({
             error: 'Logout_Failure',
             message: defect instanceof Error ? defect.message : String(defect ?? 'Unknown defect'),
             type: 'auth_error',
+          };
+        }
+      },
+    },
+
+    /**
+     * An object containing methods for OIDC session management
+     */
+    session: {
+      /**
+       * @method check
+       * @description Checks whether the user has an active session at the authorization server
+       *              using a hidden iframe with prompt=none. Supports response_type=none (default)
+       *              and response_type=id_token.
+       * @param {SessionCheckOptions} options - Optional parameters for the session check.
+       * @returns {Promise<SessionCheckSuccess | GenericError>} - Never throws; returns a typed result.
+       */
+      check: async (options?: SessionCheckOptions): Promise<SessionCheckSuccess | GenericError> => {
+        const state = store.getState();
+        const wellknown = wellknownSelector(wellknownUrl, state);
+
+        if (!wellknown?.authorization_endpoint) {
+          return {
+            error: 'Wellknown missing authorization endpoint',
+            message: 'Authorization endpoint not found in wellknown configuration',
+            type: 'wellknown_error',
+          };
+        }
+
+        const micro =
+          options?.responseType === SessionCheckResponseType.IdToken
+            ? sessionCheckIdTokenµ(wellknown, config, store, storageClient, log, options)
+            : sessionCheckNoneµ(wellknown, config, store, storageClient, log, options);
+
+        const result = await Micro.runPromiseExit(micro);
+
+        if (exitIsSuccess(result)) {
+          return result.value;
+        } else if (exitIsFail(result)) {
+          return result.cause.error;
+        } else {
+          const defect = causeIsDie(result.cause) ? result.cause.defect : undefined;
+          return {
+            error: 'Session check failure',
+            message: defect instanceof Error ? defect.message : String(defect ?? 'Unknown defect'),
+            type: 'unknown_error',
           };
         }
       },

--- a/packages/oidc-client/src/lib/client.store.ts
+++ b/packages/oidc-client/src/lib/client.store.ts
@@ -12,7 +12,7 @@ import { causeIsDie, exitIsFail, exitIsSuccess } from 'effect/Micro';
 
 import { authorizeµ, createParAuthorizeUrlµ } from './authorize.request.js';
 import { buildTokenExchangeµ } from './exchange.request.js';
-import { createClientStore, createTokenError } from './client.store.utils.js';
+import { createClientStore, createTokenError, runMicroExit } from './client.store.utils.js';
 import { isExpiryWithinThreshold } from './token.utils.js';
 import { logoutµ } from './logout.request.js';
 import { oidcApi } from './oidc.api.js';
@@ -35,7 +35,6 @@ import type {
 import type { OauthTokens, OidcConfig } from './config.types.js';
 import type { AuthorizationError, AuthorizationSuccess } from './authorize.request.types.js';
 import type { TokenExchangeErrorResponse } from './exchange.types.js';
-import { SessionCheckResponseType } from './session.types.js';
 import type { SessionCheckOptions, SessionCheckSuccess } from './session.types.js';
 
 /**
@@ -258,20 +257,7 @@ export async function oidc<ActionType extends ActionTypes = ActionTypes>({
           }),
         );
 
-        const result = await Micro.runPromiseExit(getTokensµ);
-
-        if (exitIsSuccess(result)) {
-          return result.value;
-        } else if (exitIsFail(result)) {
-          return result.cause.error;
-        } else {
-          const defect = causeIsDie(result.cause) ? result.cause.defect : undefined;
-          return {
-            error: 'Token Exchange failure',
-            message: defect instanceof Error ? defect.message : String(defect ?? 'Unknown defect'),
-            type: 'exchange_error',
-          };
-        }
+        return runMicroExit(getTokensµ, 'Token Exchange failure', 'exchange_error');
       },
 
       /**
@@ -457,20 +443,7 @@ export async function oidc<ActionType extends ActionTypes = ActionTypes>({
           ),
         );
 
-        const result = await Micro.runPromiseExit(revokeµ);
-
-        if (exitIsSuccess(result)) {
-          return result.value;
-        } else if (exitIsFail(result)) {
-          return result.cause.error;
-        } else {
-          const defect = causeIsDie(result.cause) ? result.cause.defect : undefined;
-          return {
-            error: 'Token revocation failure',
-            message: defect instanceof Error ? defect.message : String(defect ?? 'Unknown defect'),
-            type: 'auth_error',
-          };
-        }
+        return runMicroExit(revokeµ, 'Token revocation failure', 'auth_error');
       },
     },
 
@@ -533,20 +506,7 @@ export async function oidc<ActionType extends ActionTypes = ActionTypes>({
           }),
         );
 
-        const result = await Micro.runPromiseExit(info);
-
-        if (exitIsSuccess(result)) {
-          return result.value;
-        } else if (exitIsFail(result)) {
-          return result.cause.error;
-        } else {
-          const defect = causeIsDie(result.cause) ? result.cause.defect : undefined;
-          return {
-            error: 'User Info retrieval failure',
-            message: defect instanceof Error ? defect.message : String(defect ?? 'Unknown defect'),
-            type: 'auth_error',
-          };
-        }
+        return runMicroExit(info, 'User Info retrieval failure', 'auth_error');
       },
 
       /**
@@ -587,38 +547,24 @@ export async function oidc<ActionType extends ActionTypes = ActionTypes>({
           return createTokenError('no_id_token');
         }
 
-        const result = await Micro.runPromiseExit(
+        return runMicroExit(
           logoutµ({ tokens, config, wellknown, store, storageClient }),
+          'Logout_Failure',
+          'auth_error',
         );
-
-        if (exitIsSuccess(result)) {
-          return result.value;
-        } else if (exitIsFail(result)) {
-          return result.cause.error;
-        } else {
-          const defect = causeIsDie(result.cause) ? result.cause.defect : undefined;
-          return {
-            error: 'Logout_Failure',
-            message: defect instanceof Error ? defect.message : String(defect ?? 'Unknown defect'),
-            type: 'auth_error',
-          };
-        }
       },
-    },
 
-    /**
-     * An object containing methods for OIDC session management
-     */
-    session: {
       /**
-       * @method check
+       * @method session
        * @description Checks whether the user has an active session at the authorization server
        *              using a hidden iframe with prompt=none. Supports response_type=none (default)
        *              and response_type=id_token.
        * @param {SessionCheckOptions} options - Optional parameters for the session check.
        * @returns {Promise<SessionCheckSuccess | GenericError>} - Never throws; returns a typed result.
        */
-      check: async (options?: SessionCheckOptions): Promise<SessionCheckSuccess | GenericError> => {
+      session: async (
+        options?: SessionCheckOptions,
+      ): Promise<SessionCheckSuccess | GenericError> => {
         const state = store.getState();
         const wellknown = wellknownSelector(wellknownUrl, state);
 
@@ -631,24 +577,11 @@ export async function oidc<ActionType extends ActionTypes = ActionTypes>({
         }
 
         const micro =
-          options?.responseType === SessionCheckResponseType.IdToken
+          options?.responseType === 'id_token'
             ? sessionCheckIdTokenµ(wellknown, config, store, storageClient, log, options)
             : sessionCheckNoneµ(wellknown, config, store, storageClient, log, options);
 
-        const result = await Micro.runPromiseExit(micro);
-
-        if (exitIsSuccess(result)) {
-          return result.value;
-        } else if (exitIsFail(result)) {
-          return result.cause.error;
-        } else {
-          const defect = causeIsDie(result.cause) ? result.cause.defect : undefined;
-          return {
-            error: 'Session check failure',
-            message: defect instanceof Error ? defect.message : String(defect ?? 'Unknown defect'),
-            type: 'unknown_error',
-          };
-        }
+        return runMicroExit(micro, 'Session check failure', 'unknown_error');
       },
     },
   };

--- a/packages/oidc-client/src/lib/client.store.ts
+++ b/packages/oidc-client/src/lib/client.store.ts
@@ -12,7 +12,8 @@ import { causeIsDie, exitIsFail, exitIsSuccess } from 'effect/Micro';
 
 import { authorizeµ, createParAuthorizeUrlµ } from './authorize.request.js';
 import { buildTokenExchangeµ } from './exchange.request.js';
-import { createClientStore, createTokenError, runMicroExit } from './client.store.utils.js';
+import { createClientStore, createTokenError } from './client.store.utils.js';
+import { handleMicroExit } from '@forgerock/sdk-utilities';
 import { isExpiryWithinThreshold } from './token.utils.js';
 import { logoutµ } from './logout.request.js';
 import { oidcApi } from './oidc.api.js';
@@ -257,7 +258,8 @@ export async function oidc<ActionType extends ActionTypes = ActionTypes>({
           }),
         );
 
-        return runMicroExit(getTokensµ, 'Token Exchange failure', 'exchange_error');
+        const result = await Micro.runPromiseExit(getTokensµ);
+        return handleMicroExit(result, 'Token Exchange failure', 'exchange_error');
       },
 
       /**
@@ -443,7 +445,8 @@ export async function oidc<ActionType extends ActionTypes = ActionTypes>({
           ),
         );
 
-        return runMicroExit(revokeµ, 'Token revocation failure', 'auth_error');
+        const result = await Micro.runPromiseExit(revokeµ);
+        return handleMicroExit(result, 'Token revocation failure', 'auth_error');
       },
     },
 
@@ -506,7 +509,8 @@ export async function oidc<ActionType extends ActionTypes = ActionTypes>({
           }),
         );
 
-        return runMicroExit(info, 'User Info retrieval failure', 'auth_error');
+        const result = await Micro.runPromiseExit(info);
+        return handleMicroExit(result, 'User Info retrieval failure', 'auth_error');
       },
 
       /**
@@ -547,11 +551,10 @@ export async function oidc<ActionType extends ActionTypes = ActionTypes>({
           return createTokenError('no_id_token');
         }
 
-        return runMicroExit(
+        const result = await Micro.runPromiseExit(
           logoutµ({ tokens, config, wellknown, store, storageClient }),
-          'Logout_Failure',
-          'auth_error',
         );
+        return handleMicroExit(result, 'Logout_Failure', 'auth_error');
       },
 
       /**
@@ -581,7 +584,8 @@ export async function oidc<ActionType extends ActionTypes = ActionTypes>({
             ? sessionCheckIdTokenµ(wellknown, config, store, storageClient, log, options)
             : sessionCheckNoneµ(wellknown, config, store, storageClient, log, options);
 
-        return runMicroExit(micro, 'Session check failure', 'unknown_error');
+        const result = await Micro.runPromiseExit(micro);
+        return handleMicroExit(result, 'Session check failure', 'unknown_error');
       },
     },
   };

--- a/packages/oidc-client/src/lib/client.store.utils.ts
+++ b/packages/oidc-client/src/lib/client.store.utils.ts
@@ -8,6 +8,8 @@ import type { ActionTypes, RequestMiddleware } from '@forgerock/sdk-request-midd
 import { logger as loggerFn } from '@forgerock/sdk-logger';
 
 import { configureStore, type SerializedError } from '@reduxjs/toolkit';
+import { Micro } from 'effect';
+import { causeIsDie, exitIsFail, exitIsSuccess } from 'effect/Micro';
 import { oidcApi } from './oidc.api.js';
 import { wellknownApi } from './wellknown.api.js';
 
@@ -80,6 +82,26 @@ export function createLogoutError(
     } as const;
   }
   return null;
+}
+
+export async function runMicroExit<T, E>(
+  micro: Micro.Micro<T, E>,
+  defectError: string,
+  defectType: GenericError['type'],
+): Promise<T | E | GenericError> {
+  const result = await Micro.runPromiseExit(micro);
+  if (exitIsSuccess(result)) {
+    return result.value;
+  }
+  if (exitIsFail(result)) {
+    return result.cause.error;
+  }
+  const defect = causeIsDie(result.cause) ? result.cause.defect : undefined;
+  return {
+    error: defectError,
+    message: defect instanceof Error ? defect.message : String(defect ?? 'Unknown defect'),
+    type: defectType,
+  };
 }
 
 export function createTokenError(type: 'no_tokens' | 'no_access_token' | 'no_id_token') {

--- a/packages/oidc-client/src/lib/client.store.utils.ts
+++ b/packages/oidc-client/src/lib/client.store.utils.ts
@@ -8,8 +8,6 @@ import type { ActionTypes, RequestMiddleware } from '@forgerock/sdk-request-midd
 import { logger as loggerFn } from '@forgerock/sdk-logger';
 
 import { configureStore, type SerializedError } from '@reduxjs/toolkit';
-import { Micro } from 'effect';
-import { causeIsDie, exitIsFail, exitIsSuccess } from 'effect/Micro';
 import { oidcApi } from './oidc.api.js';
 import { wellknownApi } from './wellknown.api.js';
 
@@ -82,26 +80,6 @@ export function createLogoutError(
     } as const;
   }
   return null;
-}
-
-export async function runMicroExit<T, E>(
-  micro: Micro.Micro<T, E>,
-  defectError: string,
-  defectType: GenericError['type'],
-): Promise<T | E | GenericError> {
-  const result = await Micro.runPromiseExit(micro);
-  if (exitIsSuccess(result)) {
-    return result.value;
-  }
-  if (exitIsFail(result)) {
-    return result.cause.error;
-  }
-  const defect = causeIsDie(result.cause) ? result.cause.defect : undefined;
-  return {
-    error: defectError,
-    message: defect instanceof Error ? defect.message : String(defect ?? 'Unknown defect'),
-    type: defectType,
-  };
 }
 
 export function createTokenError(type: 'no_tokens' | 'no_access_token' | 'no_id_token') {

--- a/packages/oidc-client/src/lib/oidc.api.ts
+++ b/packages/oidc-client/src/lib/oidc.api.ts
@@ -27,7 +27,7 @@ import type { AuthorizationSuccess, AuthorizeSuccessResponse } from './authorize
 import type { UserInfoResponse } from './client.types.js';
 import type { PushAuthorizationResponse } from './par.types.js';
 import type { GenericError } from '@forgerock/sdk-types';
-import { SessionCheckResponseType } from './session.types.js';
+import type { SessionCheckResponseType } from './session.types.js';
 
 const IFRAME_TIMEOUT_MS = 3000;
 
@@ -188,7 +188,6 @@ export const oidcApi = createApi({
     >({
       queryFn: async ({ url, responseType }, api) => {
         const { requestMiddleware, logger } = api.extra as Extras;
-        const isIdToken = responseType === SessionCheckResponseType.IdToken;
         const errorParams = ['error', 'error_description'];
 
         const request: FetchArgs = { url };
@@ -200,23 +199,25 @@ export const oidcApi = createApi({
           .applyQuery(async (req: FetchArgs) => {
             try {
               const timeout = req.timeout ?? IFRAME_TIMEOUT_MS;
-              const params = isIdToken
-                ? await iFrameManager().getParamsByRedirect({
-                    url: req.url,
-                    successParams: ['id_token'],
-                    errorParams,
-                    includeHashParams: true,
-                    timeout,
-                  })
-                : await iFrameManager().getParamsByRedirect({
-                    url: req.url,
-                    resolveOnRedirectUri: new URL(req.url).searchParams.get(
-                      'redirect_uri',
-                    ) as string,
-                    errorParams,
-                    successParams: [],
-                    timeout,
-                  });
+              const iframeOptions =
+                responseType === 'id_token'
+                  ? {
+                      url: req.url,
+                      successParams: ['id_token'],
+                      errorParams,
+                      includeHashParams: true,
+                      timeout,
+                    }
+                  : {
+                      url: req.url,
+                      resolveOnRedirectUri: new URL(req.url).searchParams.get(
+                        'redirect_uri',
+                      ) as string,
+                      errorParams,
+                      successParams: [],
+                      timeout,
+                    };
+              const params = await iFrameManager().getParamsByRedirect(iframeOptions);
 
               if ('error' in params) {
                 return {

--- a/packages/oidc-client/src/lib/oidc.api.ts
+++ b/packages/oidc-client/src/lib/oidc.api.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright © 2025 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -9,6 +9,8 @@ import {
   fetchBaseQuery,
   type FetchArgs,
   type FetchBaseQueryError,
+  type FetchBaseQueryMeta,
+  type QueryReturnValue,
 } from '@reduxjs/toolkit/query';
 import type { OidcConfig } from './config.types.js';
 import { transformError } from './oidc.api.utils.js';
@@ -24,6 +26,10 @@ import type { TokenExchangeResponse } from './exchange.types.js';
 import type { AuthorizationSuccess, AuthorizeSuccessResponse } from './authorize.request.types.js';
 import type { UserInfoResponse } from './client.types.js';
 import type { PushAuthorizationResponse } from './par.types.js';
+import type { GenericError } from '@forgerock/sdk-types';
+import { SessionCheckResponseType } from './session.types.js';
+
+const IFRAME_TIMEOUT_MS = 3000;
 
 interface Extras<ActionType extends ActionTypes = ActionTypes, Payload = unknown> {
   requestMiddleware: RequestMiddleware<ActionType, Payload>[];
@@ -174,6 +180,96 @@ export const oidcApi = createApi({
         }
 
         return response as { data: PushAuthorizationResponse };
+      },
+    }),
+    sessionCheckIframe: builder.mutation<
+      { params: Record<string, string> },
+      { url: string; responseType: SessionCheckResponseType }
+    >({
+      queryFn: async ({ url, responseType }, api) => {
+        const { requestMiddleware, logger } = api.extra as Extras;
+        const isIdToken = responseType === SessionCheckResponseType.IdToken;
+        const errorParams = ['error', 'error_description'];
+
+        const request: FetchArgs = { url };
+
+        logger.debug('OIDC session check iframe request', request);
+
+        const response = await initQuery(request, 'authorize')
+          .applyMiddleware(requestMiddleware)
+          .applyQuery(async (req: FetchArgs) => {
+            try {
+              const timeout = req.timeout ?? IFRAME_TIMEOUT_MS;
+              const params = isIdToken
+                ? await iFrameManager().getParamsByRedirect({
+                    url: req.url,
+                    successParams: ['id_token'],
+                    errorParams,
+                    includeHashParams: true,
+                    timeout,
+                  })
+                : await iFrameManager().getParamsByRedirect({
+                    url: req.url,
+                    resolveOnRedirectUri: new URL(req.url).searchParams.get(
+                      'redirect_uri',
+                    ) as string,
+                    errorParams,
+                    successParams: [],
+                    timeout,
+                  });
+
+              if ('error' in params) {
+                return {
+                  error: {
+                    status: 400,
+                    statusText: 'SESSION_CHECK_ERROR',
+                    data: {
+                      error: params.error,
+                      message: params.error_description ?? 'An error occurred during session check',
+                      type: 'auth_error',
+                    } satisfies GenericError,
+                  },
+                };
+              }
+
+              return { data: { params } };
+            } catch (error) {
+              const isTimeout =
+                error instanceof Object &&
+                'message' in error &&
+                (error as { message: string }).message === 'iframe timed out';
+
+              return {
+                error: {
+                  status: 400,
+                  statusText: 'SESSION_CHECK_ERROR',
+                  data: {
+                    error: isTimeout ? 'iframe_timeout' : 'session_check_error',
+                    message: isTimeout
+                      ? 'Session check timed out waiting for iframe response'
+                      : 'An unexpected error occurred during session check',
+                    type: 'network_error',
+                  } satisfies GenericError,
+                },
+              };
+            }
+          });
+
+        if ('error' in response) {
+          logger.error('Error in session check iframe', response);
+          return response as QueryReturnValue<
+            { params: Record<string, string> },
+            FetchBaseQueryError,
+            FetchBaseQueryMeta
+          >;
+        }
+
+        logger.debug('OIDC session check iframe response', response);
+        return response as QueryReturnValue<
+          { params: Record<string, string> },
+          FetchBaseQueryError,
+          FetchBaseQueryMeta
+        >;
       },
     }),
     authorizeIframe: builder.mutation<AuthorizationSuccess, { url: string }>({

--- a/packages/oidc-client/src/lib/oidc.api.ts
+++ b/packages/oidc-client/src/lib/oidc.api.ts
@@ -192,7 +192,7 @@ export const oidcApi = createApi({
 
         const request: FetchArgs = { url };
 
-        logger.debug('OIDC session check iframe request', request);
+        logger.debug('OIDC session check iframe request', { responseType });
 
         const response = await initQuery(request, 'authorize')
           .applyMiddleware(requestMiddleware)
@@ -258,19 +258,58 @@ export const oidcApi = createApi({
 
         if ('error' in response) {
           logger.error('Error in session check iframe', response);
-          return response as QueryReturnValue<
-            { params: Record<string, string> },
-            FetchBaseQueryError,
-            FetchBaseQueryMeta
-          >;
+        } else {
+          logger.debug('OIDC session check iframe response received');
         }
 
-        logger.debug('OIDC session check iframe response', response);
         return response as QueryReturnValue<
           { params: Record<string, string> },
           FetchBaseQueryError,
           FetchBaseQueryMeta
         >;
+      },
+    }),
+    sessionCheckFetch: builder.mutation<{ status: 204 }, { url: string }>({
+      queryFn: async ({ url }, api, _, baseQuery) => {
+        const { requestMiddleware, logger } = api.extra as Extras;
+
+        const request: FetchArgs = {
+          url,
+          method: 'GET',
+          credentials: 'include',
+          headers: {
+            Accept: 'application/json',
+          },
+        };
+
+        logger.debug('OIDC session check fetch request');
+
+        const response = await initQuery(request, 'authorize')
+          .applyMiddleware(requestMiddleware)
+          .applyQuery(async (req: FetchArgs) => await baseQuery(req));
+
+        const responseError =
+          response.error ??
+          (response.meta?.response?.status !== 204 ? response.meta?.response : undefined);
+        if (responseError) {
+          const isClientError =
+            typeof responseError.status === 'number' && responseError.status < 500;
+          logger.error('Error in session check fetch', responseError);
+          return {
+            error: {
+              status: responseError.status ?? 'CUSTOM_ERROR',
+              statusText: 'SESSION_CHECK_ERROR',
+              data: {
+                error: isClientError ? 'login_required' : 'session_check_error',
+                message: isClientError ? 'The request requires login.' : 'Session check failed.',
+                type: isClientError ? 'auth_error' : 'network_error',
+              } satisfies GenericError,
+            } as FetchBaseQueryError,
+          };
+        }
+
+        logger.debug('OIDC session check fetch response received');
+        return { data: { status: 204 } };
       },
     }),
     authorizeIframe: builder.mutation<AuthorizationSuccess, { url: string }>({

--- a/packages/oidc-client/src/lib/session.micros.test.ts
+++ b/packages/oidc-client/src/lib/session.micros.test.ts
@@ -12,7 +12,8 @@ import * as sdkUtilities from '@forgerock/sdk-utilities';
 import {
   buildNoneUrl,
   buildIdTokenUrl,
-  dispatchSessionCheckµ,
+  dispatchSessionCheckIframeµ,
+  dispatchSessionCheckFetchµ,
   readStoredIdTokenµ,
   sessionCheckIdTokenµ,
   sessionCheckNoneµ,
@@ -89,11 +90,23 @@ function makeDispatchSetup(dispatchResult: unknown) {
   return { capturedArgs, store, dispatch };
 }
 
+function makeFetchDispatchSetup(dispatchResult: unknown) {
+  const sentinel = Symbol('fetch-dispatch-sentinel');
+  vi.spyOn(oidcApi.endpoints.sessionCheckFetch, 'initiate').mockImplementation(() => {
+    return sentinel as unknown as ReturnType<typeof oidcApi.endpoints.sessionCheckFetch.initiate>;
+  });
+
+  const dispatch = vi.fn().mockResolvedValue(dispatchResult);
+  const store: ClientStore = { dispatch } as unknown as ClientStore;
+
+  return { store, dispatch };
+}
+
 // ─── buildNoneUrl ─────────────────────────────────────────────────────────────
 
 describe('buildNoneUrl', () => {
   it('builds URL with expected params and no state', () => {
-    const url = buildNoneUrl(endpoint, config, storedTokens.idToken);
+    const url = buildNoneUrl(endpoint, config, storedTokens.idToken, redirectUri);
     const parsed = new URL(url);
 
     expect(parsed.searchParams.get('prompt')).toBe('none');
@@ -106,11 +119,20 @@ describe('buildNoneUrl', () => {
   });
 
   it('uses options.redirectUri when provided', () => {
-    const url = buildNoneUrl(endpoint, config, storedTokens.idToken, {
-      redirectUri: 'https://example.com/custom.html',
-    });
+    const url = buildNoneUrl(
+      endpoint,
+      config,
+      storedTokens.idToken,
+      'https://example.com/custom.html',
+    );
     const parsed = new URL(url);
     expect(parsed.searchParams.get('redirect_uri')).toBe('https://example.com/custom.html');
+  });
+
+  it('omits redirect_uri when neither config nor options provide one', () => {
+    const url = buildNoneUrl(endpoint, config, storedTokens.idToken, '');
+    const parsed = new URL(url);
+    expect(parsed.searchParams.has('redirect_uri')).toBe(false);
   });
 });
 
@@ -123,7 +145,7 @@ describe('buildIdTokenUrl', () => {
     vi.spyOn(sdkUtilities, 'createRandomString').mockReturnValue(knownNonce);
     vi.spyOn(sdkUtilities, 'createState').mockReturnValue(knownState);
 
-    const { url, nonce, state } = buildIdTokenUrl(endpoint, config, null);
+    const { url, nonce, state } = buildIdTokenUrl(endpoint, config, null, redirectUri);
     const parsed = new URL(url);
 
     expect(parsed.searchParams.get('response_type')).toBe('id_token');
@@ -136,49 +158,29 @@ describe('buildIdTokenUrl', () => {
   });
 
   it('includes id_token_hint when storedIdToken is present', () => {
-    const { url } = buildIdTokenUrl(endpoint, config, storedTokens.idToken);
+    const { url } = buildIdTokenUrl(endpoint, config, storedTokens.idToken, redirectUri);
     const parsed = new URL(url);
     expect(parsed.searchParams.get('id_token_hint')).toBe(storedTokens.idToken);
   });
 
   it('omits id_token_hint when storedIdToken is null', () => {
-    const { url } = buildIdTokenUrl(endpoint, config, null);
+    const { url } = buildIdTokenUrl(endpoint, config, null, redirectUri);
     const parsed = new URL(url);
     expect(parsed.searchParams.has('id_token_hint')).toBe(false);
   });
 
   it('uses options.scope when provided', () => {
-    const { url } = buildIdTokenUrl(endpoint, config, null, { scope: 'openid profile' });
+    const { url } = buildIdTokenUrl(endpoint, config, null, redirectUri, {
+      scope: 'openid profile',
+    });
     const parsed = new URL(url);
     expect(parsed.searchParams.get('scope')).toBe('openid profile');
   });
 });
 
-// ─── sessionCheckNoneµ ────────────────────────────────────────────────────────
+// ─── sessionCheckNoneµ (iframe path — with redirect_uri) ──────────────────────
 
-it.effect(
-  'sessionCheckNoneµ fails with missing_redirect_uri when no redirect URI is configured',
-  () =>
-    Micro.gen(function* () {
-      const dispatch = vi.fn();
-      const store: ClientStore = { dispatch } as unknown as ClientStore;
-      const configWithoutRedirectUri: OidcConfig = { ...config, redirectUri: '' };
-
-      const exit = yield* Micro.exit(
-        sessionCheckNoneµ(wellknown, configWithoutRedirectUri, store, makeStorageClient(null), log),
-      );
-
-      expect(Micro.exitIsFailure(exit)).toBe(true);
-      if (!Micro.exitIsFailure(exit) || !Micro.causeIsFail(exit.cause)) {
-        return;
-      }
-      expect(exit.cause.error.error).toBe('missing_redirect_uri');
-      expect(exit.cause.error.type).toBe('argument_error');
-      expect(dispatch).not.toHaveBeenCalled();
-    }),
-);
-
-it.effect('sessionCheckNoneµ dispatches and succeeds when token is stored', () =>
+it.effect('sessionCheckNoneµ uses iframe path and succeeds when redirect_uri is configured', () =>
   Micro.gen(function* () {
     const { store, dispatch } = makeDispatchSetup({ data: { params: {} } });
 
@@ -191,7 +193,7 @@ it.effect('sessionCheckNoneµ dispatches and succeeds when token is stored', () 
   }),
 );
 
-it.effect('sessionCheckNoneµ dispatches and succeeds when storage is empty (best-effort)', () =>
+it.effect('sessionCheckNoneµ iframe path fails with no_id_token_hint when storage is empty', () =>
   Micro.gen(function* () {
     const { store, dispatch } = makeDispatchSetup({ data: { params: {} } });
 
@@ -199,9 +201,198 @@ it.effect('sessionCheckNoneµ dispatches and succeeds when storage is empty (bes
       sessionCheckNoneµ(wellknown, config, store, makeStorageClient(null), log),
     );
 
+    expect(Micro.exitIsFailure(exit)).toBe(true);
+    if (!Micro.exitIsFailure(exit) || !Micro.causeIsFail(exit.cause)) {
+      return;
+    }
+    expect(exit.cause.error.error).toBe('no_id_token_hint');
+    expect(exit.cause.error.type).toBe('argument_error');
+    expect(dispatch).not.toHaveBeenCalled();
+  }),
+);
+
+// ─── sessionCheckNoneµ (fetch path — without redirect_uri) ───────────────────
+
+it.effect('sessionCheckNoneµ uses fetch path and succeeds when no redirect_uri is configured', () =>
+  Micro.gen(function* () {
+    const configWithoutRedirectUri: OidcConfig = { ...config, redirectUri: '' };
+    const { store, dispatch } = makeFetchDispatchSetup({ data: { status: 204 } });
+
+    const exit = yield* Micro.exit(
+      sessionCheckNoneµ(
+        wellknown,
+        configWithoutRedirectUri,
+        store,
+        makeStorageClient(storedTokens),
+        log,
+      ),
+    );
+
+    expect(Micro.exitIsSuccess(exit)).toBe(true);
+    if (!Micro.exitIsSuccess(exit)) {
+      return;
+    }
+    expect(exit.value).toStrictEqual({ responseType: 'none' });
+    expect(dispatch).toHaveBeenCalledOnce();
+  }),
+);
+
+it.effect('sessionCheckNoneµ fetch path fails with no_id_token_hint when storage is empty', () =>
+  Micro.gen(function* () {
+    const configWithoutRedirectUri: OidcConfig = { ...config, redirectUri: '' };
+    const { store, dispatch } = makeFetchDispatchSetup({ data: { status: 204 } });
+
+    const exit = yield* Micro.exit(
+      sessionCheckNoneµ(wellknown, configWithoutRedirectUri, store, makeStorageClient(null), log),
+    );
+
+    expect(Micro.exitIsFailure(exit)).toBe(true);
+    if (!Micro.exitIsFailure(exit) || !Micro.causeIsFail(exit.cause)) {
+      return;
+    }
+    expect(exit.cause.error.error).toBe('no_id_token_hint');
+    expect(exit.cause.error.type).toBe('argument_error');
+    expect(dispatch).not.toHaveBeenCalled();
+  }),
+);
+
+it.effect('sessionCheckNoneµ fetch path fails with login_required when AM returns 400', () =>
+  Micro.gen(function* () {
+    const configWithoutRedirectUri: OidcConfig = { ...config, redirectUri: '' };
+    const errorData: GenericError = {
+      error: 'login_required',
+      message: 'The request requires login.',
+      type: 'auth_error',
+    };
+    const { store } = makeFetchDispatchSetup({ error: { data: errorData } });
+
+    const exit = yield* Micro.exit(
+      sessionCheckNoneµ(
+        wellknown,
+        configWithoutRedirectUri,
+        store,
+        makeStorageClient(storedTokens),
+        log,
+      ),
+    );
+
+    expect(Micro.exitIsFailure(exit)).toBe(true);
+    if (!Micro.exitIsFailure(exit) || !Micro.causeIsFail(exit.cause)) {
+      return;
+    }
+    expect(exit.cause.error.error).toBe('login_required');
+    expect(exit.cause.error.type).toBe('auth_error');
+  }),
+);
+
+// ─── dispatchSessionCheckFetchµ ───────────────────────────────────────────────
+
+it.effect('dispatchSessionCheckFetchµ succeeds when dispatch resolves with data', () =>
+  Micro.gen(function* () {
+    const { store, dispatch } = makeFetchDispatchSetup({ data: { status: 204 } });
+
+    const exit = yield* Micro.exit(
+      dispatchSessionCheckFetchµ(store, 'https://example.com/authorize?prompt=none'),
+    );
+
     expect(Micro.exitIsSuccess(exit)).toBe(true);
     expect(dispatch).toHaveBeenCalledOnce();
   }),
+);
+
+it.effect(
+  'dispatchSessionCheckFetchµ fails with auth_error when dispatch resolves with an error result',
+  () =>
+    Micro.gen(function* () {
+      const errorData: GenericError = {
+        error: 'login_required',
+        message: 'The request requires login.',
+        type: 'auth_error',
+      };
+      const { store } = makeFetchDispatchSetup({ error: { data: errorData } });
+
+      const exit = yield* Micro.exit(
+        dispatchSessionCheckFetchµ(store, 'https://example.com/authorize?prompt=none'),
+      );
+
+      expect(Micro.exitIsFailure(exit)).toBe(true);
+      if (!Micro.exitIsFailure(exit) || !Micro.causeIsFail(exit.cause)) {
+        return;
+      }
+      expect(exit.cause.error.error).toBe('login_required');
+      expect(exit.cause.error.type).toBe('auth_error');
+    }),
+);
+
+it.effect('dispatchSessionCheckFetchµ fails with network_error when dispatch rejects', () =>
+  Micro.gen(function* () {
+    vi.spyOn(oidcApi.endpoints.sessionCheckFetch, 'initiate').mockReturnValue(
+      Symbol('sentinel') as unknown as ReturnType<
+        typeof oidcApi.endpoints.sessionCheckFetch.initiate
+      >,
+    );
+    const dispatch = vi.fn().mockRejectedValue(new Error('network failure'));
+    const store: ClientStore = { dispatch } as unknown as ClientStore;
+
+    const exit = yield* Micro.exit(
+      dispatchSessionCheckFetchµ(store, 'https://example.com/authorize?prompt=none'),
+    );
+
+    expect(Micro.exitIsFailure(exit)).toBe(true);
+    if (!Micro.exitIsFailure(exit) || !Micro.causeIsFail(exit.cause)) {
+      return;
+    }
+    expect(exit.cause.error.type).toBe('network_error');
+    expect(exit.cause.error.error).toBe('dispatch_error');
+  }),
+);
+
+it.effect(
+  'dispatchSessionCheckFetchµ fails with network_error when queryFn receives a string-status error (e.g. FETCH_ERROR)',
+  () =>
+    Micro.gen(function* () {
+      const errorData: GenericError = {
+        error: 'session_check_error',
+        message: 'A network error occurred during session check',
+        type: 'network_error',
+      };
+      const { store } = makeFetchDispatchSetup({ error: { data: errorData } });
+
+      const exit = yield* Micro.exit(
+        dispatchSessionCheckFetchµ(store, 'https://example.com/authorize?prompt=none'),
+      );
+
+      expect(Micro.exitIsFailure(exit)).toBe(true);
+      if (!Micro.exitIsFailure(exit) || !Micro.causeIsFail(exit.cause)) {
+        return;
+      }
+      expect(exit.cause.error.error).toBe('session_check_error');
+      expect(exit.cause.error.type).toBe('network_error');
+    }),
+);
+
+it.effect(
+  'dispatchSessionCheckFetchµ fails with network_error when queryFn receives an unexpected 2xx status',
+  () =>
+    Micro.gen(function* () {
+      const errorData: GenericError = {
+        error: 'session_check_error',
+        message: 'Unexpected response status: 200',
+        type: 'network_error',
+      };
+      const { store } = makeFetchDispatchSetup({ error: { data: errorData } });
+
+      const exit = yield* Micro.exit(
+        dispatchSessionCheckFetchµ(store, 'https://example.com/authorize?prompt=none'),
+      );
+
+      expect(Micro.exitIsFailure(exit)).toBe(true);
+      if (!Micro.exitIsFailure(exit) || !Micro.causeIsFail(exit.cause)) {
+        return;
+      }
+      expect(exit.cause.error.error).toBe('session_check_error');
+      expect(exit.cause.error.type).toBe('network_error');
+    }),
 );
 
 // ─── sessionCheckIdTokenµ ─────────────────────────────────────────────────────
@@ -232,8 +423,9 @@ it.effect('sessionCheckIdTokenµ returns claims on valid JWT', () =>
     if (!Micro.exitIsSuccess(exit)) {
       return;
     }
-    expect(exit.value.mode).toBe('id_token');
-    if (exit.value.mode !== 'id_token') {
+    expect(exit.value.responseType).toBe('id_token');
+    expect(exit.value.claims).toBeDefined();
+    if (!exit.value.claims) {
       return;
     }
     expect(exit.value.claims['nonce']).toBe(knownNonce);
@@ -281,6 +473,33 @@ it.effect('sessionCheckIdTokenµ fails with no_id_token when iframe returns no i
   }),
 );
 
+it.effect(
+  'sessionCheckIdTokenµ fails with missing_redirect_uri when no redirect_uri is configured',
+  () =>
+    Micro.gen(function* () {
+      const configWithoutRedirectUri: OidcConfig = { ...config, redirectUri: '' };
+      const { store, dispatch } = makeDispatchSetup({ data: { params: {} } });
+
+      const exit = yield* Micro.exit(
+        sessionCheckIdTokenµ(
+          wellknown,
+          configWithoutRedirectUri,
+          store,
+          makeStorageClient(storedTokens),
+          log,
+        ),
+      );
+
+      expect(Micro.exitIsFailure(exit)).toBe(true);
+      if (!Micro.exitIsFailure(exit) || !Micro.causeIsFail(exit.cause)) {
+        return;
+      }
+      expect(exit.cause.error.error).toBe('missing_redirect_uri');
+      expect(exit.cause.error.type).toBe('argument_error');
+      expect(dispatch).not.toHaveBeenCalled();
+    }),
+);
+
 // ─── readStoredIdTokenµ ───────────────────────────────────────────────────────
 
 it.effect('readStoredIdTokenµ returns idToken string when tokens are stored', () =>
@@ -314,10 +533,10 @@ it.effect('readStoredIdTokenµ fails with argument_error when storageClient.get 
   }),
 );
 
-// ─── dispatchSessionCheckµ ────────────────────────────────────────────────────
+// ─── dispatchSessionCheckIframeµ ────────────────────────────────────────────────────
 
 it.effect(
-  'dispatchSessionCheckµ succeeds and returns params when dispatch resolves with data',
+  'dispatchSessionCheckIframeµ succeeds and returns params when dispatch resolves with data',
   () =>
     Micro.gen(function* () {
       const params = { state: 'ok' };
@@ -329,7 +548,7 @@ it.effect(
         >,
       );
 
-      const result = yield* dispatchSessionCheckµ(
+      const result = yield* dispatchSessionCheckIframeµ(
         store,
         'https://example.com/authorize?prompt=none',
         'none',
@@ -339,7 +558,7 @@ it.effect(
 );
 
 it.effect(
-  'dispatchSessionCheckµ fails with auth_error when dispatch resolves with an error result',
+  'dispatchSessionCheckIframeµ fails with auth_error when dispatch resolves with an error result',
   () =>
     Micro.gen(function* () {
       const errorData: GenericError = {
@@ -356,7 +575,7 @@ it.effect(
       );
 
       const exit = yield* Micro.exit(
-        dispatchSessionCheckµ(store, 'https://example.com/authorize?prompt=none', 'none'),
+        dispatchSessionCheckIframeµ(store, 'https://example.com/authorize?prompt=none', 'none'),
       );
       expect(Micro.exitIsFailure(exit)).toBe(true);
       if (!Micro.exitIsFailure(exit) || !Micro.causeIsFail(exit.cause)) {
@@ -367,7 +586,7 @@ it.effect(
     }),
 );
 
-it.effect('dispatchSessionCheckµ fails with network_error when dispatch rejects', () =>
+it.effect('dispatchSessionCheckIframeµ fails with network_error when dispatch rejects', () =>
   Micro.gen(function* () {
     const dispatch = vi.fn().mockRejectedValue(new Error('network failure'));
     const store: ClientStore = { dispatch } as unknown as ClientStore;
@@ -378,7 +597,7 @@ it.effect('dispatchSessionCheckµ fails with network_error when dispatch rejects
     );
 
     const exit = yield* Micro.exit(
-      dispatchSessionCheckµ(store, 'https://example.com/authorize?prompt=none', 'none'),
+      dispatchSessionCheckIframeµ(store, 'https://example.com/authorize?prompt=none', 'none'),
     );
     expect(Micro.exitIsFailure(exit)).toBe(true);
     if (!Micro.exitIsFailure(exit) || !Micro.causeIsFail(exit.cause)) {

--- a/packages/oidc-client/src/lib/session.micros.test.ts
+++ b/packages/oidc-client/src/lib/session.micros.test.ts
@@ -19,7 +19,6 @@ import {
   validateSessionCheckResponseµ,
 } from './session.micros.js';
 import { oidcApi } from './oidc.api.js';
-import { SessionCheckResponseType } from './session.types.js';
 
 import { logger as loggerFn } from '@forgerock/sdk-logger';
 import type { OidcConfig } from './config.types.js';
@@ -28,6 +27,7 @@ import type { ClientStore } from './client.types.js';
 import type { StorageClient } from '@forgerock/storage';
 import type { OauthTokens } from './config.types.js';
 import type { GenericError } from '@forgerock/sdk-types';
+import type { JWTPayload } from 'jose';
 
 // ─── Fixtures ────────────────────────────────────────────────────────────────
 
@@ -96,8 +96,8 @@ describe('buildNoneUrl', () => {
     const url = buildNoneUrl(endpoint, config, storedTokens.idToken);
     const parsed = new URL(url);
 
-    expect(parsed.searchParams.get('prompt')).toBe(SessionCheckResponseType.None);
-    expect(parsed.searchParams.get('response_type')).toBe(SessionCheckResponseType.None);
+    expect(parsed.searchParams.get('prompt')).toBe('none');
+    expect(parsed.searchParams.get('response_type')).toBe('none');
     expect(parsed.searchParams.get('client_id')).toBe(clientId);
     expect(parsed.searchParams.get('redirect_uri')).toBe(redirectUri);
     expect(parsed.searchParams.get('id_token_hint')).toBe(storedTokens.idToken);
@@ -126,7 +126,7 @@ describe('buildIdTokenUrl', () => {
     const { url, nonce, state } = buildIdTokenUrl(endpoint, config, null);
     const parsed = new URL(url);
 
-    expect(parsed.searchParams.get('response_type')).toBe(SessionCheckResponseType.IdToken);
+    expect(parsed.searchParams.get('response_type')).toBe('id_token');
     expect(parsed.searchParams.get('nonce')).toBe(knownNonce);
     expect(parsed.searchParams.get('state')).toBe(knownState);
     expect(parsed.searchParams.get('scope')).toBe('openid');
@@ -232,8 +232,11 @@ it.effect('sessionCheckIdTokenµ returns claims on valid JWT', () =>
     if (!Micro.exitIsSuccess(exit)) {
       return;
     }
-    expect(exit.value.claims).toBeDefined();
-    expect((exit.value.claims as Record<string, unknown>).nonce).toBe(knownNonce);
+    expect(exit.value.mode).toBe('id_token');
+    if (exit.value.mode !== 'id_token') {
+      return;
+    }
+    expect(exit.value.claims['nonce']).toBe(knownNonce);
   }),
 );
 
@@ -329,7 +332,7 @@ it.effect(
       const result = yield* dispatchSessionCheckµ(
         store,
         'https://example.com/authorize?prompt=none',
-        SessionCheckResponseType.None,
+        'none',
       );
       expect(result).toStrictEqual(params);
     }),
@@ -353,11 +356,7 @@ it.effect(
       );
 
       const exit = yield* Micro.exit(
-        dispatchSessionCheckµ(
-          store,
-          'https://example.com/authorize?prompt=none',
-          SessionCheckResponseType.None,
-        ),
+        dispatchSessionCheckµ(store, 'https://example.com/authorize?prompt=none', 'none'),
       );
       expect(Micro.exitIsFailure(exit)).toBe(true);
       if (!Micro.exitIsFailure(exit) || !Micro.causeIsFail(exit.cause)) {
@@ -379,11 +378,7 @@ it.effect('dispatchSessionCheckµ fails with network_error when dispatch rejects
     );
 
     const exit = yield* Micro.exit(
-      dispatchSessionCheckµ(
-        store,
-        'https://example.com/authorize?prompt=none',
-        SessionCheckResponseType.None,
-      ),
+      dispatchSessionCheckµ(store, 'https://example.com/authorize?prompt=none', 'none'),
     );
     expect(Micro.exitIsFailure(exit)).toBe(true);
     if (!Micro.exitIsFailure(exit) || !Micro.causeIsFail(exit.cause)) {
@@ -396,7 +391,7 @@ it.effect('dispatchSessionCheckµ fails with network_error when dispatch rejects
 
 // ─── validateSessionCheckResponseµ ───────────────────────────────────────────
 
-function makeJwtWithClaims(claims: Record<string, unknown>): string {
+function makeJwtWithClaims(claims: JWTPayload): string {
   const payload = btoa(JSON.stringify(claims))
     .replace(/\+/g, '-')
     .replace(/\//g, '_')

--- a/packages/oidc-client/src/lib/session.micros.test.ts
+++ b/packages/oidc-client/src/lib/session.micros.test.ts
@@ -1,0 +1,512 @@
+/*
+ * Copyright © 2026 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+import { it, expect } from '@effect/vitest';
+import { Micro } from 'effect';
+import { vi, afterEach, describe } from 'vitest';
+import * as sdkUtilities from '@forgerock/sdk-utilities';
+
+import {
+  buildNoneUrl,
+  buildIdTokenUrl,
+  dispatchSessionCheckµ,
+  readStoredIdTokenµ,
+  sessionCheckIdTokenµ,
+  sessionCheckNoneµ,
+  validateSessionCheckResponseµ,
+} from './session.micros.js';
+import { oidcApi } from './oidc.api.js';
+import { SessionCheckResponseType } from './session.types.js';
+
+import { logger as loggerFn } from '@forgerock/sdk-logger';
+import type { OidcConfig } from './config.types.js';
+import type { WellknownResponse } from '@forgerock/sdk-types';
+import type { ClientStore } from './client.types.js';
+import type { StorageClient } from '@forgerock/storage';
+import type { OauthTokens } from './config.types.js';
+import type { GenericError } from '@forgerock/sdk-types';
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+const clientId = 'test-client-id';
+const redirectUri = 'https://example.com/callback.html';
+const endpoint = 'https://example.com/authorize';
+
+const config: OidcConfig = {
+  clientId,
+  redirectUri,
+  scope: 'openid profile',
+  responseType: 'code',
+  serverConfig: {
+    wellknown: 'https://example.com/.well-known/openid-configuration',
+  },
+};
+
+const wellknown: WellknownResponse = {
+  issuer: 'https://example.com',
+  authorization_endpoint: endpoint,
+  token_endpoint: 'https://example.com/token',
+  userinfo_endpoint: 'https://example.com/userinfo',
+  end_session_endpoint: 'https://example.com/logout',
+  introspection_endpoint: 'https://example.com/introspect',
+  revocation_endpoint: 'https://example.com/revoke',
+};
+
+const storedTokens: OauthTokens = {
+  accessToken: 'access-token-abc',
+  idToken: 'stored-id-token-xyz',
+  expiresAt: Date.now() + 60000,
+};
+
+function makeStorageClient(token: OauthTokens | null): StorageClient<OauthTokens> {
+  return {
+    get: vi.fn().mockResolvedValue(token),
+    set: vi.fn().mockResolvedValue(null),
+    remove: vi.fn().mockResolvedValue(null),
+  };
+}
+
+const log = loggerFn({ level: 'error' });
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function makeDispatchSetup(dispatchResult: unknown) {
+  const capturedArgs: Array<{ url: string; responseType: string }> = [];
+  const sentinel = Symbol('dispatch-sentinel');
+  vi.spyOn(oidcApi.endpoints.sessionCheckIframe, 'initiate').mockImplementation((arg) => {
+    capturedArgs.push(arg as { url: string; responseType: string });
+    return sentinel as unknown as ReturnType<typeof oidcApi.endpoints.sessionCheckIframe.initiate>;
+  });
+
+  const dispatch = vi.fn().mockResolvedValue(dispatchResult);
+  const store: ClientStore = { dispatch } as unknown as ClientStore;
+
+  return { capturedArgs, store, dispatch };
+}
+
+// ─── buildNoneUrl ─────────────────────────────────────────────────────────────
+
+describe('buildNoneUrl', () => {
+  it('builds URL with expected params and no state', () => {
+    const url = buildNoneUrl(endpoint, config, storedTokens.idToken);
+    const parsed = new URL(url);
+
+    expect(parsed.searchParams.get('prompt')).toBe(SessionCheckResponseType.None);
+    expect(parsed.searchParams.get('response_type')).toBe(SessionCheckResponseType.None);
+    expect(parsed.searchParams.get('client_id')).toBe(clientId);
+    expect(parsed.searchParams.get('redirect_uri')).toBe(redirectUri);
+    expect(parsed.searchParams.get('id_token_hint')).toBe(storedTokens.idToken);
+    expect(parsed.searchParams.has('state')).toBe(false);
+    expect(parsed.searchParams.has('nonce')).toBe(false);
+  });
+
+  it('uses options.redirectUri when provided', () => {
+    const url = buildNoneUrl(endpoint, config, storedTokens.idToken, {
+      redirectUri: 'https://example.com/custom.html',
+    });
+    const parsed = new URL(url);
+    expect(parsed.searchParams.get('redirect_uri')).toBe('https://example.com/custom.html');
+  });
+});
+
+// ─── buildIdTokenUrl ──────────────────────────────────────────────────────────
+
+describe('buildIdTokenUrl', () => {
+  it('builds URL with nonce, state, scope, and response_type=id_token', () => {
+    const knownNonce = 'test-nonce';
+    const knownState = 'test-state';
+    vi.spyOn(sdkUtilities, 'createRandomString').mockReturnValue(knownNonce);
+    vi.spyOn(sdkUtilities, 'createState').mockReturnValue(knownState);
+
+    const { url, nonce, state } = buildIdTokenUrl(endpoint, config, null);
+    const parsed = new URL(url);
+
+    expect(parsed.searchParams.get('response_type')).toBe(SessionCheckResponseType.IdToken);
+    expect(parsed.searchParams.get('nonce')).toBe(knownNonce);
+    expect(parsed.searchParams.get('state')).toBe(knownState);
+    expect(parsed.searchParams.get('scope')).toBe('openid');
+    expect(parsed.searchParams.has('id_token_hint')).toBe(false);
+    expect(nonce).toBe(knownNonce);
+    expect(state).toBe(knownState);
+  });
+
+  it('includes id_token_hint when storedIdToken is present', () => {
+    const { url } = buildIdTokenUrl(endpoint, config, storedTokens.idToken);
+    const parsed = new URL(url);
+    expect(parsed.searchParams.get('id_token_hint')).toBe(storedTokens.idToken);
+  });
+
+  it('omits id_token_hint when storedIdToken is null', () => {
+    const { url } = buildIdTokenUrl(endpoint, config, null);
+    const parsed = new URL(url);
+    expect(parsed.searchParams.has('id_token_hint')).toBe(false);
+  });
+
+  it('uses options.scope when provided', () => {
+    const { url } = buildIdTokenUrl(endpoint, config, null, { scope: 'openid profile' });
+    const parsed = new URL(url);
+    expect(parsed.searchParams.get('scope')).toBe('openid profile');
+  });
+});
+
+// ─── sessionCheckNoneµ ────────────────────────────────────────────────────────
+
+it.effect(
+  'sessionCheckNoneµ fails with missing_redirect_uri when no redirect URI is configured',
+  () =>
+    Micro.gen(function* () {
+      const dispatch = vi.fn();
+      const store: ClientStore = { dispatch } as unknown as ClientStore;
+      const configWithoutRedirectUri: OidcConfig = { ...config, redirectUri: '' };
+
+      const exit = yield* Micro.exit(
+        sessionCheckNoneµ(wellknown, configWithoutRedirectUri, store, makeStorageClient(null), log),
+      );
+
+      expect(Micro.exitIsFailure(exit)).toBe(true);
+      if (!Micro.exitIsFailure(exit) || !Micro.causeIsFail(exit.cause)) {
+        return;
+      }
+      expect(exit.cause.error.error).toBe('missing_redirect_uri');
+      expect(exit.cause.error.type).toBe('argument_error');
+      expect(dispatch).not.toHaveBeenCalled();
+    }),
+);
+
+it.effect('sessionCheckNoneµ dispatches and succeeds when token is stored', () =>
+  Micro.gen(function* () {
+    const { store, dispatch } = makeDispatchSetup({ data: { params: {} } });
+
+    const exit = yield* Micro.exit(
+      sessionCheckNoneµ(wellknown, config, store, makeStorageClient(storedTokens), log),
+    );
+
+    expect(Micro.exitIsSuccess(exit)).toBe(true);
+    expect(dispatch).toHaveBeenCalledOnce();
+  }),
+);
+
+it.effect('sessionCheckNoneµ dispatches and succeeds when storage is empty (best-effort)', () =>
+  Micro.gen(function* () {
+    const { store, dispatch } = makeDispatchSetup({ data: { params: {} } });
+
+    const exit = yield* Micro.exit(
+      sessionCheckNoneµ(wellknown, config, store, makeStorageClient(null), log),
+    );
+
+    expect(Micro.exitIsSuccess(exit)).toBe(true);
+    expect(dispatch).toHaveBeenCalledOnce();
+  }),
+);
+
+// ─── sessionCheckIdTokenµ ─────────────────────────────────────────────────────
+
+it.effect('sessionCheckIdTokenµ returns claims on valid JWT', () =>
+  Micro.gen(function* () {
+    const knownNonce = 'test-nonce-value-12345678901234';
+    const knownState = 'known-state-value';
+    vi.spyOn(sdkUtilities, 'createRandomString').mockReturnValue(knownNonce);
+    vi.spyOn(sdkUtilities, 'createState').mockReturnValue(knownState);
+
+    const payload = { nonce: knownNonce, sub: 'user1', iat: 1000 };
+    const encodedPayload = btoa(JSON.stringify(payload))
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=/g, '');
+    const validJwt = `header.${encodedPayload}.sig`;
+
+    const { store } = makeDispatchSetup({
+      data: { params: { id_token: validJwt, state: knownState } },
+    });
+
+    const exit = yield* Micro.exit(
+      sessionCheckIdTokenµ(wellknown, config, store, makeStorageClient(storedTokens), log),
+    );
+
+    expect(Micro.exitIsSuccess(exit)).toBe(true);
+    if (!Micro.exitIsSuccess(exit)) {
+      return;
+    }
+    expect(exit.value.claims).toBeDefined();
+    expect((exit.value.claims as Record<string, unknown>).nonce).toBe(knownNonce);
+  }),
+);
+
+it.effect('sessionCheckIdTokenµ fails with state_mismatch when response state does not match', () =>
+  Micro.gen(function* () {
+    vi.spyOn(sdkUtilities, 'createState').mockReturnValue('known-state-value');
+
+    const { store } = makeDispatchSetup({
+      data: { params: { id_token: 'some.jwt.token', state: 'tampered-state' } },
+    });
+
+    const exit = yield* Micro.exit(
+      sessionCheckIdTokenµ(wellknown, config, store, makeStorageClient(storedTokens), log),
+    );
+
+    expect(Micro.exitIsFailure(exit)).toBe(true);
+    if (!Micro.exitIsFailure(exit) || !Micro.causeIsFail(exit.cause)) {
+      return;
+    }
+    expect(exit.cause.error.error).toBe('state_mismatch');
+    expect(exit.cause.error.type).toBe('auth_error');
+  }),
+);
+
+it.effect('sessionCheckIdTokenµ fails with no_id_token when iframe returns no id_token param', () =>
+  Micro.gen(function* () {
+    const knownState = 'known-state-value';
+    vi.spyOn(sdkUtilities, 'createState').mockReturnValue(knownState);
+
+    const { store } = makeDispatchSetup({ data: { params: { state: knownState } } });
+
+    const exit = yield* Micro.exit(
+      sessionCheckIdTokenµ(wellknown, config, store, makeStorageClient(storedTokens), log),
+    );
+
+    expect(Micro.exitIsFailure(exit)).toBe(true);
+    if (!Micro.exitIsFailure(exit) || !Micro.causeIsFail(exit.cause)) {
+      return;
+    }
+    expect(exit.cause.error.error).toBe('no_id_token');
+    expect(exit.cause.error.type).toBe('auth_error');
+  }),
+);
+
+// ─── readStoredIdTokenµ ───────────────────────────────────────────────────────
+
+it.effect('readStoredIdTokenµ returns idToken string when tokens are stored', () =>
+  Micro.gen(function* () {
+    const result = yield* readStoredIdTokenµ(makeStorageClient(storedTokens));
+    expect(result).toBe(storedTokens.idToken);
+  }),
+);
+
+it.effect('readStoredIdTokenµ returns null when storage is empty', () =>
+  Micro.gen(function* () {
+    const result = yield* readStoredIdTokenµ(makeStorageClient(null));
+    expect(result).toBeNull();
+  }),
+);
+
+it.effect('readStoredIdTokenµ fails with argument_error when storageClient.get rejects', () =>
+  Micro.gen(function* () {
+    const failingStorage: StorageClient<OauthTokens> = {
+      get: vi.fn().mockRejectedValue(new Error('storage unavailable')),
+      set: vi.fn(),
+      remove: vi.fn(),
+    };
+    const exit = yield* Micro.exit(readStoredIdTokenµ(failingStorage));
+    expect(Micro.exitIsFailure(exit)).toBe(true);
+    if (!Micro.exitIsFailure(exit) || !Micro.causeIsFail(exit.cause)) {
+      return;
+    }
+    expect(exit.cause.error.type).toBe('argument_error');
+    expect(exit.cause.error.error).toBe('storage_error');
+  }),
+);
+
+// ─── dispatchSessionCheckµ ────────────────────────────────────────────────────
+
+it.effect(
+  'dispatchSessionCheckµ succeeds and returns params when dispatch resolves with data',
+  () =>
+    Micro.gen(function* () {
+      const params = { state: 'ok' };
+      const dispatch = vi.fn().mockResolvedValue({ data: { params } });
+      const store: ClientStore = { dispatch } as unknown as ClientStore;
+      vi.spyOn(oidcApi.endpoints.sessionCheckIframe, 'initiate').mockReturnValue(
+        Symbol('sentinel') as unknown as ReturnType<
+          typeof oidcApi.endpoints.sessionCheckIframe.initiate
+        >,
+      );
+
+      const result = yield* dispatchSessionCheckµ(
+        store,
+        'https://example.com/authorize?prompt=none',
+        SessionCheckResponseType.None,
+      );
+      expect(result).toStrictEqual(params);
+    }),
+);
+
+it.effect(
+  'dispatchSessionCheckµ fails with auth_error when dispatch resolves with an error result',
+  () =>
+    Micro.gen(function* () {
+      const errorData: GenericError = {
+        error: 'login_required',
+        message: 'User must authenticate',
+        type: 'auth_error',
+      };
+      const dispatch = vi.fn().mockResolvedValue({ error: { data: errorData } });
+      const store: ClientStore = { dispatch } as unknown as ClientStore;
+      vi.spyOn(oidcApi.endpoints.sessionCheckIframe, 'initiate').mockReturnValue(
+        Symbol('sentinel') as unknown as ReturnType<
+          typeof oidcApi.endpoints.sessionCheckIframe.initiate
+        >,
+      );
+
+      const exit = yield* Micro.exit(
+        dispatchSessionCheckµ(
+          store,
+          'https://example.com/authorize?prompt=none',
+          SessionCheckResponseType.None,
+        ),
+      );
+      expect(Micro.exitIsFailure(exit)).toBe(true);
+      if (!Micro.exitIsFailure(exit) || !Micro.causeIsFail(exit.cause)) {
+        return;
+      }
+      expect(exit.cause.error.error).toBe('login_required');
+      expect(exit.cause.error.type).toBe('auth_error');
+    }),
+);
+
+it.effect('dispatchSessionCheckµ fails with network_error when dispatch rejects', () =>
+  Micro.gen(function* () {
+    const dispatch = vi.fn().mockRejectedValue(new Error('network failure'));
+    const store: ClientStore = { dispatch } as unknown as ClientStore;
+    vi.spyOn(oidcApi.endpoints.sessionCheckIframe, 'initiate').mockReturnValue(
+      Symbol('sentinel') as unknown as ReturnType<
+        typeof oidcApi.endpoints.sessionCheckIframe.initiate
+      >,
+    );
+
+    const exit = yield* Micro.exit(
+      dispatchSessionCheckµ(
+        store,
+        'https://example.com/authorize?prompt=none',
+        SessionCheckResponseType.None,
+      ),
+    );
+    expect(Micro.exitIsFailure(exit)).toBe(true);
+    if (!Micro.exitIsFailure(exit) || !Micro.causeIsFail(exit.cause)) {
+      return;
+    }
+    expect(exit.cause.error.type).toBe('network_error');
+    expect(exit.cause.error.error).toBe('dispatch_error');
+  }),
+);
+
+// ─── validateSessionCheckResponseµ ───────────────────────────────────────────
+
+function makeJwtWithClaims(claims: Record<string, unknown>): string {
+  const payload = btoa(JSON.stringify(claims))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=/g, '');
+  return `header.${payload}.sig`;
+}
+
+it.effect(
+  'validateSessionCheckResponseµ succeeds and returns claims when state and nonce match',
+  () =>
+    Micro.gen(function* () {
+      const nonce = 'expected-nonce';
+      const state = 'expected-state';
+      const jwt = makeJwtWithClaims({ nonce, sub: 'user1' });
+      const result = yield* validateSessionCheckResponseµ({ id_token: jwt, state }, state, nonce);
+      expect(result).toMatchObject({ nonce, sub: 'user1' });
+    }),
+);
+
+it.effect('validateSessionCheckResponseµ succeeds when state, nonce, and subject all match', () =>
+  Micro.gen(function* () {
+    const nonce = 'nonce-abc';
+    const state = 'state-abc';
+    const jwt = makeJwtWithClaims({ nonce, sub: 'user1' });
+    const result = yield* validateSessionCheckResponseµ(
+      { id_token: jwt, state },
+      state,
+      nonce,
+      'user1',
+    );
+    expect(result).toMatchObject({ nonce, sub: 'user1' });
+  }),
+);
+
+it.effect('validateSessionCheckResponseµ fails with state_mismatch when state does not match', () =>
+  Micro.gen(function* () {
+    const jwt = makeJwtWithClaims({ nonce: 'nonce', sub: 'user1' });
+    const exit = yield* Micro.exit(
+      validateSessionCheckResponseµ(
+        { id_token: jwt, state: 'tampered' },
+        'expected-state',
+        'nonce',
+      ),
+    );
+    expect(Micro.exitIsFailure(exit)).toBe(true);
+    if (!Micro.exitIsFailure(exit) || !Micro.causeIsFail(exit.cause)) {
+      return;
+    }
+    expect(exit.cause.error.error).toBe('state_mismatch');
+    expect(exit.cause.error.type).toBe('auth_error');
+  }),
+);
+
+it.effect('validateSessionCheckResponseµ fails with no_id_token when id_token is absent', () =>
+  Micro.gen(function* () {
+    const state = 'expected-state';
+    const exit = yield* Micro.exit(validateSessionCheckResponseµ({ state }, state, 'nonce'));
+    expect(Micro.exitIsFailure(exit)).toBe(true);
+    if (!Micro.exitIsFailure(exit) || !Micro.causeIsFail(exit.cause)) {
+      return;
+    }
+    expect(exit.cause.error.error).toBe('no_id_token');
+    expect(exit.cause.error.type).toBe('auth_error');
+  }),
+);
+
+it.effect('validateSessionCheckResponseµ fails with nonce_mismatch when nonce does not match', () =>
+  Micro.gen(function* () {
+    const state = 'expected-state';
+    const jwt = makeJwtWithClaims({ nonce: 'wrong-nonce', sub: 'user1' });
+    const exit = yield* Micro.exit(
+      validateSessionCheckResponseµ({ id_token: jwt, state }, state, 'expected-nonce'),
+    );
+    expect(Micro.exitIsFailure(exit)).toBe(true);
+    if (!Micro.exitIsFailure(exit) || !Micro.causeIsFail(exit.cause)) {
+      return;
+    }
+    expect(exit.cause.error.error).toBe('nonce_mismatch');
+    expect(exit.cause.error.type).toBe('auth_error');
+  }),
+);
+
+it.effect('validateSessionCheckResponseµ fails with subject_mismatch when sub does not match', () =>
+  Micro.gen(function* () {
+    const nonce = 'valid-nonce';
+    const state = 'expected-state';
+    const jwt = makeJwtWithClaims({ nonce, sub: 'user2' });
+    const exit = yield* Micro.exit(
+      validateSessionCheckResponseµ({ id_token: jwt, state }, state, nonce, 'user1'),
+    );
+    expect(Micro.exitIsFailure(exit)).toBe(true);
+    if (!Micro.exitIsFailure(exit) || !Micro.causeIsFail(exit.cause)) {
+      return;
+    }
+    expect(exit.cause.error.error).toBe('subject_mismatch');
+    expect(exit.cause.error.type).toBe('auth_error');
+  }),
+);
+
+it.effect('validateSessionCheckResponseµ fails with invalid_jwt when JWT is malformed', () =>
+  Micro.gen(function* () {
+    const state = 'expected-state';
+    const exit = yield* Micro.exit(
+      validateSessionCheckResponseµ({ id_token: 'not.a.valid.jwt.payload', state }, state, 'nonce'),
+    );
+    expect(Micro.exitIsFailure(exit)).toBe(true);
+    if (!Micro.exitIsFailure(exit) || !Micro.causeIsFail(exit.cause)) {
+      return;
+    }
+    expect(exit.cause.error.error).toBe('invalid_jwt');
+    expect(exit.cause.error.type).toBe('auth_error');
+  }),
+);

--- a/packages/oidc-client/src/lib/session.micros.ts
+++ b/packages/oidc-client/src/lib/session.micros.ts
@@ -36,7 +36,7 @@ export const readStoredIdTokenµ = (
 
 // ─── Dispatch ────────────────────────────────────────────────────────────────
 
-export const dispatchSessionCheckµ = (
+export const dispatchSessionCheckIframeµ = (
   store: ClientStore,
   url: string,
   responseType: 'id_token' | 'none',
@@ -62,6 +62,33 @@ export const dispatchSessionCheckµ = (
       }
       const { params } = (result as { data: { params: Record<string, string> } }).data;
       return Micro.succeed(params);
+    }),
+  );
+
+export const dispatchSessionCheckFetchµ = (
+  store: ClientStore,
+  url: string,
+): Micro.Micro<void, GenericError, never> =>
+  Micro.tryPromise({
+    try: () => store.dispatch(oidcApi.endpoints.sessionCheckFetch.initiate({ url })),
+    catch: (err): GenericError => ({
+      error: 'dispatch_error',
+      message: err instanceof Error ? err.message : 'Failed to dispatch session check',
+      type: 'network_error',
+    }),
+  }).pipe(
+    Micro.flatMap((result) => {
+      if ('error' in result && result.error) {
+        const errData = result.error as {
+          data?: { error?: string; message?: string; type?: string };
+        };
+        return Micro.fail<GenericError>({
+          error: errData.data?.error ?? 'login_required',
+          message: errData.data?.message ?? 'The request requires login.',
+          type: (errData.data?.type as GenericError['type']) ?? 'auth_error',
+        });
+      }
+      return Micro.void;
     }),
   );
 
@@ -125,16 +152,17 @@ export const validateSessionCheckResponseµ = (
 export const buildNoneUrl = (
   endpoint: string,
   config: OidcConfig,
-  storedIdToken: string | null,
+  storedIdToken: string,
+  redirectUri: string,
   options?: SessionCheckOptions,
 ): string => {
   const params = new URLSearchParams({
     prompt: 'none',
     response_type: 'none',
     client_id: config.clientId,
-    redirect_uri: options?.redirectUri ?? config.redirectUri,
     scope: options?.scope ?? 'openid',
-    ...(storedIdToken ? { id_token_hint: storedIdToken } : {}),
+    ...(redirectUri ? { redirect_uri: redirectUri } : {}),
+    id_token_hint: storedIdToken,
   });
   return `${endpoint}?${params.toString()}`;
 };
@@ -143,6 +171,7 @@ export const buildIdTokenUrl = (
   endpoint: string,
   config: OidcConfig,
   storedIdToken: string | null,
+  redirectUri: string,
   options?: SessionCheckOptions,
 ): { url: string; nonce: string; state: string } => {
   const nonce = createRandomString(32);
@@ -151,7 +180,7 @@ export const buildIdTokenUrl = (
     prompt: 'none',
     response_type: 'id_token',
     client_id: config.clientId,
-    redirect_uri: options?.redirectUri ?? config.redirectUri,
+    redirect_uri: redirectUri,
     scope: options?.scope ?? 'openid',
     nonce,
     state,
@@ -170,25 +199,33 @@ export const sessionCheckNoneµ = (
   log: CustomLogger,
   options?: SessionCheckOptions,
 ): Micro.Micro<SessionCheckSuccess, GenericError, never> => {
-  const redirectUri = options?.redirectUri ?? config.redirectUri;
-  // none mode resolves by recognising when the iframe lands on the redirect URI.
-  // An empty redirect_uri means the iframe never matches and silently times out instead of failing fast.
-  if (!redirectUri) {
-    return Micro.fail<GenericError>({
-      error: 'missing_redirect_uri',
-      message: 'redirect_uri is required for session check',
-      type: 'argument_error',
-    });
-  }
-
   return readStoredIdTokenµ(storageClient).pipe(
     Micro.flatMap((storedIdToken) => {
-      const url = buildNoneUrl(wellknown.authorization_endpoint, config, storedIdToken, options);
-      log.debug('Session check (none) URL built');
-      return dispatchSessionCheckµ(store, url, 'none');
+      if (!storedIdToken) {
+        return Micro.fail<GenericError>({
+          error: 'no_id_token_hint',
+          message: 'response_type=none requires a stored id_token; authenticate first',
+          type: 'argument_error',
+        });
+      }
+
+      const redirectUri = options?.redirectUri ?? config.redirectUri;
+      const url = buildNoneUrl(
+        wellknown.authorization_endpoint,
+        config,
+        storedIdToken,
+        redirectUri,
+        options,
+      );
+
+      // iframe path: AM redirects back to redirect_uri; resolve on landing
+      // fetch path: no redirect_uri, AM returns 204 (valid) or 400 (invalid)
+      return redirectUri
+        ? dispatchSessionCheckIframeµ(store, url, 'none')
+        : dispatchSessionCheckFetchµ(store, url);
     }),
-    Micro.tap(() => Micro.sync(() => log.debug('Session check (none) completed successfully'))),
-    Micro.map((): SessionCheckSuccess => ({ mode: 'none' })),
+    Micro.tap(() => log.debug('Session check (none) completed successfully')),
+    Micro.map((): SessionCheckSuccess => ({ responseType: 'none' })),
   );
 };
 
@@ -202,22 +239,32 @@ export const sessionCheckIdTokenµ = (
   log: CustomLogger,
   options?: SessionCheckOptions,
 ): Micro.Micro<SessionCheckSuccess, GenericError, never> => {
+  const redirectUri = options?.redirectUri ?? config.redirectUri;
+
+  if (!redirectUri) {
+    return Micro.fail<GenericError>({
+      error: 'missing_redirect_uri',
+      message: 'redirect_uri is required for session check with response_type=id_token',
+      type: 'argument_error',
+    });
+  }
+
   return readStoredIdTokenµ(storageClient).pipe(
     Micro.flatMap((storedIdToken) => {
       const { url, nonce, state } = buildIdTokenUrl(
         wellknown.authorization_endpoint,
         config,
         storedIdToken,
+        redirectUri,
         options,
       );
-      log.debug('Session check (id_token) URL built');
-      return dispatchSessionCheckµ(store, url, 'id_token').pipe(
+      return dispatchSessionCheckIframeµ(store, url, 'id_token').pipe(
         Micro.flatMap((iframeParams) =>
           validateSessionCheckResponseµ(iframeParams, state, nonce, options?.subject),
         ),
       );
     }),
-    Micro.tap(() => Micro.sync(() => log.debug('Session check (id_token) completed successfully'))),
-    Micro.map((claims): SessionCheckSuccess => ({ mode: 'id_token', claims })),
+    Micro.tap(() => log.debug('Session check (id_token) completed successfully')),
+    Micro.map((claims): SessionCheckSuccess => ({ responseType: 'id_token', claims })),
   );
 };

--- a/packages/oidc-client/src/lib/session.micros.ts
+++ b/packages/oidc-client/src/lib/session.micros.ts
@@ -11,66 +11,59 @@ import { createRandomString, createState } from '@forgerock/sdk-utilities';
 import { oidcApi } from './oidc.api.js';
 
 import { decodeJwt } from 'jose/jwt/decode';
+import type { JWTPayload } from 'jose';
 
 import type { CustomLogger } from '@forgerock/sdk-logger';
 import type { GenericError, WellknownResponse } from '@forgerock/sdk-types';
 import type { StorageClient } from '@forgerock/storage';
 import type { OauthTokens, OidcConfig } from './config.types.js';
 import type { ClientStore } from './client.types.js';
-import { SessionCheckResponseType } from './session.types.js';
 import type { SessionCheckOptions, SessionCheckSuccess } from './session.types.js';
 
 // ─── Storage read ─────────────────────────────────────────────────────────────
 
 export const readStoredIdTokenµ = (
   storageClient: StorageClient<OauthTokens>,
-): Micro.Micro<string | null, GenericError, never> => {
-  return Micro.tryPromise({
-    try: async () => {
-      const tokens = await storageClient.get();
-      return tokens && 'idToken' in tokens ? tokens.idToken : null;
-    },
+): Micro.Micro<string | null, GenericError, never> =>
+  Micro.tryPromise({
+    try: () => storageClient.get(),
     catch: (): GenericError => ({
       error: 'storage_error',
       message: 'Failed to read tokens from storage',
       type: 'argument_error',
     }),
-  });
-};
+  }).pipe(Micro.map((tokens) => (tokens && 'idToken' in tokens ? tokens.idToken : null)));
 
 // ─── Dispatch ────────────────────────────────────────────────────────────────
 
 export const dispatchSessionCheckµ = (
   store: ClientStore,
   url: string,
-  responseType: SessionCheckResponseType,
-): Micro.Micro<Record<string, string>, GenericError, never> => {
-  return Micro.gen(function* () {
-    const result = yield* Micro.tryPromise({
-      try: () =>
-        store.dispatch(oidcApi.endpoints.sessionCheckIframe.initiate({ url, responseType })),
-      catch: (err): GenericError => ({
-        error: 'dispatch_error',
-        message: err instanceof Error ? err.message : 'Failed to dispatch session check',
-        type: 'network_error',
-      }),
-    });
-
-    if ('error' in result && result.error) {
-      const errData = result.error as {
-        data?: { error?: string; message?: string; type?: string };
-      };
-      return yield* Micro.fail<GenericError>({
-        error: errData.data?.error ?? 'session_check_error',
-        message: errData.data?.message ?? 'An error occurred during session check',
-        type: (errData.data?.type as GenericError['type']) ?? 'network_error',
-      });
-    }
-
-    const { params } = (result as { data: { params: Record<string, string> } }).data;
-    return params;
-  });
-};
+  responseType: 'id_token' | 'none',
+): Micro.Micro<Record<string, string>, GenericError, never> =>
+  Micro.tryPromise({
+    try: () => store.dispatch(oidcApi.endpoints.sessionCheckIframe.initiate({ url, responseType })),
+    catch: (err): GenericError => ({
+      error: 'dispatch_error',
+      message: err instanceof Error ? err.message : 'Failed to dispatch session check',
+      type: 'network_error',
+    }),
+  }).pipe(
+    Micro.flatMap((result) => {
+      if ('error' in result && result.error) {
+        const errData = result.error as {
+          data?: { error?: string; message?: string; type?: string };
+        };
+        return Micro.fail<GenericError>({
+          error: errData.data?.error ?? 'session_check_error',
+          message: errData.data?.message ?? 'An error occurred during session check',
+          type: (errData.data?.type as GenericError['type']) ?? 'network_error',
+        });
+      }
+      const { params } = (result as { data: { params: Record<string, string> } }).data;
+      return Micro.succeed(params);
+    }),
+  );
 
 // ─── Response validation ──────────────────────────────────────────────────────
 
@@ -79,7 +72,7 @@ export const validateSessionCheckResponseµ = (
   state: string,
   nonce: string,
   subject?: string,
-): Micro.Micro<Record<string, unknown>, GenericError, never> => {
+): Micro.Micro<JWTPayload, GenericError, never> => {
   return Micro.gen(function* () {
     if (iframeParams.state !== state) {
       return yield* Micro.fail<GenericError>({
@@ -137,7 +130,7 @@ export const buildNoneUrl = (
 ): string => {
   const params = new URLSearchParams({
     prompt: 'none',
-    response_type: SessionCheckResponseType.None,
+    response_type: 'none',
     client_id: config.clientId,
     redirect_uri: options?.redirectUri ?? config.redirectUri,
     scope: options?.scope ?? 'openid',
@@ -156,7 +149,7 @@ export const buildIdTokenUrl = (
   const state = createState();
   const params = new URLSearchParams({
     prompt: 'none',
-    response_type: SessionCheckResponseType.IdToken,
+    response_type: 'id_token',
     client_id: config.clientId,
     redirect_uri: options?.redirectUri ?? config.redirectUri,
     scope: options?.scope ?? 'openid',
@@ -177,28 +170,26 @@ export const sessionCheckNoneµ = (
   log: CustomLogger,
   options?: SessionCheckOptions,
 ): Micro.Micro<SessionCheckSuccess, GenericError, never> => {
-  return Micro.gen(function* () {
-    const storedIdToken = yield* readStoredIdTokenµ(storageClient);
+  const redirectUri = options?.redirectUri ?? config.redirectUri;
+  // none mode resolves by recognising when the iframe lands on the redirect URI.
+  // An empty redirect_uri means the iframe never matches and silently times out instead of failing fast.
+  if (!redirectUri) {
+    return Micro.fail<GenericError>({
+      error: 'missing_redirect_uri',
+      message: 'redirect_uri is required for session check',
+      type: 'argument_error',
+    });
+  }
 
-    const redirectUri = options?.redirectUri ?? config.redirectUri;
-    // none mode resolves by recognising when the iframe lands on the redirect URI.
-    // An empty redirect_uri means the iframe never matches and silently times out instead of failing fast.
-    if (!redirectUri) {
-      return yield* Micro.fail<GenericError>({
-        error: 'missing_redirect_uri',
-        message: 'redirect_uri is required for session check',
-        type: 'argument_error',
-      });
-    }
-
-    const url = buildNoneUrl(wellknown.authorization_endpoint, config, storedIdToken, options);
-    log.debug('Session check (none) URL built');
-
-    yield* dispatchSessionCheckµ(store, url, SessionCheckResponseType.None);
-    log.debug('Session check (none) completed successfully');
-
-    return {} satisfies SessionCheckSuccess;
-  });
+  return readStoredIdTokenµ(storageClient).pipe(
+    Micro.flatMap((storedIdToken) => {
+      const url = buildNoneUrl(wellknown.authorization_endpoint, config, storedIdToken, options);
+      log.debug('Session check (none) URL built');
+      return dispatchSessionCheckµ(store, url, 'none');
+    }),
+    Micro.tap(() => Micro.sync(() => log.debug('Session check (none) completed successfully'))),
+    Micro.map((): SessionCheckSuccess => ({ mode: 'none' })),
+  );
 };
 
 // ─── IdToken mode ─────────────────────────────────────────────────────────────
@@ -211,25 +202,22 @@ export const sessionCheckIdTokenµ = (
   log: CustomLogger,
   options?: SessionCheckOptions,
 ): Micro.Micro<SessionCheckSuccess, GenericError, never> => {
-  return Micro.gen(function* () {
-    const storedIdToken = yield* readStoredIdTokenµ(storageClient);
-    const { url, nonce, state } = buildIdTokenUrl(
-      wellknown.authorization_endpoint,
-      config,
-      storedIdToken,
-      options,
-    );
-    log.debug('Session check (id_token) URL built');
-
-    const iframeParams = yield* dispatchSessionCheckµ(store, url, SessionCheckResponseType.IdToken);
-    const claims = yield* validateSessionCheckResponseµ(
-      iframeParams,
-      state,
-      nonce,
-      options?.subject,
-    );
-    log.debug('Session check (id_token) completed successfully');
-
-    return { claims } satisfies SessionCheckSuccess;
-  });
+  return readStoredIdTokenµ(storageClient).pipe(
+    Micro.flatMap((storedIdToken) => {
+      const { url, nonce, state } = buildIdTokenUrl(
+        wellknown.authorization_endpoint,
+        config,
+        storedIdToken,
+        options,
+      );
+      log.debug('Session check (id_token) URL built');
+      return dispatchSessionCheckµ(store, url, 'id_token').pipe(
+        Micro.flatMap((iframeParams) =>
+          validateSessionCheckResponseµ(iframeParams, state, nonce, options?.subject),
+        ),
+      );
+    }),
+    Micro.tap(() => Micro.sync(() => log.debug('Session check (id_token) completed successfully'))),
+    Micro.map((claims): SessionCheckSuccess => ({ mode: 'id_token', claims })),
+  );
 };

--- a/packages/oidc-client/src/lib/session.micros.ts
+++ b/packages/oidc-client/src/lib/session.micros.ts
@@ -1,0 +1,235 @@
+/*
+ * Copyright © 2026 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+import { Micro } from 'effect';
+
+import { createRandomString, createState } from '@forgerock/sdk-utilities';
+
+import { oidcApi } from './oidc.api.js';
+
+import { decodeJwt } from 'jose/jwt/decode';
+
+import type { CustomLogger } from '@forgerock/sdk-logger';
+import type { GenericError, WellknownResponse } from '@forgerock/sdk-types';
+import type { StorageClient } from '@forgerock/storage';
+import type { OauthTokens, OidcConfig } from './config.types.js';
+import type { ClientStore } from './client.types.js';
+import { SessionCheckResponseType } from './session.types.js';
+import type { SessionCheckOptions, SessionCheckSuccess } from './session.types.js';
+
+// ─── Storage read ─────────────────────────────────────────────────────────────
+
+export const readStoredIdTokenµ = (
+  storageClient: StorageClient<OauthTokens>,
+): Micro.Micro<string | null, GenericError, never> => {
+  return Micro.tryPromise({
+    try: async () => {
+      const tokens = await storageClient.get();
+      return tokens && 'idToken' in tokens ? tokens.idToken : null;
+    },
+    catch: (): GenericError => ({
+      error: 'storage_error',
+      message: 'Failed to read tokens from storage',
+      type: 'argument_error',
+    }),
+  });
+};
+
+// ─── Dispatch ────────────────────────────────────────────────────────────────
+
+export const dispatchSessionCheckµ = (
+  store: ClientStore,
+  url: string,
+  responseType: SessionCheckResponseType,
+): Micro.Micro<Record<string, string>, GenericError, never> => {
+  return Micro.gen(function* () {
+    const result = yield* Micro.tryPromise({
+      try: () =>
+        store.dispatch(oidcApi.endpoints.sessionCheckIframe.initiate({ url, responseType })),
+      catch: (err): GenericError => ({
+        error: 'dispatch_error',
+        message: err instanceof Error ? err.message : 'Failed to dispatch session check',
+        type: 'network_error',
+      }),
+    });
+
+    if ('error' in result && result.error) {
+      const errData = result.error as {
+        data?: { error?: string; message?: string; type?: string };
+      };
+      return yield* Micro.fail<GenericError>({
+        error: errData.data?.error ?? 'session_check_error',
+        message: errData.data?.message ?? 'An error occurred during session check',
+        type: (errData.data?.type as GenericError['type']) ?? 'network_error',
+      });
+    }
+
+    const { params } = (result as { data: { params: Record<string, string> } }).data;
+    return params;
+  });
+};
+
+// ─── Response validation ──────────────────────────────────────────────────────
+
+export const validateSessionCheckResponseµ = (
+  iframeParams: Record<string, string>,
+  state: string,
+  nonce: string,
+  subject?: string,
+): Micro.Micro<Record<string, unknown>, GenericError, never> => {
+  return Micro.gen(function* () {
+    if (iframeParams.state !== state) {
+      return yield* Micro.fail<GenericError>({
+        error: 'state_mismatch',
+        message: 'State parameter in response does not match the expected value',
+        type: 'auth_error',
+      });
+    }
+
+    const idToken = iframeParams.id_token;
+    if (!idToken) {
+      return yield* Micro.fail<GenericError>({
+        error: 'no_id_token',
+        message: 'No id_token found in iframe response',
+        type: 'auth_error',
+      });
+    }
+
+    const claims = yield* Micro.try({
+      try: () => decodeJwt(idToken),
+      catch: (): GenericError => ({
+        error: 'invalid_jwt',
+        message: 'Failed to decode id_token JWT payload',
+        type: 'auth_error',
+      }),
+    });
+
+    if (claims.nonce !== nonce) {
+      return yield* Micro.fail<GenericError>({
+        error: 'nonce_mismatch',
+        message: 'Nonce in id_token does not match the expected value',
+        type: 'auth_error',
+      });
+    }
+
+    if (subject !== undefined && claims.sub !== subject) {
+      return yield* Micro.fail<GenericError>({
+        error: 'subject_mismatch',
+        message: 'Subject claim in id_token does not match the expected value',
+        type: 'auth_error',
+      });
+    }
+
+    return claims;
+  });
+};
+
+// ─── Param builders ───────────────────────────────────────────────────────────
+
+export const buildNoneUrl = (
+  endpoint: string,
+  config: OidcConfig,
+  storedIdToken: string | null,
+  options?: SessionCheckOptions,
+): string => {
+  const params = new URLSearchParams({
+    prompt: 'none',
+    response_type: SessionCheckResponseType.None,
+    client_id: config.clientId,
+    redirect_uri: options?.redirectUri ?? config.redirectUri,
+    scope: options?.scope ?? 'openid',
+    ...(storedIdToken ? { id_token_hint: storedIdToken } : {}),
+  });
+  return `${endpoint}?${params.toString()}`;
+};
+
+export const buildIdTokenUrl = (
+  endpoint: string,
+  config: OidcConfig,
+  storedIdToken: string | null,
+  options?: SessionCheckOptions,
+): { url: string; nonce: string; state: string } => {
+  const nonce = createRandomString(32);
+  const state = createState();
+  const params = new URLSearchParams({
+    prompt: 'none',
+    response_type: SessionCheckResponseType.IdToken,
+    client_id: config.clientId,
+    redirect_uri: options?.redirectUri ?? config.redirectUri,
+    scope: options?.scope ?? 'openid',
+    nonce,
+    state,
+    ...(storedIdToken ? { id_token_hint: storedIdToken } : {}),
+  });
+  return { url: `${endpoint}?${params.toString()}`, nonce, state };
+};
+
+// ─── None mode ───────────────────────────────────────────────────────────────
+
+export const sessionCheckNoneµ = (
+  wellknown: WellknownResponse,
+  config: OidcConfig,
+  store: ClientStore,
+  storageClient: StorageClient<OauthTokens>,
+  log: CustomLogger,
+  options?: SessionCheckOptions,
+): Micro.Micro<SessionCheckSuccess, GenericError, never> => {
+  return Micro.gen(function* () {
+    const storedIdToken = yield* readStoredIdTokenµ(storageClient);
+
+    const redirectUri = options?.redirectUri ?? config.redirectUri;
+    // none mode resolves by recognising when the iframe lands on the redirect URI.
+    // An empty redirect_uri means the iframe never matches and silently times out instead of failing fast.
+    if (!redirectUri) {
+      return yield* Micro.fail<GenericError>({
+        error: 'missing_redirect_uri',
+        message: 'redirect_uri is required for session check',
+        type: 'argument_error',
+      });
+    }
+
+    const url = buildNoneUrl(wellknown.authorization_endpoint, config, storedIdToken, options);
+    log.debug('Session check (none) URL built');
+
+    yield* dispatchSessionCheckµ(store, url, SessionCheckResponseType.None);
+    log.debug('Session check (none) completed successfully');
+
+    return {} satisfies SessionCheckSuccess;
+  });
+};
+
+// ─── IdToken mode ─────────────────────────────────────────────────────────────
+
+export const sessionCheckIdTokenµ = (
+  wellknown: WellknownResponse,
+  config: OidcConfig,
+  store: ClientStore,
+  storageClient: StorageClient<OauthTokens>,
+  log: CustomLogger,
+  options?: SessionCheckOptions,
+): Micro.Micro<SessionCheckSuccess, GenericError, never> => {
+  return Micro.gen(function* () {
+    const storedIdToken = yield* readStoredIdTokenµ(storageClient);
+    const { url, nonce, state } = buildIdTokenUrl(
+      wellknown.authorization_endpoint,
+      config,
+      storedIdToken,
+      options,
+    );
+    log.debug('Session check (id_token) URL built');
+
+    const iframeParams = yield* dispatchSessionCheckµ(store, url, SessionCheckResponseType.IdToken);
+    const claims = yield* validateSessionCheckResponseµ(
+      iframeParams,
+      state,
+      nonce,
+      options?.subject,
+    );
+    log.debug('Session check (id_token) completed successfully');
+
+    return { claims } satisfies SessionCheckSuccess;
+  });
+};

--- a/packages/oidc-client/src/lib/session.types.ts
+++ b/packages/oidc-client/src/lib/session.types.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2026 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+// Both a const object (for runtime value access: SessionCheckResponseType.IdToken) and a type
+// (for annotations: param: SessionCheckResponseType) are declared under the same name.
+// This is the TypeScript const-object + union-type pattern — a tree-shakeable alternative to enums
+// that preserves the string literals ('id_token' | 'none') in the compiled output.
+export const SessionCheckResponseType = {
+  IdToken: 'id_token',
+  None: 'none',
+} as const;
+
+export type SessionCheckResponseType =
+  (typeof SessionCheckResponseType)[keyof typeof SessionCheckResponseType];
+
+/**
+ * Both modes send id_token_hint if a stored token is available; the AS falls back to the browser
+ * session cookie if it is absent. This means a session check can succeed even without stored tokens.
+ *
+ * - id_token mode: returns a fresh id_token with claims. subject is validated if provided.
+ * - none mode: returns no claims. Success is detected by the iframe landing on the redirect URI.
+ */
+export interface SessionCheckOptions {
+  /** The response type for the session check. Default: SessionCheckResponseType.None */
+  responseType?: SessionCheckResponseType;
+  /** Overrides OidcConfig.redirectUri for the session check request. */
+  redirectUri?: string;
+  /** If provided, the sub claim in the returned id_token must match. id_token mode only. */
+  subject?: string;
+  /** OAuth scope. Default: 'openid'. */
+  scope?: string;
+}
+
+export interface SessionCheckSuccess {
+  /** Decoded id_token payload. Present only in id_token mode. */
+  claims?: Record<string, unknown>;
+}

--- a/packages/oidc-client/src/lib/session.types.ts
+++ b/packages/oidc-client/src/lib/session.types.ts
@@ -27,4 +27,12 @@ export interface SessionCheckOptions {
   scope?: string;
 }
 
-export type SessionCheckSuccess = { mode: 'none' } | { mode: 'id_token'; claims: JWTPayload };
+export type SessionCheckSuccess = {
+  responseType: SessionCheckResponseType;
+  /**
+   * Decoded (not signature-verified) JWT payload from the session-check id_token.
+   * Claims are bound to this request via nonce and state validation.
+   * Do not use these claims for primary authentication or authorization decisions.
+   */
+  claims?: JWTPayload;
+};

--- a/packages/oidc-client/src/lib/session.types.ts
+++ b/packages/oidc-client/src/lib/session.types.ts
@@ -5,17 +5,9 @@
  * of the MIT license. See the LICENSE file for details.
  */
 
-// Both a const object (for runtime value access: SessionCheckResponseType.IdToken) and a type
-// (for annotations: param: SessionCheckResponseType) are declared under the same name.
-// This is the TypeScript const-object + union-type pattern — a tree-shakeable alternative to enums
-// that preserves the string literals ('id_token' | 'none') in the compiled output.
-export const SessionCheckResponseType = {
-  IdToken: 'id_token',
-  None: 'none',
-} as const;
+import type { JWTPayload } from 'jose';
 
-export type SessionCheckResponseType =
-  (typeof SessionCheckResponseType)[keyof typeof SessionCheckResponseType];
+export type SessionCheckResponseType = 'id_token' | 'none';
 
 /**
  * Both modes send id_token_hint if a stored token is available; the AS falls back to the browser
@@ -25,7 +17,7 @@ export type SessionCheckResponseType =
  * - none mode: returns no claims. Success is detected by the iframe landing on the redirect URI.
  */
 export interface SessionCheckOptions {
-  /** The response type for the session check. Default: SessionCheckResponseType.None */
+  /** The response type for the session check. Defaults to 'none'. */
   responseType?: SessionCheckResponseType;
   /** Overrides OidcConfig.redirectUri for the session check request. */
   redirectUri?: string;
@@ -35,7 +27,4 @@ export interface SessionCheckOptions {
   scope?: string;
 }
 
-export interface SessionCheckSuccess {
-  /** Decoded id_token payload. Present only in id_token mode. */
-  claims?: Record<string, unknown>;
-}
+export type SessionCheckSuccess = { mode: 'none' } | { mode: 'id_token'; claims: JWTPayload };

--- a/packages/oidc-client/src/types.ts
+++ b/packages/oidc-client/src/types.ts
@@ -1,4 +1,4 @@
-/* Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+/* Copyright © 2025 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -7,6 +7,7 @@ export * from './lib/client.types.js';
 export * from './lib/config.types.js';
 export * from './lib/authorize.request.types.js';
 export * from './lib/exchange.types.js';
+export * from './lib/session.types.js';
 export type { PushAuthorizationResponse } from './lib/par.types.js';
 
 export type {

--- a/packages/sdk-effects/iframe-manager/src/lib/iframe-manager.effects.test.ts
+++ b/packages/sdk-effects/iframe-manager/src/lib/iframe-manager.effects.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright © 2025 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -23,41 +23,69 @@ function simulateIframeLoad(iframe: HTMLIFrameElement, href: string): void {
 
 describe('iFrameManager', () => {
   describe('getParamsByRedirect – input validation', () => {
-    it('throws synchronously when successParams is empty', () => {
+    it('rejects when successParams is empty (no resolveOnRedirectUri)', async () => {
       const manager = iFrameManager();
-      expect(() =>
+      await expect(
         manager.getParamsByRedirect({
           url: 'https://example.com',
           timeout: 1000,
           successParams: [],
           errorParams: ['error'],
         }),
-      ).toThrow('successParams and errorParams must be provided');
+      ).rejects.toEqual({
+        type: 'internal_error',
+        message: 'successParams and errorParams must be provided',
+      });
     });
 
-    it('throws synchronously when errorParams is empty', () => {
+    it('rejects when errorParams is empty (no resolveOnRedirectUri)', async () => {
       const manager = iFrameManager();
-      expect(() =>
+      await expect(
         manager.getParamsByRedirect({
           url: 'https://example.com',
           timeout: 1000,
           successParams: ['code'],
           errorParams: [],
         }),
-      ).toThrow('successParams and errorParams must be provided');
+      ).rejects.toEqual({
+        type: 'internal_error',
+        message: 'successParams and errorParams must be provided',
+      });
     });
 
-    it('throws synchronously when successParams or errorParams is undefined', () => {
+    it('rejects when errorParams is empty with resolveOnRedirectUri set', async () => {
       const manager = iFrameManager();
-      expect(() =>
+      await expect(
         manager.getParamsByRedirect({
           url: 'https://example.com',
           timeout: 1000,
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          successParams: undefined as any,
-          errorParams: ['error'],
+          successParams: [],
+          errorParams: [],
+          resolveOnRedirectUri: 'https://app.example.com/callback',
         }),
-      ).toThrow('successParams and errorParams must be provided');
+      ).rejects.toEqual({
+        type: 'internal_error',
+        message: 'errorParams must be provided',
+      });
+    });
+
+    it('does not reject when successParams is empty but resolveOnRedirectUri is set', async () => {
+      const manager = iFrameManager();
+      // The promise should not reject immediately — it will eventually timeout
+      vi.useFakeTimers();
+      const promise = manager.getParamsByRedirect({
+        url: 'https://example.com',
+        timeout: 100,
+        successParams: [],
+        errorParams: ['error'],
+        resolveOnRedirectUri: 'https://app.example.com/callback',
+      });
+      vi.advanceTimersByTime(100);
+      await expect(promise).rejects.toEqual({
+        type: 'internal_error',
+        message: 'iframe timed out',
+      });
+      vi.useRealTimers();
     });
   });
 
@@ -270,6 +298,156 @@ describe('iFrameManager', () => {
       await promise.catch(vi.fn());
 
       expect(document.querySelector('iframe')).toBeNull();
+    });
+  });
+
+  describe('getParamsByRedirect – includeHashParams', () => {
+    afterEach(() => {
+      document.body.replaceChildren();
+    });
+
+    it('includes hash fragment params when includeHashParams is true', async () => {
+      const manager = iFrameManager();
+      const promise = manager.getParamsByRedirect({
+        url: 'https://example.com/start',
+        timeout: 5000,
+        successParams: ['id_token'],
+        errorParams: ['error'],
+        includeHashParams: true,
+      });
+
+      const iframe = document.querySelector('iframe') as HTMLIFrameElement;
+      simulateIframeLoad(
+        iframe,
+        'https://app.example.com/callback#id_token=eyJhbGciOiJSUzI1NiJ9.test.sig&state=abc',
+      );
+
+      const result = await promise;
+      expect(result.id_token).toBe('eyJhbGciOiJSUzI1NiJ9.test.sig');
+      expect(result.state).toBe('abc');
+    });
+
+    it('detects error params in query string even when includeHashParams is true', async () => {
+      const manager = iFrameManager();
+      const promise = manager.getParamsByRedirect({
+        url: 'https://example.com/start',
+        timeout: 5000,
+        successParams: ['id_token'],
+        errorParams: ['error'],
+        includeHashParams: true,
+      });
+
+      const iframe = document.querySelector('iframe') as HTMLIFrameElement;
+      simulateIframeLoad(
+        iframe,
+        'https://app.example.com/callback?error=login_required&error_description=not+logged+in',
+      );
+
+      const result = await promise;
+      expect(result.error).toBe('login_required');
+    });
+
+    it('does not include hash params when includeHashParams is false', async () => {
+      const manager = iFrameManager();
+      const promise = manager.getParamsByRedirect({
+        url: 'https://example.com/start',
+        timeout: 5000,
+        successParams: ['code'],
+        errorParams: ['error'],
+        includeHashParams: false,
+      });
+
+      const iframe = document.querySelector('iframe') as HTMLIFrameElement;
+      // code is in the query string — resolves regardless of hash
+      simulateIframeLoad(iframe, 'https://app.example.com/callback?code=abc123#unrelated=ignored');
+
+      const result = await promise;
+      expect(result.code).toBe('abc123');
+      expect(result.unrelated).toBeUndefined();
+    });
+  });
+
+  describe('getParamsByRedirect – resolveOnRedirectUri', () => {
+    afterEach(() => {
+      document.body.replaceChildren();
+    });
+
+    it('resolves immediately when iframe lands on the redirect URI (exact match)', async () => {
+      const manager = iFrameManager();
+      const promise = manager.getParamsByRedirect({
+        url: 'https://as.example.com/authorize',
+        timeout: 5000,
+        successParams: [],
+        errorParams: ['error'],
+        resolveOnRedirectUri: 'https://app.example.com/callback',
+      });
+
+      const iframe = document.querySelector('iframe') as HTMLIFrameElement;
+      simulateIframeLoad(iframe, 'https://app.example.com/callback?state=abc123');
+
+      const result = await promise;
+      expect(result.state).toBe('abc123');
+    });
+
+    it('resolves with parsed query params on redirect URI landing', async () => {
+      const manager = iFrameManager();
+      const promise = manager.getParamsByRedirect({
+        url: 'https://as.example.com/authorize',
+        timeout: 5000,
+        successParams: [],
+        errorParams: ['error'],
+        resolveOnRedirectUri: 'https://app.example.com/callback',
+      });
+
+      const iframe = document.querySelector('iframe') as HTMLIFrameElement;
+      simulateIframeLoad(iframe, 'https://app.example.com/callback?state=xyz&session_state=foo');
+
+      const result = await promise;
+      expect(result).toEqual({ state: 'xyz', session_state: 'foo' });
+    });
+
+    it('does not resolve on a path that is a substring of the redirect URI', async () => {
+      vi.useFakeTimers();
+      const manager = iFrameManager();
+      const promise = manager.getParamsByRedirect({
+        url: 'https://as.example.com/authorize',
+        timeout: 500,
+        successParams: [],
+        errorParams: ['error'],
+        resolveOnRedirectUri: 'https://app.example.com/callback',
+      });
+
+      const iframe = document.querySelector('iframe') as HTMLIFrameElement;
+      // "/callbacks-leak" shares the prefix "/callback" — must NOT resolve
+      simulateIframeLoad(iframe, 'https://app.example.com/callbacks-leak?state=evil');
+
+      vi.advanceTimersByTime(500);
+      await expect(promise).rejects.toEqual({
+        type: 'internal_error',
+        message: 'iframe timed out',
+      });
+      vi.useRealTimers();
+    });
+
+    it('detects error params before checking redirect URI match', async () => {
+      const manager = iFrameManager();
+      const promise = manager.getParamsByRedirect({
+        url: 'https://as.example.com/authorize',
+        timeout: 5000,
+        successParams: [],
+        errorParams: ['error'],
+        resolveOnRedirectUri: 'https://app.example.com/callback',
+      });
+
+      const iframe = document.querySelector('iframe') as HTMLIFrameElement;
+      // Error lands on the redirect URI — error check fires first
+      simulateIframeLoad(
+        iframe,
+        'https://app.example.com/callback?error=login_required&error_description=no+session',
+      );
+
+      const result = await promise;
+      expect(result.error).toBe('login_required');
     });
   });
 });

--- a/packages/sdk-effects/iframe-manager/src/lib/iframe-manager.effects.ts
+++ b/packages/sdk-effects/iframe-manager/src/lib/iframe-manager.effects.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright © 2025 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -16,6 +16,10 @@ export interface GetParamsFromIFrameOptions {
   successParams: string[];
   /** Array of query parameter keys indicating an error occurred. */
   errorParams: string[];
+  /** When true, merges URL fragment (hash) params into search params before resolution. Use for response_type=id_token. */
+  includeHashParams?: boolean;
+  /** When set, resolves immediately upon navigating to a URL matching this redirect URI (origin + pathname). Use for response_type=none. */
+  resolveOnRedirectUri?: string;
 }
 
 export type ResolvedParams = Record<string, string>;
@@ -44,6 +48,18 @@ function searchParamsToRecord(params: URLSearchParams): ResolvedParams {
   return result;
 }
 
+// Compares origin + pathname rather than string prefix to avoid substring/trailing-slash false matches
+// (e.g. "/callback" vs "/callbacks-leak") and to ignore appended query/hash params.
+function isRedirectUriMatch(currentHref: string, redirectUri: string): boolean {
+  try {
+    const current = new URL(currentHref);
+    const target = new URL(redirectUri);
+    return current.origin === target.origin && current.pathname === target.pathname;
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Initializes the Iframe Manager effect.
  * @returns An object containing the API for managing iframe requests.
@@ -63,16 +79,24 @@ export function iFrameManager() {
    */
   return {
     getParamsByRedirect: (options: GetParamsFromIFrameOptions): Promise<ResolvedParams> => {
-      const { url, timeout, successParams, errorParams } = options;
+      const { url, timeout, successParams, errorParams, includeHashParams, resolveOnRedirectUri } =
+        options;
 
-      if (
-        !successParams ||
-        !errorParams ||
-        successParams.length === 0 ||
-        errorParams.length === 0
-      ) {
-        const error = new Error('successParams and errorParams must be provided');
-        throw error;
+      // Without resolveOnRedirectUri, both arrays are required — successParams detects success,
+      // errorParams detects errors; if either is missing one outcome is undetectable.
+      if (!resolveOnRedirectUri && (!successParams?.length || !errorParams?.length)) {
+        return Promise.reject({
+          type: 'internal_error',
+          message: 'successParams and errorParams must be provided',
+        });
+      }
+      // With resolveOnRedirectUri (response_type=none), success is detected via URI landing so
+      // successParams:[] is intentional — but errorParams is still required since errors arrive as query params.
+      if (resolveOnRedirectUri && !errorParams?.length) {
+        return Promise.reject({
+          type: 'internal_error',
+          message: 'errorParams must be provided',
+        });
       }
 
       return new Promise<ResolvedParams>((resolve, reject) => {
@@ -109,26 +133,42 @@ export function iFrameManager() {
                 return; // Wait for actual navigation
               }
 
-              const redirectUrl = new URL(currentIframeHref);
-              const searchParams = redirectUrl.searchParams;
-              const parsedParams = searchParamsToRecord(searchParams);
+              const { searchParams, hash } = new URL(currentIframeHref);
+              // hash is the raw URL fragment including '#' (e.g. "#id_token=eyJ...&state=abc").
+              // For response_type=id_token, the token arrives in the fragment instead of the query string.
+              // slice(1) strips the leading '#', then new URLSearchParams parses "key=value&key=value"
+              // exactly like a query string — merging both sets into one URLSearchParams for uniform scanning.
+              const redirectParams = includeHashParams
+                ? new URLSearchParams([...searchParams, ...new URLSearchParams(hash.slice(1))])
+                : searchParams;
+              const parsedParams = searchParamsToRecord(redirectParams);
 
               // 1. Check for Error Parameters
-              if (hasErrorParams(searchParams, errorParams)) {
+              if (hasErrorParams(redirectParams, errorParams)) {
+                cleanup();
+                resolve(parsedParams);
+                return;
+              }
+
+              // 2. resolveOnRedirectUri mode: resolve as soon as the iframe lands on the redirect URI
+              if (
+                resolveOnRedirectUri &&
+                isRedirectUriMatch(currentIframeHref, resolveOnRedirectUri)
+              ) {
                 cleanup();
                 resolve(parsedParams); // Resolve with all parsed params for context
                 return;
               }
 
-              // 2. Check for Success Parameters
-              if (hasSomeSuccessParams(searchParams, successParams)) {
+              // 3. Check for Success Parameters
+              if (hasSomeSuccessParams(redirectParams, successParams)) {
                 cleanup();
                 resolve(parsedParams); // Resolve with all parsed params
                 return;
               }
 
               /*
-               * 3. Neither Error nor Success: Intermediate Redirect?
+               * 4. Neither Error nor Success: Intermediate Redirect?
                * If neither error nor all required success params are found,
                * assume it's an intermediate step in the redirect flow.
                * Do nothing, let the timeout eventually handle non-resolving states

--- a/packages/sdk-utilities/package.json
+++ b/packages/sdk-utilities/package.json
@@ -40,7 +40,8 @@
     "test:watch": "pnpm nx nxTest --watch"
   },
   "dependencies": {
-    "@forgerock/sdk-types": "workspace:*"
+    "@forgerock/sdk-types": "workspace:*",
+    "effect": "catalog:effect"
   },
   "nx": {
     "tags": ["scope:sdk-utilities"]

--- a/packages/sdk-utilities/src/index.ts
+++ b/packages/sdk-utilities/src/index.ts
@@ -8,6 +8,7 @@
  */
 
 export * from './lib/error/index.js';
+export * from './lib/micro.utils.js';
 export * from './lib/oidc/index.js';
 export * from './lib/strings/index.js';
 export * from './lib/url/index.js';

--- a/packages/sdk-utilities/src/lib/micro.utils.ts
+++ b/packages/sdk-utilities/src/lib/micro.utils.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+import { causeIsDie, exitIsFail, exitIsSuccess } from 'effect/Micro';
+import type { MicroExit } from 'effect/Micro';
+import type { GenericError } from '@forgerock/sdk-types';
+
+export function handleMicroExit<T, E>(
+  result: MicroExit<T, E>,
+  defectError: string,
+  defectType: GenericError['type'],
+): T | E | GenericError {
+  if (exitIsSuccess(result)) {
+    return result.value;
+  }
+  if (exitIsFail(result)) {
+    return result.cause.error;
+  }
+  const defect = causeIsDie(result.cause) ? result.cause.defect : undefined;
+  return {
+    error: defectError,
+    message: defect instanceof Error ? defect.message : String(defect ?? 'Unknown defect'),
+    type: defectType,
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -595,6 +595,9 @@ importers:
       '@forgerock/sdk-types':
         specifier: workspace:*
         version: link:../sdk-types
+      effect:
+        specifier: catalog:effect
+        version: 3.21.0
 
   scratchpad:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ catalogs:
     immer:
       specifier: ^10.1.1
       version: 10.2.0
+    jose:
+      specifier: ^6.0.0
+      version: 6.2.3
     msw:
       specifier: ^2.5.1
       version: 2.12.1
@@ -547,6 +550,9 @@ importers:
       effect:
         specifier: catalog:effect
         version: 3.21.0
+      jose:
+        specifier: 'catalog:'
+        version: 6.2.3
     devDependencies:
       '@effect/vitest':
         specifier: catalog:effect
@@ -5987,6 +5993,9 @@ packages:
 
   jju@1.4.0:
     resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
+
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -14832,6 +14841,8 @@ snapshots:
   jiti@2.6.1: {}
 
   jju@1.4.0: {}
+
+  jose@6.2.3: {}
 
   js-tokens@4.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,6 +8,7 @@ packages:
   - 'scratchpad'
 catalog:
   '@forgerock/javascript-sdk': '4.9.0'
+  jose: '^6.0.0'
   '@reduxjs/toolkit': '^2.8.2'
   '@types/express': '5.0.6'
   immer: '^10.1.1'


### PR DESCRIPTION
https://pingidentity.atlassian.net/browse/SDKS-5003

## Implementation Decisions

- I am returning ANY valid session for response type id_token. This is how it has been implemented in https://github.com/ForgeRock/oidcSessionCheck/blob/d321e1124d9cc87a188103e4e5c0f8ff13078557/sessionCheckFrame.src.js#L70. We can discuss about whether we need to be strict about verifying a user by subject / id_token in storage. In that case, subject / id_token will be required, which might restrict the use cases for session check
- id_token param is a fragment (not query param) for security purposes, so that it is not sent with server requests and is somewhat secure compared to query params
- state param is not echoed back for response type none which is expected. I did test it though, and so I haven’t added state sending or validation for response type none
- Added logging but avoided logging any tokens / claims

## How to test

- Build and start the oidc app with `pnpm nx build oidc-app && pnpm nx serve oidc-app`
- Load the `http://localhost:8443/ping-am` page and Login (Background)
- Clicking on Session Check (none) and Session Check (id_token) buttons should return empty and claims fields respectively
- Even if the token is invalid and the user is logged in, both buttons return valid sessions
- Only when the user is logged out, session check fails

## Recording

https://github.com/user-attachments/assets/b92d0ff8-6499-4bb3-83bf-cd81d5e0dcdb




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a user-facing session check API supporting silent (prompt=none) and id_token modes with optional subject validation.

* **Enhancements**
  * Session-check delivery via iframe or fetch, hash-fragment merging, exact redirect-URI matching, and improved error mappings.
  * Public types and client API updated to return typed session-check results.
  * UI: session-check buttons added to test app pages.

* **Tests**
  * Expanded unit and e2e coverage for success/failure paths, JWT/nonce/state validation, and timeouts.

* **Documentation**
  * README updated with examples and expected outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->