### PR TITLE
feat(davinci-client): add form image collector

### DIFF
--- a/.changeset/curly-wolves-swim.md
+++ b/.changeset/curly-wolves-swim.md
@@ -2,4 +2,4 @@
 '@forgerock/davinci-client': minor
 ---
 
-Add `ImageCollector` for rendering `IMAGE` form fields from DaVinci Forms.
+Add `ImageCollector` for rendering `IMAGE` form fields from PingOne Forms.

--- a/.changeset/curly-wolves-swim.md
+++ b/.changeset/curly-wolves-swim.md
@@ -1,0 +1,5 @@
+---
+'@forgerock/davinci-client': minor
+---
+
+Add `ImageCollector` for rendering `IMAGE` form fields from DaVinci Forms.

--- a/e2e/davinci-app/components/form-image.ts
+++ b/e2e/davinci-app/components/form-image.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+import type { ImageCollector } from '@forgerock/davinci-client/types';
+
+export default function (formEl: HTMLFormElement, collector: ImageCollector) {
+  if (collector.error) {
+    const errorEl = document.createElement('p');
+    errorEl.innerText = `Image error: ${collector.error}`;
+    formEl.appendChild(errorEl);
+    return;
+  }
+
+  const container = document.createElement('div');
+
+  const img = document.createElement('img');
+  img.src = collector.output.src;
+  img.alt = collector.output.alt;
+  img.setAttribute('data-testid', 'form-image');
+
+  if (collector.output.href) {
+    const anchor = document.createElement('a');
+    anchor.href = collector.output.href;
+    anchor.appendChild(img);
+    container.appendChild(anchor);
+  } else {
+    container.appendChild(img);
+  }
+
+  formEl.appendChild(container);
+}

--- a/e2e/davinci-app/components/form-image.ts
+++ b/e2e/davinci-app/components/form-image.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/e2e/davinci-app/main.ts
+++ b/e2e/davinci-app/main.ts
@@ -35,6 +35,7 @@ import readOnlyComponent from './components/read-only.js';
 import objectValueComponent from './components/object-value.js';
 import fidoComponent from './components/fido.js';
 import qrCodeComponent from './components/qr-code.js';
+import formImageComponent from './components/form-image.js';
 import pollingComponent from './components/polling.js';
 import booleanComponent from './components/boolean.js';
 
@@ -232,6 +233,8 @@ const urlParams = new URLSearchParams(window.location.search);
         );
       } else if (collector.type === 'QrCodeCollector') {
         qrCodeComponent(formEl, collector);
+      } else if (collector.type === 'ImageCollector') {
+        formImageComponent(formEl, collector);
       } else if (collector.type === 'TextCollector') {
         textComponent(
           formEl, // You can ignore this; it's just for rendering

--- a/e2e/davinci-app/server-configs.ts
+++ b/e2e/davinci-app/server-configs.ts
@@ -47,6 +47,18 @@ export const serverConfigs: Record<string, DaVinciConfig> = {
     },
   },
   /**
+   * Form Fields (old env — image feature flag enabled)
+   */
+  '60de77d5-dd2c-41ef-8c40-f8bb2381a359': {
+    clientId: '60de77d5-dd2c-41ef-8c40-f8bb2381a359',
+    redirectUri: window.location.origin + '/',
+    scope: 'openid profile email name revoke',
+    serverConfig: {
+      wellknown:
+        'https://auth.pingone.ca/02fb4743-189a-4bc7-9d6c-a919edfe6447/as/.well-known/openid-configuration',
+    },
+  },
+  /**
    * Form Fields
    */
   'e4ef2896-8d90-4abd-bf0f-7b8034995927': {

--- a/e2e/davinci-suites/src/form-image.test.ts
+++ b/e2e/davinci-suites/src/form-image.test.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+import { expect, test } from '@playwright/test';
+
+import { asyncEvents } from './utils/async-events.js';
+
+test('Should render image collector in form', async ({ page }) => {
+  const { navigate } = asyncEvents(page);
+  await navigate('/?clientId=60de77d5-dd2c-41ef-8c40-f8bb2381a359');
+
+  await expect(page.getByText('Select Test Form')).toBeVisible();
+  await page.getByRole('button', { name: 'Form Fields' }).click();
+
+  await expect(page.getByText('Form Fields Tests')).toBeVisible();
+
+  const formImage = page.getByTestId('form-image');
+  await expect(formImage).toBeVisible();
+  await expect(formImage).toHaveAttribute('src', /QC-Montreal-Skyline_hero\.jpg/);
+  await expect(formImage).toHaveAttribute('alt', 'New Image');
+
+  const formImageAnchor = page.locator('a:has([data-testid="form-image"])');
+  await expect(formImageAnchor).toHaveAttribute('href', 'https://www.pingidentity.com/en.html');
+});

--- a/e2e/davinci-suites/src/form-image.test.ts
+++ b/e2e/davinci-suites/src/form-image.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/packages/davinci-client/api-report/davinci-client.api.md
+++ b/packages/davinci-client/api-report/davinci-client.api.md
@@ -173,7 +173,7 @@ export interface CollectorRichContent {
 }
 
 // @public (undocumented)
-export type Collectors = FlowCollector | PasswordCollector | ValidatedPasswordCollector | TextCollector | BooleanCollector | ValidatedBooleanCollector | SingleSelectCollector | IdpCollector | SubmitCollector | ActionCollector<'ActionCollector'> | SingleValueCollector<'SingleValueCollector'> | MultiSelectCollector | DeviceAuthenticationCollector | DeviceRegistrationCollector | PhoneNumberCollector | PhoneNumberExtensionCollector | ReadOnlyCollector | RichTextCollector | ValidatedTextCollector | ProtectCollector | PollingCollector | FidoRegistrationCollector | FidoAuthenticationCollector | QrCodeCollector | UnknownCollector;
+export type Collectors = FlowCollector | PasswordCollector | ValidatedPasswordCollector | TextCollector | BooleanCollector | ValidatedBooleanCollector | SingleSelectCollector | IdpCollector | SubmitCollector | ActionCollector<'ActionCollector'> | SingleValueCollector<'SingleValueCollector'> | MultiSelectCollector | DeviceAuthenticationCollector | DeviceRegistrationCollector | PhoneNumberCollector | PhoneNumberExtensionCollector | ReadOnlyCollector | RichTextCollector | ValidatedTextCollector | ProtectCollector | PollingCollector | FidoRegistrationCollector | FidoAuthenticationCollector | QrCodeCollector | ImageCollector | UnknownCollector;
 
 // @public
 export type CollectorValueType<T> = T extends {
@@ -945,6 +945,25 @@ export type GetClient = StartNode['client'] | ContinueNode['client'] | ErrorNode
 // @public (undocumented)
 export type IdpCollector = ActionCollectorWithUrl<'IdpCollector'>;
 
+// @public
+export interface ImageCollector extends NoValueCollectorBase<'ImageCollector'> {
+    // (undocumented)
+    output: NoValueCollectorBase<'ImageCollector'>['output'] & {
+        src: string;
+        alt: string;
+        href?: string;
+    };
+}
+
+// @public (undocumented)
+export type ImageField = {
+    type: 'IMAGE';
+    key: string;
+    description: string;
+    imageUrl: string;
+    hyperlinkUrl?: string;
+};
+
 // @public (undocumented)
 export type InferActionCollectorType<T extends ActionCollectorTypes> = T extends 'IdpCollector' ? IdpCollector : T extends 'SubmitCollector' ? SubmitCollector : T extends 'FlowCollector' ? FlowCollector : ActionCollectorWithUrl<'ActionCollector'> | ActionCollectorNoUrl<'ActionCollector'>;
 
@@ -955,7 +974,7 @@ export type InferAutoCollectorType<T extends AutoCollectorTypes> = T extends 'Pr
 export type InferMultiValueCollectorType<T extends MultiValueCollectorTypes> = T extends 'MultiSelectCollector' ? MultiValueCollectorWithValue<'MultiSelectCollector'> : MultiValueCollectorWithValue<'MultiValueCollector'> | MultiValueCollectorNoValue<'MultiValueCollector'>;
 
 // @public
-export type InferNoValueCollectorType<T extends NoValueCollectorTypes> = T extends 'ReadOnlyCollector' ? ReadOnlyCollector : T extends 'RichTextCollector' ? RichTextCollector : T extends 'QrCodeCollector' ? QrCodeCollector : NoValueCollectorBase<'NoValueCollector'>;
+export type InferNoValueCollectorType<T extends NoValueCollectorTypes> = T extends 'ReadOnlyCollector' ? ReadOnlyCollector : T extends 'RichTextCollector' ? RichTextCollector : T extends 'QrCodeCollector' ? QrCodeCollector : T extends 'ImageCollector' ? ImageCollector : NoValueCollectorBase<'NoValueCollector'>;
 
 // @public
 export type InferSingleValueCollectorType<T extends SingleValueCollectorTypes> = T extends 'TextCollector' ? TextCollector : T extends 'SingleSelectCollector' ? SingleSelectCollector : T extends 'ValidatedTextCollector' ? ValidatedTextCollector : T extends 'PasswordCollector' ? PasswordCollector : T extends 'ValidatedPasswordCollector' ? ValidatedPasswordCollector : T extends 'BooleanCollector' ? BooleanCollector : T extends 'ValidatedBooleanCollector' ? ValidatedBooleanCollector : SingleValueCollectorWithValue<'SingleValueCollector'> | SingleValueCollectorNoValue<'SingleValueCollector'>;
@@ -1127,10 +1146,10 @@ export interface NoValueCollectorBase<T extends NoValueCollectorTypes> {
 }
 
 // @public (undocumented)
-export type NoValueCollectors = NoValueCollectorBase<'NoValueCollector'> | ReadOnlyCollector | RichTextCollector | QrCodeCollector;
+export type NoValueCollectors = NoValueCollectorBase<'NoValueCollector'> | ReadOnlyCollector | RichTextCollector | QrCodeCollector | ImageCollector;
 
 // @public
-export type NoValueCollectorTypes = 'ReadOnlyCollector' | 'RichTextCollector' | 'NoValueCollector' | 'QrCodeCollector';
+export type NoValueCollectorTypes = 'ReadOnlyCollector' | 'RichTextCollector' | 'NoValueCollector' | 'QrCodeCollector' | 'ImageCollector';
 
 // @public
 export interface OAuthDetails {
@@ -1513,7 +1532,7 @@ export type ReadOnlyField = {
 };
 
 // @public (undocumented)
-export type ReadOnlyFields = ReadOnlyField | QrCodeField | AgreementField;
+export type ReadOnlyFields = ReadOnlyField | QrCodeField | AgreementField | ImageField;
 
 // @public (undocumented)
 export type RedirectField = {

--- a/packages/davinci-client/api-report/davinci-client.api.md
+++ b/packages/davinci-client/api-report/davinci-client.api.md
@@ -283,16 +283,12 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
     resume: (input: {
         continueToken: string;
     }) => Promise<InternalErrorResponse | NodeStates>;
-    start: <QueryParams extends OutgoingQueryParams = OutgoingQueryParams>(options?: StartOptions<QueryParams> | undefined) => Promise<ContinueNode | ErrorNode | FailureNode | StartNode | SuccessNode>;
+    start: <QueryParams extends OutgoingQueryParams = OutgoingQueryParams>(options?: StartOptions<QueryParams> | undefined) => Promise<StartNode | ErrorNode | FailureNode | ContinueNode | SuccessNode>;
     update: <T extends SingleValueCollectors | MultiSelectCollector | ObjectValueCollectors | AutoCollectors>(collector: T) => Updater<T>;
     validate: (collector: SingleValueCollectors | ObjectValueCollectors | MultiValueCollectors | AutoCollectors) => Validator;
     pollStatus: (collector: PollingCollector) => Poller;
     getClient: () => {
-        action: string;
-        collectors: Collectors[];
-        description?: string;
-        name?: string;
-        status: "continue";
+        status: "start";
     } | {
         action: string;
         collectors: Collectors[];
@@ -302,7 +298,11 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
     } | {
         status: "failure";
     } | {
-        status: "start";
+        action: string;
+        collectors: Collectors[];
+        description?: string;
+        name?: string;
+        status: "continue";
     } | {
         authorization?: {
             code?: string;
@@ -313,15 +313,9 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
     getCollectors: () => Collectors[];
     getError: () => DaVinciError | null;
     getErrorCollectors: () => CollectorErrors[];
-    getNode: () => ContinueNode | ErrorNode | FailureNode | StartNode | SuccessNode;
+    getNode: () => StartNode | ErrorNode | FailureNode | ContinueNode | SuccessNode;
     getServer: () => {
-        _links?: Links;
-        id?: string;
-        interactionId?: string;
-        interactionToken?: string;
-        href?: string;
-        eventName?: string;
-        status: "continue";
+        status: "start";
     } | {
         _links?: Links;
         eventName?: string;
@@ -338,7 +332,13 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         interactionToken?: string;
         status: "failure";
     } | {
-        status: "start";
+        _links?: Links;
+        id?: string;
+        interactionId?: string;
+        interactionToken?: string;
+        href?: string;
+        eventName?: string;
+        status: "continue";
     } | {
         _links?: Links;
         eventName?: string;
@@ -355,14 +355,14 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         } & Omit<{
             requestId: string;
             data?: unknown;
-            error?: FetchBaseQueryError | SerializedError | undefined;
+            error?: SerializedError | FetchBaseQueryError | undefined;
             endpointName: string;
             startedTimeStamp: number;
             fulfilledTimeStamp?: number;
         }, "data" | "fulfilledTimeStamp"> & Required<Pick<{
             requestId: string;
             data?: unknown;
-            error?: FetchBaseQueryError | SerializedError | undefined;
+            error?: SerializedError | FetchBaseQueryError | undefined;
             endpointName: string;
             startedTimeStamp: number;
             fulfilledTimeStamp?: number;
@@ -379,14 +379,14 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         } & Omit<{
             requestId: string;
             data?: unknown;
-            error?: FetchBaseQueryError | SerializedError | undefined;
+            error?: SerializedError | FetchBaseQueryError | undefined;
             endpointName: string;
             startedTimeStamp: number;
             fulfilledTimeStamp?: number;
         }, "error"> & Required<Pick<{
             requestId: string;
             data?: unknown;
-            error?: FetchBaseQueryError | SerializedError | undefined;
+            error?: SerializedError | FetchBaseQueryError | undefined;
             endpointName: string;
             startedTimeStamp: number;
             fulfilledTimeStamp?: number;
@@ -407,14 +407,14 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         } & Omit<{
             requestId: string;
             data?: unknown;
-            error?: FetchBaseQueryError | SerializedError | undefined;
+            error?: SerializedError | FetchBaseQueryError | undefined;
             endpointName: string;
             startedTimeStamp: number;
             fulfilledTimeStamp?: number;
         }, "data" | "fulfilledTimeStamp"> & Required<Pick<{
             requestId: string;
             data?: unknown;
-            error?: FetchBaseQueryError | SerializedError | undefined;
+            error?: SerializedError | FetchBaseQueryError | undefined;
             endpointName: string;
             startedTimeStamp: number;
             fulfilledTimeStamp?: number;
@@ -431,14 +431,14 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         } & Omit<{
             requestId: string;
             data?: unknown;
-            error?: FetchBaseQueryError | SerializedError | undefined;
+            error?: SerializedError | FetchBaseQueryError | undefined;
             endpointName: string;
             startedTimeStamp: number;
             fulfilledTimeStamp?: number;
         }, "error"> & Required<Pick<{
             requestId: string;
             data?: unknown;
-            error?: FetchBaseQueryError | SerializedError | undefined;
+            error?: SerializedError | FetchBaseQueryError | undefined;
             endpointName: string;
             startedTimeStamp: number;
             fulfilledTimeStamp?: number;

--- a/packages/davinci-client/api-report/davinci-client.types.api.md
+++ b/packages/davinci-client/api-report/davinci-client.types.api.md
@@ -173,7 +173,7 @@ export interface CollectorRichContent {
 }
 
 // @public (undocumented)
-export type Collectors = FlowCollector | PasswordCollector | ValidatedPasswordCollector | TextCollector | BooleanCollector | ValidatedBooleanCollector | SingleSelectCollector | IdpCollector | SubmitCollector | ActionCollector<'ActionCollector'> | SingleValueCollector<'SingleValueCollector'> | MultiSelectCollector | DeviceAuthenticationCollector | DeviceRegistrationCollector | PhoneNumberCollector | PhoneNumberExtensionCollector | ReadOnlyCollector | RichTextCollector | ValidatedTextCollector | ProtectCollector | PollingCollector | FidoRegistrationCollector | FidoAuthenticationCollector | QrCodeCollector | UnknownCollector;
+export type Collectors = FlowCollector | PasswordCollector | ValidatedPasswordCollector | TextCollector | BooleanCollector | ValidatedBooleanCollector | SingleSelectCollector | IdpCollector | SubmitCollector | ActionCollector<'ActionCollector'> | SingleValueCollector<'SingleValueCollector'> | MultiSelectCollector | DeviceAuthenticationCollector | DeviceRegistrationCollector | PhoneNumberCollector | PhoneNumberExtensionCollector | ReadOnlyCollector | RichTextCollector | ValidatedTextCollector | ProtectCollector | PollingCollector | FidoRegistrationCollector | FidoAuthenticationCollector | QrCodeCollector | ImageCollector | UnknownCollector;
 
 // @public
 export type CollectorValueType<T> = T extends {
@@ -942,6 +942,25 @@ export type GetClient = StartNode['client'] | ContinueNode['client'] | ErrorNode
 // @public (undocumented)
 export type IdpCollector = ActionCollectorWithUrl<'IdpCollector'>;
 
+// @public
+export interface ImageCollector extends NoValueCollectorBase<'ImageCollector'> {
+    // (undocumented)
+    output: NoValueCollectorBase<'ImageCollector'>['output'] & {
+        src: string;
+        alt: string;
+        href?: string;
+    };
+}
+
+// @public (undocumented)
+export type ImageField = {
+    type: 'IMAGE';
+    key: string;
+    description: string;
+    imageUrl: string;
+    hyperlinkUrl?: string;
+};
+
 // @public (undocumented)
 export type InferActionCollectorType<T extends ActionCollectorTypes> = T extends 'IdpCollector' ? IdpCollector : T extends 'SubmitCollector' ? SubmitCollector : T extends 'FlowCollector' ? FlowCollector : ActionCollectorWithUrl<'ActionCollector'> | ActionCollectorNoUrl<'ActionCollector'>;
 
@@ -952,7 +971,7 @@ export type InferAutoCollectorType<T extends AutoCollectorTypes> = T extends 'Pr
 export type InferMultiValueCollectorType<T extends MultiValueCollectorTypes> = T extends 'MultiSelectCollector' ? MultiValueCollectorWithValue<'MultiSelectCollector'> : MultiValueCollectorWithValue<'MultiValueCollector'> | MultiValueCollectorNoValue<'MultiValueCollector'>;
 
 // @public
-export type InferNoValueCollectorType<T extends NoValueCollectorTypes> = T extends 'ReadOnlyCollector' ? ReadOnlyCollector : T extends 'RichTextCollector' ? RichTextCollector : T extends 'QrCodeCollector' ? QrCodeCollector : NoValueCollectorBase<'NoValueCollector'>;
+export type InferNoValueCollectorType<T extends NoValueCollectorTypes> = T extends 'ReadOnlyCollector' ? ReadOnlyCollector : T extends 'RichTextCollector' ? RichTextCollector : T extends 'QrCodeCollector' ? QrCodeCollector : T extends 'ImageCollector' ? ImageCollector : NoValueCollectorBase<'NoValueCollector'>;
 
 // @public
 export type InferSingleValueCollectorType<T extends SingleValueCollectorTypes> = T extends 'TextCollector' ? TextCollector : T extends 'SingleSelectCollector' ? SingleSelectCollector : T extends 'ValidatedTextCollector' ? ValidatedTextCollector : T extends 'PasswordCollector' ? PasswordCollector : T extends 'ValidatedPasswordCollector' ? ValidatedPasswordCollector : T extends 'BooleanCollector' ? BooleanCollector : T extends 'ValidatedBooleanCollector' ? ValidatedBooleanCollector : SingleValueCollectorWithValue<'SingleValueCollector'> | SingleValueCollectorNoValue<'SingleValueCollector'>;
@@ -1124,10 +1143,10 @@ export interface NoValueCollectorBase<T extends NoValueCollectorTypes> {
 }
 
 // @public (undocumented)
-export type NoValueCollectors = NoValueCollectorBase<'NoValueCollector'> | ReadOnlyCollector | RichTextCollector | QrCodeCollector;
+export type NoValueCollectors = NoValueCollectorBase<'NoValueCollector'> | ReadOnlyCollector | RichTextCollector | QrCodeCollector | ImageCollector;
 
 // @public
-export type NoValueCollectorTypes = 'ReadOnlyCollector' | 'RichTextCollector' | 'NoValueCollector' | 'QrCodeCollector';
+export type NoValueCollectorTypes = 'ReadOnlyCollector' | 'RichTextCollector' | 'NoValueCollector' | 'QrCodeCollector' | 'ImageCollector';
 
 // @public
 export interface OAuthDetails {
@@ -1510,7 +1529,7 @@ export type ReadOnlyField = {
 };
 
 // @public (undocumented)
-export type ReadOnlyFields = ReadOnlyField | QrCodeField | AgreementField;
+export type ReadOnlyFields = ReadOnlyField | QrCodeField | AgreementField | ImageField;
 
 // @public (undocumented)
 export type RedirectField = {

--- a/packages/davinci-client/api-report/davinci-client.types.api.md
+++ b/packages/davinci-client/api-report/davinci-client.types.api.md
@@ -283,16 +283,12 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
     resume: (input: {
         continueToken: string;
     }) => Promise<InternalErrorResponse | NodeStates>;
-    start: <QueryParams extends OutgoingQueryParams = OutgoingQueryParams>(options?: StartOptions<QueryParams> | undefined) => Promise<ContinueNode | ErrorNode | FailureNode | StartNode | SuccessNode>;
+    start: <QueryParams extends OutgoingQueryParams = OutgoingQueryParams>(options?: StartOptions<QueryParams> | undefined) => Promise<StartNode | ErrorNode | FailureNode | ContinueNode | SuccessNode>;
     update: <T extends SingleValueCollectors | MultiSelectCollector | ObjectValueCollectors | AutoCollectors>(collector: T) => Updater<T>;
     validate: (collector: SingleValueCollectors | ObjectValueCollectors | MultiValueCollectors | AutoCollectors) => Validator;
     pollStatus: (collector: PollingCollector) => Poller;
     getClient: () => {
-        action: string;
-        collectors: Collectors[];
-        description?: string;
-        name?: string;
-        status: "continue";
+        status: "start";
     } | {
         action: string;
         collectors: Collectors[];
@@ -302,7 +298,11 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
     } | {
         status: "failure";
     } | {
-        status: "start";
+        action: string;
+        collectors: Collectors[];
+        description?: string;
+        name?: string;
+        status: "continue";
     } | {
         authorization?: {
             code?: string;
@@ -313,15 +313,9 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
     getCollectors: () => Collectors[];
     getError: () => DaVinciError | null;
     getErrorCollectors: () => CollectorErrors[];
-    getNode: () => ContinueNode | ErrorNode | FailureNode | StartNode | SuccessNode;
+    getNode: () => StartNode | ErrorNode | FailureNode | ContinueNode | SuccessNode;
     getServer: () => {
-        _links?: Links;
-        id?: string;
-        interactionId?: string;
-        interactionToken?: string;
-        href?: string;
-        eventName?: string;
-        status: "continue";
+        status: "start";
     } | {
         _links?: Links;
         eventName?: string;
@@ -338,7 +332,13 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         interactionToken?: string;
         status: "failure";
     } | {
-        status: "start";
+        _links?: Links;
+        id?: string;
+        interactionId?: string;
+        interactionToken?: string;
+        href?: string;
+        eventName?: string;
+        status: "continue";
     } | {
         _links?: Links;
         eventName?: string;
@@ -355,14 +355,14 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         } & Omit<{
             requestId: string;
             data?: unknown;
-            error?: FetchBaseQueryError | SerializedError | undefined;
+            error?: SerializedError | FetchBaseQueryError | undefined;
             endpointName: string;
             startedTimeStamp: number;
             fulfilledTimeStamp?: number;
         }, "data" | "fulfilledTimeStamp"> & Required<Pick<{
             requestId: string;
             data?: unknown;
-            error?: FetchBaseQueryError | SerializedError | undefined;
+            error?: SerializedError | FetchBaseQueryError | undefined;
             endpointName: string;
             startedTimeStamp: number;
             fulfilledTimeStamp?: number;
@@ -379,14 +379,14 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         } & Omit<{
             requestId: string;
             data?: unknown;
-            error?: FetchBaseQueryError | SerializedError | undefined;
+            error?: SerializedError | FetchBaseQueryError | undefined;
             endpointName: string;
             startedTimeStamp: number;
             fulfilledTimeStamp?: number;
         }, "error"> & Required<Pick<{
             requestId: string;
             data?: unknown;
-            error?: FetchBaseQueryError | SerializedError | undefined;
+            error?: SerializedError | FetchBaseQueryError | undefined;
             endpointName: string;
             startedTimeStamp: number;
             fulfilledTimeStamp?: number;
@@ -407,14 +407,14 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         } & Omit<{
             requestId: string;
             data?: unknown;
-            error?: FetchBaseQueryError | SerializedError | undefined;
+            error?: SerializedError | FetchBaseQueryError | undefined;
             endpointName: string;
             startedTimeStamp: number;
             fulfilledTimeStamp?: number;
         }, "data" | "fulfilledTimeStamp"> & Required<Pick<{
             requestId: string;
             data?: unknown;
-            error?: FetchBaseQueryError | SerializedError | undefined;
+            error?: SerializedError | FetchBaseQueryError | undefined;
             endpointName: string;
             startedTimeStamp: number;
             fulfilledTimeStamp?: number;
@@ -431,14 +431,14 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         } & Omit<{
             requestId: string;
             data?: unknown;
-            error?: FetchBaseQueryError | SerializedError | undefined;
+            error?: SerializedError | FetchBaseQueryError | undefined;
             endpointName: string;
             startedTimeStamp: number;
             fulfilledTimeStamp?: number;
         }, "error"> & Required<Pick<{
             requestId: string;
             data?: unknown;
-            error?: FetchBaseQueryError | SerializedError | undefined;
+            error?: SerializedError | FetchBaseQueryError | undefined;
             endpointName: string;
             startedTimeStamp: number;
             fulfilledTimeStamp?: number;

--- a/packages/davinci-client/src/lib/collector.types.test-d.ts
+++ b/packages/davinci-client/src/lib/collector.types.test-d.ts
@@ -28,6 +28,7 @@ import type {
   ReadOnlyCollector,
   RichTextCollector,
   QrCodeCollector,
+  ImageCollector,
   PhoneNumberCollector,
   PhoneNumberExtensionCollector,
   ObjectValueCollectorWithObjectValue,
@@ -646,6 +647,43 @@ describe('Collector Types', () => {
       };
 
       expectTypeOf(tCollector).toEqualTypeOf<ReadOnlyCollector>();
+    });
+
+    it('should correctly infer ImageCollector Type', () => {
+      const tCollector: InferNoValueCollectorType<'ImageCollector'> = {
+        category: 'NoValueCollector',
+        type: 'ImageCollector',
+        name: 'ImageCollector',
+        id: '1',
+        error: null,
+        output: {
+          key: 'image1',
+          label: 'A hero image',
+          type: 'IMAGE',
+          src: 'https://example.com/image.png',
+          alt: 'A hero image',
+          href: 'https://example.com',
+        },
+      };
+      expectTypeOf(tCollector).toEqualTypeOf<ImageCollector>();
+    });
+
+    it('should correctly infer ImageCollector Type without optional href', () => {
+      const tCollector: InferNoValueCollectorType<'ImageCollector'> = {
+        category: 'NoValueCollector',
+        type: 'ImageCollector',
+        name: 'ImageCollector',
+        id: '1',
+        error: null,
+        output: {
+          key: 'image1',
+          label: 'A hero image',
+          type: 'IMAGE',
+          src: 'https://example.com/image.png',
+          alt: 'A hero image',
+        },
+      };
+      expectTypeOf(tCollector).toEqualTypeOf<ImageCollector>();
     });
   });
 

--- a/packages/davinci-client/src/lib/collector.types.ts
+++ b/packages/davinci-client/src/lib/collector.types.ts
@@ -600,7 +600,8 @@ export type NoValueCollectorTypes =
   | 'ReadOnlyCollector'
   | 'RichTextCollector'
   | 'NoValueCollector'
-  | 'QrCodeCollector';
+  | 'QrCodeCollector'
+  | 'ImageCollector';
 
 export interface NoValueCollectorBase<T extends NoValueCollectorTypes> {
   category: 'NoValueCollector';
@@ -651,6 +652,19 @@ export interface QrCodeCollector extends NoValueCollectorBase<'QrCodeCollector'>
 }
 
 /**
+ * @interface ImageCollector - Display-only collector for IMAGE fields. Extends the
+ * generic `NoValueCollectorBase` with the image URL (`src`), `alt` text, and an optional
+ * hyperlink URL (`href`).
+ */
+export interface ImageCollector extends NoValueCollectorBase<'ImageCollector'> {
+  output: NoValueCollectorBase<'ImageCollector'>['output'] & {
+    src: string;
+    alt: string;
+    href?: string;
+  };
+}
+
+/**
  * @interface ReadOnlyCollector - Display-only collector for plain LABEL fields.
  * Extends `NoValueCollectorBase` with the plain-text `content` from the field.
  */
@@ -689,13 +703,16 @@ export type InferNoValueCollectorType<T extends NoValueCollectorTypes> =
       ? RichTextCollector
       : T extends 'QrCodeCollector'
         ? QrCodeCollector
-        : NoValueCollectorBase<'NoValueCollector'>;
+        : T extends 'ImageCollector'
+          ? ImageCollector
+          : NoValueCollectorBase<'NoValueCollector'>;
 
 export type NoValueCollectors =
   | NoValueCollectorBase<'NoValueCollector'>
   | ReadOnlyCollector
   | RichTextCollector
-  | QrCodeCollector;
+  | QrCodeCollector
+  | ImageCollector;
 
 export type NoValueCollector<T extends NoValueCollectorTypes> = InferNoValueCollectorType<T>;
 

--- a/packages/davinci-client/src/lib/collector.utils.test.ts
+++ b/packages/davinci-client/src/lib/collector.utils.test.ts
@@ -932,6 +932,23 @@ describe('No Value Collectors', () => {
         },
       });
     });
+
+    it('should not set a content error for IMAGE fields', () => {
+      const imageField: ImageField = {
+        type: 'IMAGE',
+        key: 'image',
+        imageUrl: 'https://example.com/image.png',
+        description: 'Alt text',
+      };
+      const result = returnNoValueCollector(imageField, 0, 'ImageCollector');
+      expect(result.error).toBeNull();
+    });
+
+    it('should set a content error for non-IMAGE fields missing content', () => {
+      const field = { type: 'LABEL', key: 'label' } as unknown as ReadOnlyField;
+      const result = returnNoValueCollector(field, 0, 'NoValueCollector');
+      expect(result.error).toBe('Content is not found in the field object. ');
+    });
   });
 
   describe('returnReadOnlyCollector', () => {
@@ -1177,8 +1194,8 @@ describe('returnImageCollector', () => {
     expect(result.output.label).toBe('Friendly alt text');
   });
 
-  // (e) imageUrl absent — src defaults to empty string
-  it('should default src to empty string when imageUrl is absent', () => {
+  // (e) imageUrl empty — src defaults to empty string, error is set
+  it('should default src to empty string and set an error when imageUrl is empty', () => {
     const mockField: ImageField = {
       type: 'IMAGE',
       key: 'image',
@@ -1187,6 +1204,46 @@ describe('returnImageCollector', () => {
     };
     const result = returnImageCollector(mockField, 0);
     expect(result.output.src).toBe('');
+    expect(result.error).toBe('ImageUrl is not found in the field object. ');
+  });
+
+  // (e2) description empty — label/alt default to empty string, error is set
+  it('should set an error when description is empty', () => {
+    const mockField: ImageField = {
+      type: 'IMAGE',
+      key: 'image',
+      description: '',
+      imageUrl: 'https://example.com/image.png',
+    };
+    const result = returnImageCollector(mockField, 0);
+    expect(result.error).toBe('Description is not found in the field object. ');
+  });
+
+  // (e3) both imageUrl and description empty — error lists both
+  it('should set an error for both missing fields when both are empty', () => {
+    const mockField: ImageField = {
+      type: 'IMAGE',
+      key: 'image',
+      description: '',
+      imageUrl: '',
+    };
+    const result = returnImageCollector(mockField, 0);
+    expect(result.error).toBe(
+      'ImageUrl is not found in the field object. Description is not found in the field object. ',
+    );
+  });
+
+  // (e4) imageUrl present — src passes through verbatim
+  it('should pass imageUrl through as src', () => {
+    const mockField: ImageField = {
+      type: 'IMAGE',
+      key: 'image',
+      description: 'Alt text',
+      imageUrl: 'https://example.com/image.png',
+    };
+    const result = returnImageCollector(mockField, 0);
+    expect(result.output.src).toBe('https://example.com/image.png');
+    expect(result.error).toBeNull();
   });
 
   // (f) output.label mirrors alt

--- a/packages/davinci-client/src/lib/collector.utils.test.ts
+++ b/packages/davinci-client/src/lib/collector.utils.test.ts
@@ -23,6 +23,7 @@ import {
   returnObjectValueCollector,
   returnSingleValueAutoCollector,
   returnObjectValueAutoCollector,
+  returnImageCollector,
   returnQrCodeCollector,
   normalizeReplacements,
   returnBooleanCollector,
@@ -33,6 +34,7 @@ import type {
   DaVinciField,
   DeviceAuthenticationField,
   DeviceRegistrationField,
+  ImageField,
   PasswordField,
   FidoAuthenticationField,
   FidoRegistrationField,
@@ -1093,6 +1095,117 @@ describe('returnQrCodeCollector', () => {
     const mockField = { type: 'QR_CODE' } as unknown as QrCodeField;
     const result = returnQrCodeCollector(mockField, 0);
     expect(result.error).toContain('Content is not found');
+  });
+});
+
+describe('returnImageCollector', () => {
+  // (a) Full payload — all five SDK contract fields present
+  it('should return a fully-populated ImageCollector when all contract fields are present', () => {
+    const mockField: ImageField = {
+      type: 'IMAGE',
+      key: 'heroImage',
+      imageUrl: 'https://cdn.example.com/image.png',
+      description: 'Alt text',
+      hyperlinkUrl: 'https://example.com/install',
+    };
+    const result = returnImageCollector(mockField, 1);
+    expect(result).toEqual({
+      category: 'NoValueCollector',
+      error: null,
+      type: 'ImageCollector',
+      id: 'heroImage-1',
+      name: 'heroImage-1',
+      output: {
+        key: 'heroImage-1',
+        label: 'Alt text',
+        type: 'IMAGE',
+        src: 'https://cdn.example.com/image.png',
+        alt: 'Alt text',
+        href: 'https://example.com/install',
+      },
+    });
+  });
+
+  // (b) Minimal payload — no hyperlinkUrl
+  it('should omit href when hyperlinkUrl is absent', () => {
+    const mockField: ImageField = {
+      type: 'IMAGE',
+      key: 'image',
+      description: 'Alt text',
+      imageUrl: 'https://example.com/test-image.png',
+    };
+    const result = returnImageCollector(mockField, 0);
+    expect(result.error).toBeNull();
+    expect(result.output.src).toBe('https://example.com/test-image.png');
+    expect(result.output.alt).toBe('Alt text');
+    expect(result.output.label).toBe('Alt text');
+    expect(result.output).not.toHaveProperty('href');
+  });
+
+  // (c) hyperlinkUrl present — href emitted; absent — omitted
+  it('should emit href when hyperlinkUrl is set and omit it when absent', () => {
+    const withHyperlink: ImageField = {
+      type: 'IMAGE',
+      key: 'image',
+      description: 'Alt text',
+      imageUrl: 'https://example.com/test-image.png',
+      hyperlinkUrl: 'https://example.com/click-target',
+    };
+    const resultWith = returnImageCollector(withHyperlink, 0);
+    expect(resultWith.output.href).toBe('https://example.com/click-target');
+
+    const withoutHyperlink: ImageField = {
+      type: 'IMAGE',
+      key: 'image',
+      description: 'Alt text',
+      imageUrl: 'https://example.com/test-image.png',
+    };
+    const resultWithout = returnImageCollector(withoutHyperlink, 0);
+    expect(resultWithout.output).not.toHaveProperty('href');
+  });
+
+  // (d) alt passes through verbatim as alt and label
+  it('should pass alt through verbatim as alt and label', () => {
+    const mockField: ImageField = {
+      type: 'IMAGE',
+      key: 'image',
+      description: 'Friendly alt text',
+      imageUrl: 'https://example.com/test-image.png',
+    };
+    const result = returnImageCollector(mockField, 0);
+    expect(result.output.alt).toBe('Friendly alt text');
+    expect(result.output.label).toBe('Friendly alt text');
+  });
+
+  // (e) imageUrl absent — src defaults to empty string
+  it('should default src to empty string when imageUrl is absent', () => {
+    const mockField: ImageField = {
+      type: 'IMAGE',
+      key: 'image',
+      description: 'Alt text',
+      imageUrl: '',
+    };
+    const result = returnImageCollector(mockField, 0);
+    expect(result.output.src).toBe('');
+  });
+
+  // (f) output.label mirrors alt
+  it('should set output.label to alt when present, empty string when absent', () => {
+    const withAlt: ImageField = {
+      type: 'IMAGE',
+      key: 'image',
+      description: 'Alt text',
+      imageUrl: 'https://example.com/test-image.png',
+    };
+    expect(returnImageCollector(withAlt, 0).output.label).toBe('Alt text');
+
+    const withoutAlt: ImageField = {
+      type: 'IMAGE',
+      key: 'image',
+      description: '',
+      imageUrl: 'https://example.com/test-image.png',
+    };
+    expect(returnImageCollector(withoutAlt, 0).output.label).toBe('');
   });
 });
 

--- a/packages/davinci-client/src/lib/collector.utils.ts
+++ b/packages/davinci-client/src/lib/collector.utils.ts
@@ -946,7 +946,7 @@ export function returnNoValueCollector<
   CollectorType extends NoValueCollectorTypes = 'NoValueCollector',
 >(field: Field, idx: number, collectorType: CollectorType) {
   let error = '';
-  if (!('content' in field)) {
+  if (field.type !== 'IMAGE' && !('content' in field)) {
     error = `${error}Content is not found in the field object. `;
   }
   if (!('type' in field)) {
@@ -1038,15 +1038,22 @@ export function returnQrCodeCollector(field: QrCodeField, idx: number): QrCodeCo
  */
 export function returnImageCollector(field: ImageField, idx: number): ImageCollector {
   const base = returnNoValueCollector(field, idx, 'ImageCollector');
+  let error = base.error || '';
+  if (!field.imageUrl) {
+    error = `${error}ImageUrl is not found in the field object. `;
+  }
+  if (!field.description) {
+    error = `${error}Description is not found in the field object. `;
+  }
 
   return {
     ...base,
-    error: null,
+    error: error || null,
     output: {
       ...base.output,
-      label: field.description,
-      src: field.imageUrl,
-      alt: field.description,
+      label: field.description || '',
+      src: field.imageUrl || '',
+      alt: field.description || '',
       ...(field.hyperlinkUrl ? { href: field.hyperlinkUrl } : {}),
     },
   };

--- a/packages/davinci-client/src/lib/collector.utils.ts
+++ b/packages/davinci-client/src/lib/collector.utils.ts
@@ -31,6 +31,7 @@ import type {
   AutoCollectors,
   SingleValueAutoCollectorTypes,
   ObjectValueAutoCollectorTypes,
+  ImageCollector,
   QrCodeCollector,
   ReadOnlyCollector,
   RichTextCollector,
@@ -45,6 +46,7 @@ import type {
   DeviceRegistrationField,
   FidoAuthenticationField,
   FidoRegistrationField,
+  ImageField,
   MultiSelectField,
   PasswordField,
   PhoneNumberField,
@@ -959,7 +961,7 @@ export function returnNoValueCollector<
     name: `${field.key || field.type}-${idx}`,
     output: {
       key: `${field.key || field.type}-${idx}`,
-      label: field.content,
+      label: 'content' in field ? field.content : '',
       type: field.type,
     },
   } as InferNoValueCollectorType<CollectorType>;
@@ -1019,6 +1021,33 @@ export function returnQrCodeCollector(field: QrCodeField, idx: number): QrCodeCo
       ...base.output,
       label: field.fallbackText || '',
       src: field.content || '',
+    },
+  };
+}
+
+/**
+ * @function returnImageCollector - Creates an ImageCollector object for displaying IMAGE fields.
+ *
+ * Composes on top of `returnNoValueCollector` for `category`, `id`, `name`, and base
+ * `output.{key, type}`. Overrides `output.label` and `output.alt` with `field.description`
+ * (IMAGE has no wire `label` property).
+ *
+ * @param {ImageField} field - The IMAGE field from the API response.
+ * @param {number} idx - The index used in the collector `id`/`name`.
+ * @returns {ImageCollector} The constructed ImageCollector object.
+ */
+export function returnImageCollector(field: ImageField, idx: number): ImageCollector {
+  const base = returnNoValueCollector(field, idx, 'ImageCollector');
+
+  return {
+    ...base,
+    error: null,
+    output: {
+      ...base.output,
+      label: field.description,
+      src: field.imageUrl,
+      alt: field.description,
+      ...(field.hyperlinkUrl ? { href: field.hyperlinkUrl } : {}),
     },
   };
 }

--- a/packages/davinci-client/src/lib/davinci.types.ts
+++ b/packages/davinci-client/src/lib/davinci.types.ts
@@ -140,6 +140,16 @@ export type QrCodeField = {
   fallbackText?: string;
 };
 
+export type ImageField = {
+  type: 'IMAGE';
+  key: string;
+  description: string;
+  imageUrl: string;
+
+  // Optional properties
+  hyperlinkUrl?: string;
+};
+
 export type AgreementField = {
   type: 'AGREEMENT';
   key: string;
@@ -328,7 +338,7 @@ export type ComplexValueFields =
   | FidoAuthenticationField
   | PollingField;
 export type MultiValueFields = MultiSelectField;
-export type ReadOnlyFields = ReadOnlyField | QrCodeField | AgreementField;
+export type ReadOnlyFields = ReadOnlyField | QrCodeField | AgreementField | ImageField;
 export type RedirectFields = RedirectField;
 export type SingleValueFields =
   | StandardField

--- a/packages/davinci-client/src/lib/node.reducer.test.ts
+++ b/packages/davinci-client/src/lib/node.reducer.test.ts
@@ -21,6 +21,7 @@ import type {
   ProtectCollector,
   QrCodeCollector,
   ReadOnlyCollector,
+  ImageCollector,
   SubmitCollector,
   TextCollector,
   BooleanCollector,
@@ -427,6 +428,35 @@ describe('The node collector reducer', () => {
     );
   });
 
+  it('should throw NoValueCollectors are read-only on update', () => {
+    const action = {
+      type: 'node/update',
+      payload: {
+        id: 'image-0',
+        value: 'attempted-update',
+      },
+    };
+    const state: ImageCollector[] = [
+      {
+        category: 'NoValueCollector',
+        error: null,
+        type: 'ImageCollector',
+        id: 'image-0',
+        name: 'image-0',
+        output: {
+          key: 'image-0',
+          label: 'Alt text',
+          type: 'IMAGE',
+          src: 'https://example.com/test-image.png',
+          alt: 'Alt text',
+        },
+      },
+    ];
+    expect(() => nodeCollectorReducer(state, action)).toThrowError(
+      'NoValueCollectors, like ReadOnlyCollectors, are read-only',
+    );
+  });
+
   it('should handle QR_CODE field type', () => {
     const action = {
       type: 'node/next',
@@ -496,6 +526,42 @@ describe('The node collector reducer', () => {
           title: 'Terms and Conditions',
         },
       } satisfies ReadOnlyCollector,
+    ]);
+  });
+
+  it('should handle IMAGE field type', () => {
+    const action = {
+      type: 'node/next',
+      payload: {
+        fields: [
+          {
+            type: 'IMAGE',
+            key: 'image-field',
+            imageUrl: 'https://example.com/test-image.png',
+            description: 'Test image alt text',
+            hyperlinkUrl: 'https://example.com/click-target',
+          },
+        ],
+        formData: {},
+      },
+    };
+    const result = nodeCollectorReducer(undefined, action);
+    expect(result).toEqual([
+      {
+        category: 'NoValueCollector',
+        error: null,
+        type: 'ImageCollector',
+        id: 'image-field-0',
+        name: 'image-field-0',
+        output: {
+          key: 'image-field-0',
+          label: 'Test image alt text',
+          type: 'IMAGE',
+          src: 'https://example.com/test-image.png',
+          alt: 'Test image alt text',
+          href: 'https://example.com/click-target',
+        },
+      } satisfies ImageCollector,
     ]);
   });
 });

--- a/packages/davinci-client/src/lib/node.reducer.ts
+++ b/packages/davinci-client/src/lib/node.reducer.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/packages/davinci-client/src/lib/node.reducer.ts
+++ b/packages/davinci-client/src/lib/node.reducer.ts
@@ -33,6 +33,7 @@ import {
   returnFidoRegistrationCollector,
   returnFidoAuthenticationCollector,
   returnQrCodeCollector,
+  returnImageCollector,
 } from './collector.utils.js';
 import type { DaVinciField, UnknownField } from './davinci.types.js';
 import type { PhoneNumberOutputValue, PhoneNumberExtensionOutputValue } from './collector.types.js';
@@ -87,6 +88,10 @@ export const nodeCollectorReducer = createReducer(initialCollectorValues, (build
 
             if (field.type === 'QR_CODE') {
               return returnQrCodeCollector(field, idx);
+            }
+
+            if (field.type === 'IMAGE') {
+              return returnImageCollector(field, idx);
             }
 
             // *Some* collectors may have default or existing data to display

--- a/packages/davinci-client/src/lib/node.types.test-d.ts
+++ b/packages/davinci-client/src/lib/node.types.test-d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/packages/davinci-client/src/lib/node.types.test-d.ts
+++ b/packages/davinci-client/src/lib/node.types.test-d.ts
@@ -42,6 +42,7 @@ import type {
   FidoRegistrationCollector,
   FidoAuthenticationCollector,
   QrCodeCollector,
+  ImageCollector,
 } from './collector.types.js';
 // ErrorDetail and Links are used as part of the DaVinciError and server._links types respectively
 
@@ -250,6 +251,7 @@ describe('Node Types', () => {
         | FidoRegistrationCollector
         | FidoAuthenticationCollector
         | QrCodeCollector
+        | ImageCollector
         | UnknownCollector
       >();
 

--- a/packages/davinci-client/src/lib/node.types.ts
+++ b/packages/davinci-client/src/lib/node.types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/packages/davinci-client/src/lib/node.types.ts
+++ b/packages/davinci-client/src/lib/node.types.ts
@@ -31,6 +31,7 @@ import type {
   FidoRegistrationCollector,
   FidoAuthenticationCollector,
   QrCodeCollector,
+  ImageCollector,
   PhoneNumberExtensionCollector,
 } from './collector.types.js';
 import type { Links } from './davinci.types.js';
@@ -60,6 +61,7 @@ export type Collectors =
   | FidoRegistrationCollector
   | FidoAuthenticationCollector
   | QrCodeCollector
+  | ImageCollector
   | UnknownCollector;
 
 export interface CollectorErrors {


### PR DESCRIPTION
# JIRA Ticket
https://pingidentity.atlassian.net/browse/SDKS-5101

# Review Note:
The third commit [davinci-client: add image collector e2e test against old env](https://github.com/ForgeRock/ping-javascript-sdk/pull/698/changes/b0d790de9a0ccba541ea5d8d01ee3331c4b9e885) is only added temporarily. Right now, only the old Davinci env has the feature flag DV-21617-forms-image-component-sdk-response enabled. So instead of updating the form to match the old env, I've added a new file form-image.test.ts and added old Davinci config to server-configs.ts file as a separate commit. Will remove this commit as soon as the flag is enabled for new Davinci console.

## Description
Adds support for the IMAGE field type in DaVinci forms. When a form includes an image component, the SDK now parses it into an ImageCollector, a read-only collector with description, imageUrl, and hyperlink properties.

## How to test

- pnpm nx serve davinci-app
- Navigate to http://localhost:5829/?clientId=60de77d5-dd2c-41ef-8c40-f8bb2381a359
- Click Form Fields
- Verify the Canada skyline image renders on the form
- Verify the image is wrapped in a link to https://www.pingidentity.com/en.html

## Recording

https://github.com/user-attachments/assets/aa74240d-7373-4ed3-bb88-afb7f4d46c39

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for `IMAGE` form fields in PingOne Forms, including rendering images with optional hyperlinks.

* **API Updates**
  * Extended the public client API typings to include `ImageCollector`/`ImageField`.
  * Updated agreement and checkbox typing rules (e.g., required agreement title) and adjusted supported collector types.

* **Tests**
  * Added end-to-end coverage to verify image rendering (src/alt) and hyperlink behavior in form workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->