### PR TITLE
chore(changeset): remove am-mock-api from changeset and add to ignore list

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -27,6 +27,7 @@
     "@forgerock/protect-app",
     "@forgerock/protect-suites",
     "@forgerock/journey-app",
-    "@forgerock/journey-suites"
+    "@forgerock/journey-suites",
+    "am-mock-api"
   ]
 }

--- a/.changeset/some-shirts-joke.md
+++ b/.changeset/some-shirts-joke.md
@@ -3,7 +3,6 @@
 '@forgerock/sdk-oidc': minor
 '@forgerock/davinci-client': minor
 '@forgerock/oidc-client': minor
-'am-mock-api': patch
 ---
 
 Add support for PAR in oidc-client requests for redirect flows


### PR DESCRIPTION
## Summary
- Removes `am-mock-api` patch entry from the `some-shirts-joke.md` changeset
- Adds `am-mock-api` to the changeset `ignore` list in `config.json` so it is excluded from future release tracking

## Test plan
- [ ] Verify changeset publish does not attempt to version `am-mock-api`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for PAR in redirect-flow requests.
* **Chores**
  * Updated release metadata to include the latest minor versions for several SDK-related packages.
  * Excluded an additional internal package from changeset processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->