### PR TITLE
feat(davinci-client): add metadata collector (SDKS-5100)

### DIFF
--- a/.changeset/real-swans-leave.md
+++ b/.changeset/real-swans-leave.md
@@ -1,0 +1,5 @@
+---
+'@forgerock/davinci-client': minor
+---
+
+Add MetadataCollector support

--- a/e2e/davinci-app/components/metadata.ts
+++ b/e2e/davinci-app/components/metadata.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+import type { MetadataCollector, Updater, MetadataError } from '@forgerock/davinci-client/types';
+
+export default function metadataComponent(
+  formEl: HTMLFormElement,
+  updater: Updater<MetadataCollector>,
+  submitForm: () => Promise<void>,
+) {
+  const successBtn = document.createElement('button');
+  successBtn.type = 'button';
+  successBtn.innerHTML = 'Metadata Success';
+
+  const errorBtn = document.createElement('button');
+  errorBtn.type = 'button';
+  errorBtn.innerHTML = 'Metadata Error';
+
+  formEl.appendChild(successBtn);
+  formEl.appendChild(errorBtn);
+
+  successBtn.onclick = async () => {
+    updater({ status: 'succeeded' });
+    await submitForm();
+  };
+
+  errorBtn.onclick = async () => {
+    const metadataError: MetadataError = {
+      code: 'ERROR_CODE',
+      message: 'Operation cancelled',
+    };
+
+    updater(metadataError);
+    await submitForm();
+  };
+}

--- a/e2e/davinci-app/main.ts
+++ b/e2e/davinci-app/main.ts
@@ -38,6 +38,7 @@ import qrCodeComponent from './components/qr-code.js';
 import formImageComponent from './components/form-image.js';
 import pollingComponent from './components/polling.js';
 import booleanComponent from './components/boolean.js';
+import metadataComponent from './components/metadata.js';
 
 const loggerFn = {
   error: () => {
@@ -286,6 +287,12 @@ const urlParams = new URLSearchParams(window.location.search);
           formEl, // You can ignore this; it's just for rendering
           collector, // This is the plain object of the collector
           davinciClient.pollStatus(collector), // Returns a poll function
+          davinciClient.update(collector), // Returns an update function for this collector
+          submitForm,
+        );
+      } else if (collector.type === 'MetadataCollector') {
+        metadataComponent(
+          formEl, // You can ignore this; it's just for rendering
           davinciClient.update(collector), // Returns an update function for this collector
           submitForm,
         );

--- a/e2e/davinci-app/server-configs.ts
+++ b/e2e/davinci-app/server-configs.ts
@@ -93,7 +93,7 @@ export const serverConfigs: Record<string, DaVinciConfig> = {
     },
   },
   /**
-   * Polling
+   * AutoCollectors: Polling, Metadata
    */
   '31a587ce-9aa4-4f36-a09f-78cd8a0a74a0': {
     clientId: '31a587ce-9aa4-4f36-a09f-78cd8a0a74a0',

--- a/e2e/davinci-suites/src/metadata.test.ts
+++ b/e2e/davinci-suites/src/metadata.test.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+import { expect, test } from '@playwright/test';
+import { asyncEvents } from './utils/async-events.js';
+
+test.describe('Metadata Collector', () => {
+  const clientId = '31a587ce-9aa4-4f36-a09f-78cd8a0a74a0';
+  const davinciPolicy = '7793be21a14dd80c1d26b367e81ea985';
+
+  test('should submit with success status when metadata collection succeeds', async ({ page }) => {
+    const { navigate } = asyncEvents(page);
+    await navigate(`/?clientId=${clientId}&acr_values=${davinciPolicy}`);
+
+    await page.getByRole('button', { name: 'Sign On' }).click();
+    await expect(page.getByRole('button', { name: 'Metadata Success' })).toBeVisible();
+
+    await page.getByRole('button', { name: 'Metadata Success' }).click();
+
+    await expect(page.getByRole('heading', { name: 'Message' })).toBeVisible();
+    await expect(page.getByText('"status":"succeeded"')).toBeVisible();
+  });
+
+  test('should submit with error details when metadata collection fails', async ({ page }) => {
+    const { navigate } = asyncEvents(page);
+    await navigate(`/?clientId=${clientId}&acr_values=${davinciPolicy}`);
+
+    await page.getByRole('button', { name: 'Sign On' }).click();
+    await expect(page.getByRole('button', { name: 'Metadata Error' })).toBeVisible();
+
+    await page.getByRole('button', { name: 'Metadata Error' }).click();
+
+    await expect(page.getByRole('heading', { name: 'Message' })).toBeVisible();
+    await expect(page.getByText('"code":"ERROR_CODE"')).toBeVisible();
+    await expect(page.getByText('"message":"Operation cancelled"')).toBeVisible();
+  });
+});

--- a/packages/davinci-client/api-report/davinci-client.api.md
+++ b/packages/davinci-client/api-report/davinci-client.api.md
@@ -140,7 +140,7 @@ export interface AutoCollector<C extends AutoCollectorCategories, T extends Auto
 export type AutoCollectorCategories = 'SingleValueAutoCollector' | 'ObjectValueAutoCollector';
 
 // @public (undocumented)
-export type AutoCollectors = ProtectCollector | FidoRegistrationCollector | FidoAuthenticationCollector | PollingCollector | SingleValueAutoCollector | ObjectValueAutoCollector;
+export type AutoCollectors = ProtectCollector | FidoRegistrationCollector | FidoAuthenticationCollector | MetadataCollector | PollingCollector | SingleValueAutoCollector | ObjectValueAutoCollector;
 
 // @public (undocumented)
 export type AutoCollectorTypes = SingleValueAutoCollectorTypes | ObjectValueAutoCollectorTypes;
@@ -173,7 +173,7 @@ export interface CollectorRichContent {
 }
 
 // @public (undocumented)
-export type Collectors = FlowCollector | PasswordCollector | ValidatedPasswordCollector | TextCollector | BooleanCollector | ValidatedBooleanCollector | SingleSelectCollector | IdpCollector | SubmitCollector | ActionCollector<'ActionCollector'> | SingleValueCollector<'SingleValueCollector'> | MultiSelectCollector | DeviceAuthenticationCollector | DeviceRegistrationCollector | PhoneNumberCollector | PhoneNumberExtensionCollector | ReadOnlyCollector | RichTextCollector | ValidatedTextCollector | ProtectCollector | PollingCollector | FidoRegistrationCollector | FidoAuthenticationCollector | QrCodeCollector | ImageCollector | UnknownCollector;
+export type Collectors = FlowCollector | MetadataCollector | PasswordCollector | ValidatedPasswordCollector | TextCollector | BooleanCollector | ValidatedBooleanCollector | SingleSelectCollector | IdpCollector | SubmitCollector | ActionCollector<'ActionCollector'> | SingleValueCollector<'SingleValueCollector'> | MultiSelectCollector | DeviceAuthenticationCollector | DeviceRegistrationCollector | PhoneNumberCollector | PhoneNumberExtensionCollector | ReadOnlyCollector | RichTextCollector | ValidatedTextCollector | ProtectCollector | PollingCollector | FidoRegistrationCollector | FidoAuthenticationCollector | QrCodeCollector | ImageCollector | UnknownCollector;
 
 // @public
 export type CollectorValueType<T> = T extends {
@@ -211,6 +211,8 @@ export type CollectorValueType<T> = T extends {
 } ? FidoRegistrationInputValue : T extends {
     type: 'FidoAuthenticationCollector';
 } ? FidoAuthenticationInputValue : T extends {
+    type: 'MetadataCollector';
+} ? Record<string, unknown> | MetadataError : T extends {
     category: 'SingleValueCollector';
 } ? string : T extends {
     category: 'ValidatedSingleValueCollector';
@@ -225,10 +227,10 @@ export type CollectorValueType<T> = T extends {
 } ? never : CollectorValueTypes;
 
 // @public
-export type CollectorValueTypes = string | string[] | boolean | PhoneNumberInputValue | PhoneNumberExtensionInputValue | FidoRegistrationInputValue | FidoAuthenticationInputValue;
+export type CollectorValueTypes = string | string[] | boolean | PhoneNumberInputValue | PhoneNumberExtensionInputValue | FidoRegistrationInputValue | FidoAuthenticationInputValue | MetadataError;
 
 // @public (undocumented)
-export type ComplexValueFields = DeviceAuthenticationField | DeviceRegistrationField | PhoneNumberField | PhoneNumberExtensionField | FidoRegistrationField | FidoAuthenticationField | PollingField;
+export type ComplexValueFields = DeviceAuthenticationField | DeviceRegistrationField | PhoneNumberField | PhoneNumberExtensionField | FidoRegistrationField | FidoAuthenticationField | PollingField | MetadataField;
 
 // @public (undocumented)
 export interface ContinueNode {
@@ -283,7 +285,7 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
     resume: (input: {
         continueToken: string;
     }) => Promise<InternalErrorResponse | NodeStates>;
-    start: <QueryParams extends OutgoingQueryParams = OutgoingQueryParams>(options?: StartOptions<QueryParams> | undefined) => Promise<ContinueNode | ErrorNode | FailureNode | StartNode | SuccessNode>;
+    start: <QueryParams extends OutgoingQueryParams = OutgoingQueryParams>(options?: StartOptions<QueryParams> | undefined) => Promise<ContinueNode | ErrorNode | StartNode | SuccessNode | FailureNode>;
     update: <T extends SingleValueCollectors | MultiSelectCollector | ObjectValueCollectors | AutoCollectors>(collector: T) => Updater<T>;
     validate: (collector: SingleValueCollectors | ObjectValueCollectors | MultiValueCollectors | AutoCollectors) => Validator;
     pollStatus: (collector: PollingCollector) => Poller;
@@ -294,26 +296,26 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         name?: string;
         status: "continue";
     } | {
+        status: "start";
+    } | {
         action: string;
         collectors: Collectors[];
         description?: string;
         name?: string;
         status: "error";
     } | {
-        status: "failure";
-    } | {
-        status: "start";
-    } | {
         authorization?: {
             code?: string;
             state?: string;
         };
         status: "success";
+    } | {
+        status: "failure";
     } | null;
     getCollectors: () => Collectors[];
     getError: () => DaVinciError | null;
     getErrorCollectors: () => CollectorErrors[];
-    getNode: () => ContinueNode | ErrorNode | FailureNode | StartNode | SuccessNode;
+    getNode: () => ContinueNode | ErrorNode | StartNode | SuccessNode | FailureNode;
     getServer: () => {
         _links?: Links;
         id?: string;
@@ -323,6 +325,8 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         eventName?: string;
         status: "continue";
     } | {
+        status: "start";
+    } | {
         _links?: Links;
         eventName?: string;
         id?: string;
@@ -332,22 +336,20 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
     } | {
         _links?: Links;
         eventName?: string;
-        href?: string;
-        id?: string;
-        interactionId?: string;
-        interactionToken?: string;
-        status: "failure";
-    } | {
-        status: "start";
-    } | {
-        _links?: Links;
-        eventName?: string;
         id?: string;
         interactionId?: string;
         interactionToken?: string;
         href?: string;
         session?: string;
         status: "success";
+    } | {
+        _links?: Links;
+        eventName?: string;
+        href?: string;
+        id?: string;
+        interactionId?: string;
+        interactionToken?: string;
+        status: "failure";
     } | null;
     cache: {
         getLatestResponse: () => ({
@@ -635,6 +637,9 @@ export interface DaVinciRequest {
         };
     };
 }
+
+// @public
+export type DaVinciRequestValueTypes = string | number | boolean | (string | number | boolean)[] | DeviceValue | PhoneNumberInputValue | FidoRegistrationInputValue | FidoAuthenticationInputValue | MetadataError;
 
 // @public (undocumented)
 export interface DaVinciSuccessResponse extends DaVinciBaseResponse {
@@ -968,7 +973,7 @@ export type ImageField = {
 export type InferActionCollectorType<T extends ActionCollectorTypes> = T extends 'IdpCollector' ? IdpCollector : T extends 'SubmitCollector' ? SubmitCollector : T extends 'FlowCollector' ? FlowCollector : ActionCollectorWithUrl<'ActionCollector'> | ActionCollectorNoUrl<'ActionCollector'>;
 
 // @public
-export type InferAutoCollectorType<T extends AutoCollectorTypes> = T extends 'ProtectCollector' ? ProtectCollector : T extends 'PollingCollector' ? PollingCollector : T extends 'FidoRegistrationCollector' ? FidoRegistrationCollector : T extends 'FidoAuthenticationCollector' ? FidoAuthenticationCollector : T extends 'ObjectValueAutoCollector' ? ObjectValueAutoCollector : SingleValueAutoCollector;
+export type InferAutoCollectorType<T extends AutoCollectorTypes> = T extends 'ProtectCollector' ? ProtectCollector : T extends 'PollingCollector' ? PollingCollector : T extends 'FidoRegistrationCollector' ? FidoRegistrationCollector : T extends 'FidoAuthenticationCollector' ? FidoAuthenticationCollector : T extends 'MetadataCollector' ? MetadataCollector : T extends 'ObjectValueAutoCollector' ? ObjectValueAutoCollector : SingleValueAutoCollector;
 
 // @public
 export type InferMultiValueCollectorType<T extends MultiValueCollectorTypes> = T extends 'MultiSelectCollector' ? MultiValueCollectorWithValue<'MultiSelectCollector'> : MultiValueCollectorWithValue<'MultiValueCollector'> | MultiValueCollectorNoValue<'MultiValueCollector'>;
@@ -1004,6 +1009,27 @@ export interface Links {
 }
 
 export { LogLevel }
+
+// @public (undocumented)
+export type MetadataCollector = AutoCollector<'ObjectValueAutoCollector', 'MetadataCollector', MetadataCollectorInputValue, Record<string, unknown>>;
+
+// @public (undocumented)
+export type MetadataCollectorInputValue = Record<string, unknown> | MetadataError;
+
+// @public
+export interface MetadataError {
+    // (undocumented)
+    code: string;
+    // (undocumented)
+    message: string;
+}
+
+// @public (undocumented)
+export type MetadataField = {
+    type: 'METADATA';
+    key: string;
+    payload: Record<string, unknown>;
+};
 
 // @public (undocumented)
 export type MultiSelectCollector = MultiValueCollectorWithValue<'MultiSelectCollector'>;
@@ -1222,7 +1248,7 @@ export interface ObjectOptionsCollectorWithStringValue<T extends ObjectValueColl
 export type ObjectValueAutoCollector = AutoCollector<'ObjectValueAutoCollector', 'ObjectValueAutoCollector', Record<string, unknown>>;
 
 // @public (undocumented)
-export type ObjectValueAutoCollectorTypes = 'ObjectValueAutoCollector' | 'FidoRegistrationCollector' | 'FidoAuthenticationCollector';
+export type ObjectValueAutoCollectorTypes = 'ObjectValueAutoCollector' | 'FidoRegistrationCollector' | 'FidoAuthenticationCollector' | 'MetadataCollector';
 
 // @public (undocumented)
 export type ObjectValueCollector<T extends ObjectValueCollectorTypes> = ObjectOptionsCollectorWithObjectValue<T> | ObjectOptionsCollectorWithStringValue<T> | ObjectValueCollectorWithObjectValue<T>;

--- a/packages/davinci-client/api-report/davinci-client.types.api.md
+++ b/packages/davinci-client/api-report/davinci-client.types.api.md
@@ -140,7 +140,7 @@ export interface AutoCollector<C extends AutoCollectorCategories, T extends Auto
 export type AutoCollectorCategories = 'SingleValueAutoCollector' | 'ObjectValueAutoCollector';
 
 // @public (undocumented)
-export type AutoCollectors = ProtectCollector | FidoRegistrationCollector | FidoAuthenticationCollector | PollingCollector | SingleValueAutoCollector | ObjectValueAutoCollector;
+export type AutoCollectors = ProtectCollector | FidoRegistrationCollector | FidoAuthenticationCollector | MetadataCollector | PollingCollector | SingleValueAutoCollector | ObjectValueAutoCollector;
 
 // @public (undocumented)
 export type AutoCollectorTypes = SingleValueAutoCollectorTypes | ObjectValueAutoCollectorTypes;
@@ -173,7 +173,7 @@ export interface CollectorRichContent {
 }
 
 // @public (undocumented)
-export type Collectors = FlowCollector | PasswordCollector | ValidatedPasswordCollector | TextCollector | BooleanCollector | ValidatedBooleanCollector | SingleSelectCollector | IdpCollector | SubmitCollector | ActionCollector<'ActionCollector'> | SingleValueCollector<'SingleValueCollector'> | MultiSelectCollector | DeviceAuthenticationCollector | DeviceRegistrationCollector | PhoneNumberCollector | PhoneNumberExtensionCollector | ReadOnlyCollector | RichTextCollector | ValidatedTextCollector | ProtectCollector | PollingCollector | FidoRegistrationCollector | FidoAuthenticationCollector | QrCodeCollector | ImageCollector | UnknownCollector;
+export type Collectors = FlowCollector | MetadataCollector | PasswordCollector | ValidatedPasswordCollector | TextCollector | BooleanCollector | ValidatedBooleanCollector | SingleSelectCollector | IdpCollector | SubmitCollector | ActionCollector<'ActionCollector'> | SingleValueCollector<'SingleValueCollector'> | MultiSelectCollector | DeviceAuthenticationCollector | DeviceRegistrationCollector | PhoneNumberCollector | PhoneNumberExtensionCollector | ReadOnlyCollector | RichTextCollector | ValidatedTextCollector | ProtectCollector | PollingCollector | FidoRegistrationCollector | FidoAuthenticationCollector | QrCodeCollector | ImageCollector | UnknownCollector;
 
 // @public
 export type CollectorValueType<T> = T extends {
@@ -211,6 +211,8 @@ export type CollectorValueType<T> = T extends {
 } ? FidoRegistrationInputValue : T extends {
     type: 'FidoAuthenticationCollector';
 } ? FidoAuthenticationInputValue : T extends {
+    type: 'MetadataCollector';
+} ? Record<string, unknown> | MetadataError : T extends {
     category: 'SingleValueCollector';
 } ? string : T extends {
     category: 'ValidatedSingleValueCollector';
@@ -225,10 +227,10 @@ export type CollectorValueType<T> = T extends {
 } ? never : CollectorValueTypes;
 
 // @public
-export type CollectorValueTypes = string | string[] | boolean | PhoneNumberInputValue | PhoneNumberExtensionInputValue | FidoRegistrationInputValue | FidoAuthenticationInputValue;
+export type CollectorValueTypes = string | string[] | boolean | PhoneNumberInputValue | PhoneNumberExtensionInputValue | FidoRegistrationInputValue | FidoAuthenticationInputValue | MetadataError;
 
 // @public (undocumented)
-export type ComplexValueFields = DeviceAuthenticationField | DeviceRegistrationField | PhoneNumberField | PhoneNumberExtensionField | FidoRegistrationField | FidoAuthenticationField | PollingField;
+export type ComplexValueFields = DeviceAuthenticationField | DeviceRegistrationField | PhoneNumberField | PhoneNumberExtensionField | FidoRegistrationField | FidoAuthenticationField | PollingField | MetadataField;
 
 // @public (undocumented)
 export interface ContinueNode {
@@ -283,7 +285,7 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
     resume: (input: {
         continueToken: string;
     }) => Promise<InternalErrorResponse | NodeStates>;
-    start: <QueryParams extends OutgoingQueryParams = OutgoingQueryParams>(options?: StartOptions<QueryParams> | undefined) => Promise<ContinueNode | ErrorNode | FailureNode | StartNode | SuccessNode>;
+    start: <QueryParams extends OutgoingQueryParams = OutgoingQueryParams>(options?: StartOptions<QueryParams> | undefined) => Promise<ContinueNode | ErrorNode | StartNode | SuccessNode | FailureNode>;
     update: <T extends SingleValueCollectors | MultiSelectCollector | ObjectValueCollectors | AutoCollectors>(collector: T) => Updater<T>;
     validate: (collector: SingleValueCollectors | ObjectValueCollectors | MultiValueCollectors | AutoCollectors) => Validator;
     pollStatus: (collector: PollingCollector) => Poller;
@@ -294,26 +296,26 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         name?: string;
         status: "continue";
     } | {
+        status: "start";
+    } | {
         action: string;
         collectors: Collectors[];
         description?: string;
         name?: string;
         status: "error";
     } | {
-        status: "failure";
-    } | {
-        status: "start";
-    } | {
         authorization?: {
             code?: string;
             state?: string;
         };
         status: "success";
+    } | {
+        status: "failure";
     } | null;
     getCollectors: () => Collectors[];
     getError: () => DaVinciError | null;
     getErrorCollectors: () => CollectorErrors[];
-    getNode: () => ContinueNode | ErrorNode | FailureNode | StartNode | SuccessNode;
+    getNode: () => ContinueNode | ErrorNode | StartNode | SuccessNode | FailureNode;
     getServer: () => {
         _links?: Links;
         id?: string;
@@ -323,6 +325,8 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         eventName?: string;
         status: "continue";
     } | {
+        status: "start";
+    } | {
         _links?: Links;
         eventName?: string;
         id?: string;
@@ -332,22 +336,20 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
     } | {
         _links?: Links;
         eventName?: string;
-        href?: string;
-        id?: string;
-        interactionId?: string;
-        interactionToken?: string;
-        status: "failure";
-    } | {
-        status: "start";
-    } | {
-        _links?: Links;
-        eventName?: string;
         id?: string;
         interactionId?: string;
         interactionToken?: string;
         href?: string;
         session?: string;
         status: "success";
+    } | {
+        _links?: Links;
+        eventName?: string;
+        href?: string;
+        id?: string;
+        interactionId?: string;
+        interactionToken?: string;
+        status: "failure";
     } | null;
     cache: {
         getLatestResponse: () => ({
@@ -635,6 +637,9 @@ export interface DaVinciRequest {
         };
     };
 }
+
+// @public
+export type DaVinciRequestValueTypes = string | number | boolean | (string | number | boolean)[] | DeviceValue | PhoneNumberInputValue | FidoRegistrationInputValue | FidoAuthenticationInputValue | MetadataError;
 
 // @public (undocumented)
 export interface DaVinciSuccessResponse extends DaVinciBaseResponse {
@@ -965,7 +970,7 @@ export type ImageField = {
 export type InferActionCollectorType<T extends ActionCollectorTypes> = T extends 'IdpCollector' ? IdpCollector : T extends 'SubmitCollector' ? SubmitCollector : T extends 'FlowCollector' ? FlowCollector : ActionCollectorWithUrl<'ActionCollector'> | ActionCollectorNoUrl<'ActionCollector'>;
 
 // @public
-export type InferAutoCollectorType<T extends AutoCollectorTypes> = T extends 'ProtectCollector' ? ProtectCollector : T extends 'PollingCollector' ? PollingCollector : T extends 'FidoRegistrationCollector' ? FidoRegistrationCollector : T extends 'FidoAuthenticationCollector' ? FidoAuthenticationCollector : T extends 'ObjectValueAutoCollector' ? ObjectValueAutoCollector : SingleValueAutoCollector;
+export type InferAutoCollectorType<T extends AutoCollectorTypes> = T extends 'ProtectCollector' ? ProtectCollector : T extends 'PollingCollector' ? PollingCollector : T extends 'FidoRegistrationCollector' ? FidoRegistrationCollector : T extends 'FidoAuthenticationCollector' ? FidoAuthenticationCollector : T extends 'MetadataCollector' ? MetadataCollector : T extends 'ObjectValueAutoCollector' ? ObjectValueAutoCollector : SingleValueAutoCollector;
 
 // @public
 export type InferMultiValueCollectorType<T extends MultiValueCollectorTypes> = T extends 'MultiSelectCollector' ? MultiValueCollectorWithValue<'MultiSelectCollector'> : MultiValueCollectorWithValue<'MultiValueCollector'> | MultiValueCollectorNoValue<'MultiValueCollector'>;
@@ -1001,6 +1006,27 @@ export interface Links {
 }
 
 export { LogLevel }
+
+// @public (undocumented)
+export type MetadataCollector = AutoCollector<'ObjectValueAutoCollector', 'MetadataCollector', MetadataCollectorInputValue, Record<string, unknown>>;
+
+// @public (undocumented)
+export type MetadataCollectorInputValue = Record<string, unknown> | MetadataError;
+
+// @public
+export interface MetadataError {
+    // (undocumented)
+    code: string;
+    // (undocumented)
+    message: string;
+}
+
+// @public (undocumented)
+export type MetadataField = {
+    type: 'METADATA';
+    key: string;
+    payload: Record<string, unknown>;
+};
 
 // @public (undocumented)
 export type MultiSelectCollector = MultiValueCollectorWithValue<'MultiSelectCollector'>;
@@ -1219,7 +1245,7 @@ export interface ObjectOptionsCollectorWithStringValue<T extends ObjectValueColl
 export type ObjectValueAutoCollector = AutoCollector<'ObjectValueAutoCollector', 'ObjectValueAutoCollector', Record<string, unknown>>;
 
 // @public (undocumented)
-export type ObjectValueAutoCollectorTypes = 'ObjectValueAutoCollector' | 'FidoRegistrationCollector' | 'FidoAuthenticationCollector';
+export type ObjectValueAutoCollectorTypes = 'ObjectValueAutoCollector' | 'FidoRegistrationCollector' | 'FidoAuthenticationCollector' | 'MetadataCollector';
 
 // @public (undocumented)
 export type ObjectValueCollector<T extends ObjectValueCollectorTypes> = ObjectOptionsCollectorWithObjectValue<T> | ObjectOptionsCollectorWithStringValue<T> | ObjectValueCollectorWithObjectValue<T>;

--- a/packages/davinci-client/src/lib/client.types.ts
+++ b/packages/davinci-client/src/lib/client.types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -17,6 +17,7 @@ import type {
   ValidatedTextCollector,
   ValidatedBooleanCollector,
   ValidatedPasswordCollector,
+  MetadataError,
 } from './collector.types.js';
 import type { ErrorNode, FailureNode, ContinueNode, StartNode, SuccessNode } from './node.types.js';
 
@@ -39,7 +40,8 @@ export type CollectorValueTypes =
   | PhoneNumberInputValue
   | PhoneNumberExtensionInputValue
   | FidoRegistrationInputValue
-  | FidoAuthenticationInputValue;
+  | FidoAuthenticationInputValue
+  | MetadataError;
 
 /**
  * Maps collector types to the specific value type they accept.
@@ -84,21 +86,23 @@ export type CollectorValueType<T> =
                   ? FidoRegistrationInputValue
                   : T extends { type: 'FidoAuthenticationCollector' }
                     ? FidoAuthenticationInputValue
-                    : // category catch-alls
-                      // fallbacks for collectors that don't match on `type`
-                      T extends { category: 'SingleValueCollector' }
-                      ? string
-                      : T extends { category: 'ValidatedSingleValueCollector' }
+                    : T extends { type: 'MetadataCollector' }
+                      ? Record<string, unknown> | MetadataError
+                      : // category catch-alls
+                        // fallbacks for collectors that don't match on `type`
+                        T extends { category: 'SingleValueCollector' }
                         ? string
-                        : T extends { category: 'SingleValueAutoCollector' }
+                        : T extends { category: 'ValidatedSingleValueCollector' }
                           ? string
-                          : T extends { category: 'MultiValueCollector' }
-                            ? string[]
-                            : T extends { category: 'ActionCollector' }
-                              ? never
-                              : T extends { category: 'NoValueCollector' }
+                          : T extends { category: 'SingleValueAutoCollector' }
+                            ? string
+                            : T extends { category: 'MultiValueCollector' }
+                              ? string[]
+                              : T extends { category: 'ActionCollector' }
                                 ? never
-                                : CollectorValueTypes;
+                                : T extends { category: 'NoValueCollector' }
+                                  ? never
+                                  : CollectorValueTypes;
 
 /**
  * A function type that updates a collector's value. Accepts values appropriate for the collector type.

--- a/packages/davinci-client/src/lib/collector.types.ts
+++ b/packages/davinci-client/src/lib/collector.types.ts
@@ -767,6 +767,19 @@ export interface FidoRegistrationOutputValue {
   trigger: string;
 }
 
+/**
+ * A structured error to return to DaVinci if the application fails to respond successfully to a MetadataCollector
+ *
+ * @property code - Error code
+ * @property message - Error description
+ */
+export interface MetadataError {
+  code: string;
+  message: string;
+}
+
+export type MetadataCollectorInputValue = Record<string, unknown> | MetadataError;
+
 export interface AssertionValue extends Omit<
   PublicKeyCredential,
   'rawId' | 'response' | 'getClientExtensionResults' | 'toJSON'
@@ -806,7 +819,8 @@ export type SingleValueAutoCollectorTypes =
 export type ObjectValueAutoCollectorTypes =
   | 'ObjectValueAutoCollector'
   | 'FidoRegistrationCollector'
-  | 'FidoAuthenticationCollector';
+  | 'FidoAuthenticationCollector'
+  | 'MetadataCollector';
 export type AutoCollectorTypes = SingleValueAutoCollectorTypes | ObjectValueAutoCollectorTypes;
 
 export interface AutoCollector<
@@ -851,6 +865,12 @@ export type FidoAuthenticationCollector = AutoCollector<
   FidoAuthenticationInputValue,
   FidoAuthenticationOutputValue
 >;
+export type MetadataCollector = AutoCollector<
+  'ObjectValueAutoCollector',
+  'MetadataCollector',
+  MetadataCollectorInputValue,
+  Record<string, unknown>
+>;
 export type PollingCollector = AutoCollector<
   'SingleValueAutoCollector',
   'PollingCollector',
@@ -872,6 +892,7 @@ export type AutoCollectors =
   | ProtectCollector
   | FidoRegistrationCollector
   | FidoAuthenticationCollector
+  | MetadataCollector
   | PollingCollector
   | SingleValueAutoCollector
   | ObjectValueAutoCollector;
@@ -891,10 +912,12 @@ export type InferAutoCollectorType<T extends AutoCollectorTypes> = T extends 'Pr
       ? FidoRegistrationCollector
       : T extends 'FidoAuthenticationCollector'
         ? FidoAuthenticationCollector
-        : T extends 'ObjectValueAutoCollector'
-          ? ObjectValueAutoCollector
-          : /**
-             * At this point, we have not passed in a collector type
-             * so we can return a SingleValueAutoCollector
-             **/
-            SingleValueAutoCollector;
+        : T extends 'MetadataCollector'
+          ? MetadataCollector
+          : T extends 'ObjectValueAutoCollector'
+            ? ObjectValueAutoCollector
+            : /**
+               * At this point, we have not passed in a collector type
+               * so we can return a SingleValueAutoCollector
+               **/
+              SingleValueAutoCollector;

--- a/packages/davinci-client/src/lib/collector.utils.test.ts
+++ b/packages/davinci-client/src/lib/collector.utils.test.ts
@@ -21,6 +21,7 @@ import {
   returnNoValueCollector,
   returnObjectSelectCollector,
   returnObjectValueCollector,
+  returnMetadataCollector,
   returnSingleValueAutoCollector,
   returnObjectValueAutoCollector,
   returnImageCollector,
@@ -35,6 +36,7 @@ import type {
   DeviceAuthenticationField,
   DeviceRegistrationField,
   ImageField,
+  MetadataField,
   PasswordField,
   FidoAuthenticationField,
   FidoRegistrationField,
@@ -2108,5 +2110,41 @@ describe('returnBooleanCollector', () => {
     };
     const result = returnBooleanCollector(field, 0);
     expect(result.output).not.toHaveProperty('richContent');
+  });
+});
+
+describe('returnMetadataCollector', () => {
+  const mockField: MetadataField = {
+    type: 'METADATA',
+    key: 'metadata-key',
+    payload: {
+      sessionToken: 'abc123',
+      userId: 'user-456',
+    },
+  };
+
+  it('should create a valid MetadataCollector with payload in output', () => {
+    const result = returnMetadataCollector(mockField, 0);
+    expect(result).toEqual({
+      category: 'ObjectValueAutoCollector',
+      error: null,
+      type: 'MetadataCollector',
+      id: 'metadata-key-0',
+      name: 'metadata-key',
+      input: {
+        key: 'metadata-key',
+        value: {},
+        type: 'METADATA',
+        validation: null,
+      },
+      output: {
+        key: 'metadata-key',
+        type: 'METADATA',
+        config: {
+          sessionToken: 'abc123',
+          userId: 'user-456',
+        },
+      },
+    });
   });
 });

--- a/packages/davinci-client/src/lib/collector.utils.ts
+++ b/packages/davinci-client/src/lib/collector.utils.ts
@@ -47,6 +47,7 @@ import type {
   FidoAuthenticationField,
   FidoRegistrationField,
   ImageField,
+  MetadataField,
   MultiSelectField,
   PasswordField,
   PhoneNumberField,
@@ -497,7 +498,7 @@ export function returnSingleValueAutoCollector<
  * @returns {AutoCollector} The constructed AutoCollector object.
  */
 export function returnObjectValueAutoCollector<
-  Field extends FidoRegistrationField | FidoAuthenticationField,
+  Field extends FidoRegistrationField | FidoAuthenticationField | MetadataField,
   CollectorType extends ObjectValueAutoCollectorTypes = 'ObjectValueAutoCollector',
 >(field: Field, idx: number, collectorType: CollectorType) {
   let error = '';
@@ -517,7 +518,26 @@ export function returnObjectValueAutoCollector<
     });
   }
 
-  if (field.action === 'REGISTER') {
+  if (field.type === 'METADATA') {
+    return {
+      category: 'ObjectValueAutoCollector',
+      error: error || null,
+      type: collectorType,
+      id: `${field.key}-${idx}`,
+      name: field.key,
+      input: {
+        key: field.key,
+        value: {},
+        type: field.type,
+        validation: validationArray.length ? validationArray : null,
+      },
+      output: {
+        key: field.key,
+        type: field.type,
+        config: field.payload,
+      },
+    } as InferAutoCollectorType<'MetadataCollector'>;
+  } else if (field.action === 'REGISTER') {
     return {
       category: 'ObjectValueAutoCollector',
       error: error || null,
@@ -789,6 +809,8 @@ export function returnObjectCollector<
     });
   }
 
+  const label = 'label' in field ? field.label : '';
+
   let options;
   let defaultValue;
   let extensionLabel: string | null = null;
@@ -884,7 +906,7 @@ export function returnObjectCollector<
     },
     output: {
       key: field.key,
-      label: field.label,
+      label: label,
       type: field.type,
       ...(options && { options: options || [] }),
       ...(extensionLabel !== null && { extensionLabel }),
@@ -910,6 +932,16 @@ export function returnObjectSelectCollector(
       ? 'DeviceAuthenticationCollector'
       : 'DeviceRegistrationCollector',
   );
+}
+
+/**
+ * @function returnMetadataCollector - Creates a MetadataCollector from a METADATA field.
+ * @param {MetadataField} field - The METADATA field from the API response.
+ * @param {number} idx - The index used in the collector id/name.
+ * @returns {MetadataCollector} The constructed MetadataCollector.
+ */
+export function returnMetadataCollector(field: MetadataField, idx: number) {
+  return returnObjectValueAutoCollector(field, idx, 'MetadataCollector');
 }
 
 export function returnObjectValueCollector(

--- a/packages/davinci-client/src/lib/davinci.api.ts
+++ b/packages/davinci-client/src/lib/davinci.api.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -168,7 +168,12 @@ export const davinciApi = createApi({
         }
 
         if (!body) {
-          requestBody = transformSubmitRequest(state.node, logger);
+          const hasMetadataCollector = state.node.client?.collectors?.some(
+            (collector) => collector.type === 'MetadataCollector',
+          );
+          requestBody = hasMetadataCollector
+            ? transformActionRequest(state.node, state.node.client?.action, logger)
+            : transformSubmitRequest(state.node, logger);
         } else {
           requestBody = body;
         }

--- a/packages/davinci-client/src/lib/davinci.types.ts
+++ b/packages/davinci-client/src/lib/davinci.types.ts
@@ -13,6 +13,13 @@ import type {
   FetchBaseQueryMeta,
   MutationResultSelectorResult,
 } from '@reduxjs/toolkit/query';
+import {
+  DeviceValue,
+  PhoneNumberInputValue,
+  FidoRegistrationInputValue,
+  FidoAuthenticationInputValue,
+  MetadataError,
+} from './collector.types.js';
 
 export interface DaVinciRequest {
   id: string;
@@ -26,6 +33,20 @@ export interface DaVinciRequest {
     };
   };
 }
+
+/**
+ * Allowed value types for DaVinci formData request bodies. This differs from `CollectorValueTypes` because input values may be transformed for DaVinci.
+ */
+export type DaVinciRequestValueTypes =
+  | string
+  | number
+  | boolean
+  | (string | number | boolean)[]
+  | DeviceValue
+  | PhoneNumberInputValue
+  | FidoRegistrationInputValue
+  | FidoAuthenticationInputValue
+  | MetadataError;
 
 /**
  * Base Response for DaVinci API
@@ -327,6 +348,12 @@ export type PollingField = {
   challenge?: string;
 };
 
+export type MetadataField = {
+  type: 'METADATA';
+  key: string;
+  payload: Record<string, unknown>;
+};
+
 export type UnknownField = Record<string, unknown>;
 
 export type ComplexValueFields =
@@ -336,7 +363,8 @@ export type ComplexValueFields =
   | PhoneNumberExtensionField
   | FidoRegistrationField
   | FidoAuthenticationField
-  | PollingField;
+  | PollingField
+  | MetadataField;
 export type MultiValueFields = MultiSelectField;
 export type ReadOnlyFields = ReadOnlyField | QrCodeField | AgreementField | ImageField;
 export type RedirectFields = RedirectField;

--- a/packages/davinci-client/src/lib/davinci.utils.ts
+++ b/packages/davinci-client/src/lib/davinci.utils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -22,12 +22,8 @@ import type {
   DaVinciSuccessResponse,
 } from './davinci.types.js';
 import type { ContinueNode } from './node.types.js';
-import {
-  DeviceValue,
-  FidoAuthenticationInputValue,
-  FidoRegistrationInputValue,
-  PhoneNumberInputValue,
-} from './collector.types.js';
+import { DaVinciRequestValueTypes } from './davinci.types.js';
+
 /**
  * @function transformSubmitRequest - Transforms a NextNode into a DaVinciRequest for form submissions
  * @param {ContinueNode} node - The node to transform into a DaVinciRequest
@@ -50,15 +46,7 @@ export function transformSubmitRequest(
   );
 
   const formData = collectors?.reduce<{
-    [key: string]:
-      | string
-      | number
-      | boolean
-      | (string | number | boolean)[]
-      | DeviceValue
-      | PhoneNumberInputValue
-      | FidoRegistrationInputValue
-      | FidoAuthenticationInputValue;
+    [key: string]: DaVinciRequestValueTypes;
   }>((acc, collector) => {
     acc[collector.input.key] = collector.input.value;
     return acc;
@@ -100,7 +88,26 @@ export function transformActionRequest(
   action: string,
   logger: ReturnType<typeof loggerFn>,
 ): DaVinciRequest {
+  // Filter out ActionCollectors as they do not collect values
+  const collectors = node.client?.collectors?.filter(
+    (collector) =>
+      collector.category === 'MultiValueCollector' ||
+      collector.category === 'SingleValueCollector' ||
+      collector.category === 'ValidatedSingleValueCollector' ||
+      collector.category === 'ObjectValueCollector' ||
+      collector.category === 'SingleValueAutoCollector' ||
+      collector.category === 'ObjectValueAutoCollector',
+  );
+
+  const formData = collectors?.reduce<{
+    [key: string]: DaVinciRequestValueTypes | Record<string, unknown>;
+  }>((acc, collector) => {
+    acc[collector.input.key] = collector.input.value;
+    return acc;
+  }, {});
+
   logger.debug('Transforming action request', { node, action });
+
   return {
     id: node.server.id || '',
     eventName: node.server.eventName || '',
@@ -108,7 +115,8 @@ export function transformActionRequest(
     parameters: {
       eventType: 'action',
       data: {
-        actionKey: action,
+        actionKey: action || node.client?.action || '',
+        ...(Object.keys(formData ?? {}).length && { formData: formData }),
       },
     },
   };

--- a/packages/davinci-client/src/lib/node.reducer.test.ts
+++ b/packages/davinci-client/src/lib/node.reducer.test.ts
@@ -12,6 +12,7 @@ import type {
   DeviceRegistrationCollector,
   FidoAuthenticationCollector,
   FidoRegistrationCollector,
+  MetadataCollector,
   MultiSelectCollector,
   PasswordCollector,
   ValidatedPasswordCollector,
@@ -2179,5 +2180,88 @@ describe('The node collector reducer with FidoAuthenticationFieldValue', () => {
         },
       },
     ]);
+  });
+});
+
+describe('The node collector reducer with MetadataField', () => {
+  it('should create a MetadataCollector from a METADATA field', () => {
+    const action = {
+      type: 'node/next',
+      payload: {
+        fields: [
+          {
+            type: 'METADATA',
+            key: 'metadata-key',
+            payload: { sessionToken: 'abc123' },
+          },
+        ],
+        formData: {},
+      },
+    };
+
+    const result = nodeCollectorReducer(undefined, action);
+    expect(result[0]).toEqual({
+      category: 'ObjectValueAutoCollector',
+      error: null,
+      type: 'MetadataCollector',
+      id: 'metadata-key-0',
+      name: 'metadata-key',
+      input: {
+        key: 'metadata-key',
+        value: {},
+        type: 'METADATA',
+        validation: null,
+      },
+      output: {
+        key: 'metadata-key',
+        type: 'METADATA',
+        config: { sessionToken: 'abc123' },
+      },
+    } satisfies MetadataCollector);
+  });
+
+  it('should update a MetadataCollector input value', () => {
+    const state: MetadataCollector[] = [
+      {
+        category: 'ObjectValueAutoCollector',
+        error: null,
+        type: 'MetadataCollector',
+        id: 'metadata-key-0',
+        name: 'metadata-key',
+        input: { key: 'metadata-key', value: {}, type: 'METADATA', validation: null },
+        output: {
+          key: 'metadata-key',
+          type: 'METADATA',
+          config: { sessionToken: 'abc123' },
+        },
+      },
+    ];
+
+    const action = {
+      type: 'node/update',
+      payload: { id: 'metadata-key-0', value: { result: 'ok' } },
+    };
+    const result = nodeCollectorReducer(state, action);
+    expect((result[0] as MetadataCollector).input.value).toEqual({ result: 'ok' });
+  });
+
+  it('should throw when updating a MetadataCollector with a non-object value', () => {
+    const state: MetadataCollector[] = [
+      {
+        category: 'ObjectValueAutoCollector',
+        error: null,
+        type: 'MetadataCollector',
+        id: 'metadata-key-0',
+        name: 'metadata-key',
+        input: { key: 'metadata-key', value: {}, type: 'METADATA', validation: null },
+        output: { key: 'metadata-key', type: 'METADATA', config: {} },
+      },
+    ];
+
+    const action = {
+      type: 'node/update',
+      payload: { id: 'metadata-key-0', value: 'not-an-object' },
+    };
+    expect(() => nodeCollectorReducer(state, action)).toThrow('Value argument must be an object');
   });
 });

--- a/packages/davinci-client/src/lib/node.reducer.ts
+++ b/packages/davinci-client/src/lib/node.reducer.ts
@@ -15,6 +15,7 @@ import { createAction, createReducer } from '@reduxjs/toolkit';
 import {
   returnActionCollector,
   returnFlowCollector,
+  returnMetadataCollector,
   returnPasswordCollector,
   returnValidatedPasswordCollector,
   returnIdpCollector,
@@ -169,6 +170,9 @@ export const nodeCollectorReducer = createReducer(initialCollectorValues, (build
                 }
                 break;
               }
+              case 'METADATA': {
+                return returnMetadataCollector(field, idx);
+              }
               default:
               // Default is handled below
             }
@@ -200,6 +204,7 @@ export const nodeCollectorReducer = createReducer(initialCollectorValues, (build
       if (collector.category === 'NoValueCollector') {
         throw new Error('NoValueCollectors, like ReadOnlyCollectors, are read-only');
       }
+
       if (action.payload.value === undefined) {
         throw new Error('Value argument cannot be undefined');
       }
@@ -332,6 +337,17 @@ export const nodeCollectorReducer = createReducer(initialCollectorValues, (build
           throw new Error('Value argument must contain an assertionValue property');
         }
         collector.input.value = action.payload.value;
+      }
+
+      if (collector.type === 'MetadataCollector') {
+        if (
+          typeof action.payload.value !== 'object' ||
+          action.payload.value === null ||
+          Array.isArray(action.payload.value)
+        ) {
+          throw new Error('Value argument must be an object');
+        }
+        collector.input.value = action.payload.value as Record<string, unknown>;
       }
     })
     /**

--- a/packages/davinci-client/src/lib/node.slice.ts
+++ b/packages/davinci-client/src/lib/node.slice.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -20,7 +20,7 @@ import { getCollectorErrors } from './node.utils.js';
  */
 import type { Draft, PayloadAction } from '@reduxjs/toolkit';
 
-import type { SubmitCollector } from './collector.types.js';
+import type { MetadataCollector, SubmitCollector } from './collector.types.js';
 import type {
   DavinciErrorResponse,
   DaVinciFailureResponse,
@@ -192,12 +192,16 @@ export const nodeSlice = createSlice({
         (collector): collector is SubmitCollector => collector.type === 'SubmitCollector',
       )[0];
 
+      const metadataCollector = collectors.filter(
+        (collector): collector is MetadataCollector => collector.type === 'MetadataCollector',
+      )[0];
+
       newState.cache = {
         key: action.payload.requestId,
       };
 
       newState.client = {
-        action: submitCollector?.output.key,
+        action: submitCollector?.output.key || metadataCollector?.output.key,
         description: action.payload.data?.form?.description,
         collectors,
         name: action.payload.data.form?.name,

--- a/packages/davinci-client/src/lib/node.types.test-d.ts
+++ b/packages/davinci-client/src/lib/node.types.test-d.ts
@@ -19,6 +19,7 @@ import type { ErrorDetail, Links } from './davinci.types.js';
 import type {
   ActionCollector,
   FlowCollector,
+  MetadataCollector,
   MultiSelectCollector,
   PasswordCollector,
   ValidatedPasswordCollector,
@@ -228,6 +229,7 @@ describe('Node Types', () => {
     it('should validate Collectors union type', () => {
       expectTypeOf<Collectors>().toMatchTypeOf<
         | TextCollector
+        | MetadataCollector
         | PasswordCollector
         | ValidatedPasswordCollector
         | FlowCollector

--- a/packages/davinci-client/src/lib/node.types.ts
+++ b/packages/davinci-client/src/lib/node.types.ts
@@ -8,6 +8,7 @@ import { GenericError } from '@forgerock/sdk-types';
 
 import type {
   FlowCollector,
+  MetadataCollector,
   PasswordCollector,
   ValidatedPasswordCollector,
   TextCollector,
@@ -38,6 +39,7 @@ import type { Links } from './davinci.types.js';
 
 export type Collectors =
   | FlowCollector
+  | MetadataCollector
   | PasswordCollector
   | ValidatedPasswordCollector
   | TextCollector

--- a/packages/davinci-client/src/types.ts
+++ b/packages/davinci-client/src/types.ts
@@ -1,4 +1,4 @@
-/* Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+/* Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.


### PR DESCRIPTION
# JIRA Ticket

https://pingidentity.atlassian.net/browse/SDKS-5100

## Description

## What
Adds `MetadataCollector` support to `davinci-client`, enabling DaVinci flows to deliver server-side metadata payloads (e.g. session tokens, user context) to client applications. The collector carries its payload in `output.value` and reports success or structured errors back to the server via `transformActionRequest`.

## Why
DaVinci flows need a mechanism to push arbitrary metadata to the client and receive a status (success or error) in return, without relying on a standard form submission. This fills that gap in the collector model.

## Changes
- **New types**: `MetadataCollector`, `MetadataError`, `MetadataField`, and `DaVinciRequestValueTypes` (extracted from inline union in `davinci.utils.ts`)
- **`collector.types.ts` / `collector.utils.ts`**: Added `MetadataCollector` type alias and `returnMetadataCollector` factory; updated `returnObjectCollector` to handle the label-less `METADATA` field shape
- **`node.reducer.ts`**: Added `METADATA` case to build a `MetadataCollector` from a field; added object-type guard for MetadataCollector update values
- **`node.slice.ts`**: Falls back to `metadataCollector.output.key` for `client.action` when no `SubmitCollector` is present
- **`davinci.api.ts`**: Auto-routes to `transformActionRequest` when a `MetadataCollector` is in the collector list
- **`davinci.utils.ts`**: `transformActionRequest` now collects form data from all value-bearing collectors and includes it in the request body alongside `actionKey`
- **`client.store.ts`**: Exposes `getMetadataError` helper on the client facade for constructing structured error objects
- **Tests**: Unit tests for `returnMetadataCollector` and reducer MetadataField handling (create, update, invalid update)
- **E2e app**: Added `metadataComponent` demonstrating success and error paths; wired into `main.ts`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added metadata collection support for capturing structured values during journeys.
  * Added standardized metadata error handling with code and message details.
  * Added public metadata types and utility exports.
  * Metadata submissions now support both success and error outcomes.

* **Bug Fixes**
  * Improved request handling and state transitions for metadata collection.

* **Tests**
  * Added end-to-end coverage for successful and failed metadata flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->