### PR TITLE
feat(davinci-client): send FIDO errors to DaVinci (SDKS-4480)

### DIFF
--- a/.changeset/thirty-badgers-lick.md
+++ b/.changeset/thirty-badgers-lick.md
@@ -1,0 +1,5 @@
+---
+'@forgerock/davinci-client': minor
+---
+
+Catch FIDO/WebAuthn DOMExeceptions and send them to DaVinci

--- a/.changeset/thirty-badgers-lick.md
+++ b/.changeset/thirty-badgers-lick.md
@@ -2,4 +2,4 @@
 '@forgerock/davinci-client': minor
 ---
 
-Catch FIDO/WebAuthn DOMExeceptions and send them to DaVinci
+Catch FIDO/WebAuthn DOMExceptions and send them to DaVinci

--- a/e2e/davinci-app/components/fido.ts
+++ b/e2e/davinci-app/components/fido.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -32,13 +32,13 @@ export default function fidoComponent(
       console.log('fido.register response:', response);
       if ('error' in response) {
         console.error(response);
+      }
+
+      const error = updater(response);
+      if (error && 'error' in error) {
+        console.error(error.error.message);
       } else {
-        const error = updater(response);
-        if (error && 'error' in error) {
-          console.error(error.error.message);
-        } else {
-          await submitForm();
-        }
+        await submitForm();
       }
     };
   } else if (collector.type === 'FidoAuthenticationCollector') {
@@ -54,13 +54,13 @@ export default function fidoComponent(
       console.log('fido.authenticate response:', response);
       if ('error' in response) {
         console.error(response);
+      }
+
+      const error = updater(response);
+      if (error && 'error' in error) {
+        console.error(error.error.message);
       } else {
-        const error = updater(response);
-        if (error && 'error' in error) {
-          console.error(error.error.message);
-        } else {
-          await submitForm();
-        }
+        await submitForm();
       }
     };
   }

--- a/e2e/davinci-app/server-configs.ts
+++ b/e2e/davinci-app/server-configs.ts
@@ -60,6 +60,7 @@ export const serverConfigs: Record<string, DaVinciConfig> = {
   },
   /**
    * Form Fields
+   * ValidatedPasswordCollector / Password Policy
    */
   'e4ef2896-8d90-4abd-bf0f-7b8034995927': {
     clientId: 'e4ef2896-8d90-4abd-bf0f-7b8034995927',
@@ -93,29 +94,10 @@ export const serverConfigs: Record<string, DaVinciConfig> = {
     },
   },
   /**
-   * AutoCollectors: Polling, Metadata
+   * AutoCollectors: Polling, Metadata, FIDO
    */
   '31a587ce-9aa4-4f36-a09f-78cd8a0a74a0': {
     clientId: '31a587ce-9aa4-4f36-a09f-78cd8a0a74a0',
-    redirectUri: window.location.origin + '/',
-    scope: 'openid profile email revoke',
-    serverConfig: {
-      wellknown:
-        'https://auth.pingone.ca/356a254c-cba3-4ade-be1a-860136e8df01/as/.well-known/openid-configuration',
-    },
-  },
-  /**
-   * ValidatedPasswordCollector / Password Policy
-   * Flow: Andy - MFA Device Registration/Authentication (PingOne Forms)
-   * Policy ID (acr_values): 769eecb92f8e66f88005a85e8b939a01
-   * Environment: 356a254c-cba3-4ade-be1a-860136e8df01
-   *
-   * New client created 2026-05-28 with:
-   * - http://localhost:5829 in Redirect URIs
-   * - http://localhost:5829 in CORS Allowed Origins
-   */
-  'fb456db5-2e08-46d3-adf0-05bf8d26ad60': {
-    clientId: 'fb456db5-2e08-46d3-adf0-05bf8d26ad60',
     redirectUri: window.location.origin + '/',
     scope: 'openid profile email revoke',
     serverConfig: {

--- a/e2e/davinci-suites/src/fido.test.ts
+++ b/e2e/davinci-suites/src/fido.test.ts
@@ -1,37 +1,53 @@
+/*
+ * Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
 import { test, expect, CDPSession } from '@playwright/test';
 import { asyncEvents } from './utils/async-events.js';
 
 const username = 'JSFidoUser@user.com';
 const password = 'FakePassword#123';
-let cdp: CDPSession | undefined;
-let authenticatorId: string | undefined;
 
 test.use({ browserName: 'chromium' }); // ensure CDP/WebAuthn is available
+test.describe.configure({ mode: 'serial' });
 
-test.beforeEach(async ({ context, page }) => {
-  cdp = await context.newCDPSession(page);
-  await cdp.send('WebAuthn.enable');
+test.describe('FIDO/WebAuthn Success Tests', () => {
+  let cdp: CDPSession | undefined;
+  let authenticatorId: string | undefined;
 
-  // A "platform" authenticator (aka internal) with UV+RK enabled is the usual default for passkeys.
-  const response = await cdp.send('WebAuthn.addVirtualAuthenticator', {
-    options: {
-      protocol: 'ctap2',
-      transport: 'internal', // platform authenticator
-      hasResidentKey: true, // allow discoverable credentials (passkeys)
-      hasUserVerification: true, // device supports UV
-      isUserVerified: true, // simulate successful UV (PIN/biometric)
-      automaticPresenceSimulation: true, // auto "touch"/presence
-    },
+  test.beforeEach(async ({ context, page }) => {
+    if (authenticatorId) {
+      await cdp?.send('WebAuthn.removeVirtualAuthenticator', { authenticatorId });
+      authenticatorId = undefined;
+    }
+
+    cdp = await context.newCDPSession(page);
+    await expect(cdp).toBeDefined();
+    await cdp.send('WebAuthn.enable');
+
+    // A "platform" authenticator (aka internal) with UV+RK enabled is the usual default for passkeys.
+    const response = await cdp.send('WebAuthn.addVirtualAuthenticator', {
+      options: {
+        protocol: 'ctap2',
+        transport: 'internal', // platform authenticator
+        hasResidentKey: true, // allow discoverable credentials (passkeys)
+        hasUserVerification: true, // device supports UV
+        isUserVerified: true, // simulate successful UV (PIN/biometric)
+        automaticPresenceSimulation: true, // auto "touch"/presence
+      },
+    });
+    authenticatorId = response.authenticatorId;
   });
-  authenticatorId = response.authenticatorId;
-});
 
-test.afterEach(async () => {
-  await cdp.send('WebAuthn.removeVirtualAuthenticator', { authenticatorId });
-  await cdp.send('WebAuthn.disable');
-});
-
-test.describe('FIDO/WebAuthn Tests', () => {
+  test.afterEach(async () => {
+    if (authenticatorId) {
+      await cdp?.send('WebAuthn.removeVirtualAuthenticator', { authenticatorId });
+      authenticatorId = undefined;
+    }
+    await cdp?.send('WebAuthn.disable');
+  });
   test('Register and authenticate with webauthn device', async ({ page }) => {
     const { navigate } = asyncEvents(page);
 
@@ -47,6 +63,10 @@ test.describe('FIDO/WebAuthn Tests', () => {
     await page.getByLabel('Username').fill(username);
     await page.getByLabel('Password').fill(password);
     await page.getByRole('button', { name: 'Sign On' }).click();
+
+    if (!cdp || !authenticatorId) {
+      throw new Error('Missing virtual authenticator');
+    }
 
     // Register WebAuthn credential
     const { credentials: initialCredentials } = await cdp.send('WebAuthn.getCredentials', {
@@ -103,6 +123,13 @@ test.describe('FIDO/WebAuthn Tests', () => {
     await page.getByLabel('Password').fill(password);
     await page.getByRole('button', { name: 'Sign On' }).click();
 
+    await expect(cdp).toBeDefined;
+    await expect(authenticatorId).toBeDefined();
+
+    if (!cdp || !authenticatorId) {
+      throw new Error('Missing virtual authenticator');
+    }
+
     // Register WebAuthn credential
     const { credentials: initialCredentials } = await cdp.send('WebAuthn.getCredentials', {
       authenticatorId,
@@ -140,5 +167,151 @@ test.describe('FIDO/WebAuthn Tests', () => {
 
     // Verify we're back at home page if successful
     await expect(page.getByText('FIDO2 Test Form')).toBeVisible();
+  });
+});
+
+test.describe('FIDO/WebAuthn Error Tests', () => {
+  let cdp: CDPSession | undefined;
+  let authenticatorId: string | undefined;
+
+  test.beforeEach(async ({ context, page }) => {
+    if (authenticatorId) {
+      await cdp?.send('WebAuthn.removeVirtualAuthenticator', { authenticatorId });
+      authenticatorId = undefined;
+    }
+
+    cdp = await context.newCDPSession(page);
+    await expect(cdp).toBeDefined();
+    await cdp.send('WebAuthn.enable');
+
+    // Starts with UV succeeding so setup steps (e.g. registering a device before testing
+    // an auth failure) work; individual tests call WebAuthn.setUserVerified(false) right
+    // before the operation that should fail, which Chromium surfaces as NotAllowedError —
+    // simulating the user canceling the prompt.
+    const response = await cdp.send('WebAuthn.addVirtualAuthenticator', {
+      options: {
+        protocol: 'ctap2',
+        transport: 'internal', // platform authenticator
+        hasResidentKey: true, // allow discoverable credentials (passkeys)
+        hasUserVerification: true, // device supports UV
+        isUserVerified: true, // simulate successful UV (PIN/biometric) by default
+        automaticPresenceSimulation: true, // auto "touch"/presence
+      },
+    });
+    authenticatorId = response.authenticatorId;
+  });
+
+  test.afterEach(async () => {
+    if (authenticatorId) {
+      await cdp?.send('WebAuthn.removeVirtualAuthenticator', { authenticatorId });
+      authenticatorId = undefined;
+    }
+    await cdp?.send('WebAuthn.disable');
+  });
+  test('Registration shows NotAllowedError when the WebAuthn prompt is canceled', async ({
+    page,
+  }) => {
+    const { navigate } = asyncEvents(page);
+
+    await navigate(
+      '/?clientId=20dd0ed0-bb9b-4c8f-9a60-9ebeb4b348e0&acr_values=98f2c058aae71ec09eb268db6810ff3c',
+    );
+    await expect(page.getByText('FIDO2 Test Form')).toBeVisible();
+
+    await page.getByRole('button', { name: 'USER_LOGIN' }).click();
+    await page.getByLabel('Username').fill(username);
+    await page.getByLabel('Password').fill(password);
+    await page.getByRole('button', { name: 'Sign On' }).click();
+
+    if (!cdp || !authenticatorId) {
+      throw new Error('Missing virtual authenticator');
+    }
+
+    await page.getByRole('button', { name: 'DEVICE_REGISTRATION' }).click();
+    await page.getByRole('button', { name: 'Biometrics/Security Key' }).click();
+
+    // Make user verification fail for this authenticator so the registration attempt is
+    // rejected with NotAllowedError — simulating the user canceling the prompt.
+    await cdp.send('WebAuthn.setUserVerified', { authenticatorId, isUserVerified: false });
+    await page.getByRole('button', { name: 'FIDO Register' }).click();
+
+    await expect(page.getByText('FIDO Registration Error - NotAllowedError')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'FIDO Register' })).toBeVisible();
+  });
+
+  test('Device authentication shows NotAllowedError when the WebAuthn prompt is canceled', async ({
+    page,
+  }) => {
+    const { navigate } = asyncEvents(page);
+
+    await navigate(
+      '/?clientId=20dd0ed0-bb9b-4c8f-9a60-9ebeb4b348e0&acr_values=98f2c058aae71ec09eb268db6810ff3c',
+    );
+    await expect(page.getByText('FIDO2 Test Form')).toBeVisible();
+
+    await page.getByRole('button', { name: 'USER_LOGIN' }).click();
+    await page.getByLabel('Username').fill(username);
+    await page.getByLabel('Password').fill(password);
+    await page.getByRole('button', { name: 'Sign On' }).click();
+
+    if (!cdp || !authenticatorId) {
+      throw new Error('Missing virtual authenticator');
+    }
+
+    // Register a credential so there is a device to authenticate with.
+    await page.getByRole('button', { name: 'DEVICE_REGISTRATION' }).click();
+    await page.getByRole('button', { name: 'Biometrics/Security Key' }).click();
+    await page.getByRole('button', { name: 'FIDO Register' }).click();
+    await page.getByRole('button', { name: 'Continue' }).click();
+    await expect(page.getByText('FIDO2 Test Form')).toBeVisible();
+
+    await page.getByRole('button', { name: 'DEVICE_AUTHENTICATION' }).click();
+    await page.getByRole('button', { name: 'Biometrics/Security Key' }).last().click();
+
+    // Make user verification fail for this authenticator so the assertion attempt is
+    // rejected with NotAllowedError — simulating the user canceling the prompt.
+    await cdp.send('WebAuthn.setUserVerified', { authenticatorId, isUserVerified: false });
+    await page.getByRole('button', { name: 'FIDO Authenticate' }).click();
+
+    await expect(page.getByText('FIDO Authentication Error - NotAllowedError')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'FIDO Authenticate' })).toBeVisible();
+  });
+
+  test('Usernameless authentication shows NotAllowedError when the WebAuthn prompt is canceled', async ({
+    page,
+  }) => {
+    const { navigate } = asyncEvents(page);
+
+    await navigate(
+      '/?clientId=20dd0ed0-bb9b-4c8f-9a60-9ebeb4b348e0&acr_values=98f2c058aae71ec09eb268db6810ff3c',
+    );
+    await expect(page.getByText('FIDO2 Test Form')).toBeVisible();
+
+    await page.getByRole('button', { name: 'USER_LOGIN' }).click();
+    await page.getByLabel('Username').fill(username);
+    await page.getByLabel('Password').fill(password);
+    await page.getByRole('button', { name: 'Sign On' }).click();
+
+    if (!cdp || !authenticatorId) {
+      throw new Error('Missing virtual authenticator');
+    }
+
+    // Register a discoverable credential so there is a passkey to authenticate with.
+    await page.getByRole('button', { name: 'DEVICE_REGISTRATION' }).click();
+    await page.getByRole('button', { name: 'Biometrics/Security Key' }).click();
+    await page.getByRole('button', { name: 'FIDO Register' }).click();
+    await page.getByRole('button', { name: 'Continue' }).click();
+    await expect(page.getByText('FIDO2 Test Form')).toBeVisible();
+
+    await page.getByRole('button', { name: 'USER_NAMELESS' }).click();
+    await expect(page.getByText('FIDO2 Authentication')).toBeVisible();
+
+    // Make user verification fail for this authenticator so the assertion attempt is
+    // rejected with NotAllowedError — simulating the user canceling the prompt.
+    await cdp.send('WebAuthn.setUserVerified', { authenticatorId, isUserVerified: false });
+    await page.getByRole('button', { name: 'FIDO Authenticate' }).click();
+
+    await expect(page.getByText('FIDO Usernameless Error - NotAllowedError')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'FIDO Authenticate' })).toBeVisible();
   });
 });

--- a/e2e/davinci-suites/src/fido.test.ts
+++ b/e2e/davinci-suites/src/fido.test.ts
@@ -10,6 +10,9 @@ import { asyncEvents } from './utils/async-events.js';
 const username = 'JSFidoUser@user.com';
 const password = 'FakePassword#123';
 
+const clientId = '31a587ce-9aa4-4f36-a09f-78cd8a0a74a0';
+const policyId = '3eff62cf953372519225d375fd200358';
+
 test.use({ browserName: 'chromium' }); // ensure CDP/WebAuthn is available
 test.describe.configure({ mode: 'serial' });
 
@@ -51,11 +54,9 @@ test.describe('FIDO/WebAuthn Success Tests', () => {
   test('Register and authenticate with webauthn device', async ({ page }) => {
     const { navigate } = asyncEvents(page);
 
-    await navigate(
-      '/?clientId=20dd0ed0-bb9b-4c8f-9a60-9ebeb4b348e0&acr_values=98f2c058aae71ec09eb268db6810ff3c',
-    );
+    await navigate(`/?clientId=${clientId}&acr_values=${policyId}`);
     await expect(page).toHaveURL(
-      'http://localhost:5829/?clientId=20dd0ed0-bb9b-4c8f-9a60-9ebeb4b348e0&acr_values=98f2c058aae71ec09eb268db6810ff3c',
+      `http://localhost:5829/?clientId=${clientId}&acr_values=${policyId}`,
     );
     await expect(page.getByText('FIDO2 Test Form')).toBeVisible();
 
@@ -110,11 +111,9 @@ test.describe('FIDO/WebAuthn Success Tests', () => {
   test('Register and authenticate with usernameless', async ({ page }) => {
     const { navigate } = asyncEvents(page);
 
-    await navigate(
-      '/?clientId=20dd0ed0-bb9b-4c8f-9a60-9ebeb4b348e0&acr_values=98f2c058aae71ec09eb268db6810ff3c',
-    );
+    await navigate(`/?clientId=${clientId}&acr_values=${policyId}`);
     await expect(page).toHaveURL(
-      'http://localhost:5829/?clientId=20dd0ed0-bb9b-4c8f-9a60-9ebeb4b348e0&acr_values=98f2c058aae71ec09eb268db6810ff3c',
+      `http://localhost:5829/?clientId=${clientId}&acr_values=${policyId}`,
     );
     await expect(page.getByText('FIDO2 Test Form')).toBeVisible();
 
@@ -213,9 +212,7 @@ test.describe('FIDO/WebAuthn Error Tests', () => {
   }) => {
     const { navigate } = asyncEvents(page);
 
-    await navigate(
-      '/?clientId=20dd0ed0-bb9b-4c8f-9a60-9ebeb4b348e0&acr_values=98f2c058aae71ec09eb268db6810ff3c',
-    );
+    await navigate(`/?clientId=${clientId}&acr_values=${policyId}`);
     await expect(page.getByText('FIDO2 Test Form')).toBeVisible();
 
     await page.getByRole('button', { name: 'USER_LOGIN' }).click();
@@ -244,9 +241,7 @@ test.describe('FIDO/WebAuthn Error Tests', () => {
   }) => {
     const { navigate } = asyncEvents(page);
 
-    await navigate(
-      '/?clientId=20dd0ed0-bb9b-4c8f-9a60-9ebeb4b348e0&acr_values=98f2c058aae71ec09eb268db6810ff3c',
-    );
+    await navigate(`/?clientId=${clientId}&acr_values=${policyId}`);
     await expect(page.getByText('FIDO2 Test Form')).toBeVisible();
 
     await page.getByRole('button', { name: 'USER_LOGIN' }).click();
@@ -282,9 +277,7 @@ test.describe('FIDO/WebAuthn Error Tests', () => {
   }) => {
     const { navigate } = asyncEvents(page);
 
-    await navigate(
-      '/?clientId=20dd0ed0-bb9b-4c8f-9a60-9ebeb4b348e0&acr_values=98f2c058aae71ec09eb268db6810ff3c',
-    );
+    await navigate(`/?clientId=${clientId}&acr_values=${policyId}`);
     await expect(page.getByText('FIDO2 Test Form')).toBeVisible();
 
     await page.getByRole('button', { name: 'USER_LOGIN' }).click();

--- a/e2e/davinci-suites/src/password-policy.test.ts
+++ b/e2e/davinci-suites/src/password-policy.test.ts
@@ -78,7 +78,7 @@ test.describe('ValidatedPasswordCollector — password policy (Example - Registr
       try {
         await deleteTestUser(page, email);
       } catch (err) {
-        console.error(`[cleanup] Failed to delete test user ${email}:`, err);
+        throw new Error(`[cleanup] Failed to delete test user ${email}: ${JSON.stringify(err)}`);
       }
     }
   });
@@ -146,26 +146,17 @@ test.describe('ValidatedPasswordCollector — password policy (Example - Registr
     await page.locator('#userPassword').fill(password);
 
     // Submit the form by calling submit() on the form element
-    await page.locator('form').evaluate((form: HTMLFormElement) => form.submit());
+    await page.getByRole('button', { name: 'Submit' }).click({ timeout: 10000 });
 
     // Wait for the page to navigate to the next step
-    // The heading should change from "Example - Registration 1" to something else
-    await page.waitForFunction(
-      () => {
-        const heading = document.querySelector('h2');
-        return heading && !heading.textContent?.includes('Example - Registration');
-      },
-      { timeout: 10000 },
-    );
-
-    // Verify we've moved to the next step
-    const heading = page.locator('h2').first();
-    await expect(heading).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Example - Registration' })).not.toBeVisible();
 
     // If the flow shows a "Continue" button, click through to complete it
     const continueBtn = page.getByRole('button', { name: 'Continue' });
     if (await continueBtn.isVisible()) {
       await continueBtn.click();
     }
+
+    await expect(page.getByRole('heading', { name: 'Complete' })).toBeVisible();
   });
 });

--- a/e2e/davinci-suites/src/password-policy.test.ts
+++ b/e2e/davinci-suites/src/password-policy.test.ts
@@ -8,14 +8,8 @@ import { expect, test } from '@playwright/test';
 import { asyncEvents } from './utils/async-events.js';
 import { password } from './utils/demo-user.js';
 
-/**
- * DaVinci flow: Andy - MFA Device Registration/Authentication (PingOne Forms)
- * Client ID: fb456db5-2e08-46d3-adf0-05bf8d26ad60
- * Flow ID (acr_values): 769eecb92f8e66f88005a85e8b939a01
- * Wellknown: https://auth.pingone.ca/356a254c-cba3-4ade-be1a-860136e8df01/as/.well-known/openid-configuration
- */
-const CLIENT_ID = 'fb456db5-2e08-46d3-adf0-05bf8d26ad60';
-const FLOW_ID = '769eecb92f8e66f88005a85e8b939a01';
+const CLIENT_ID = 'e4ef2896-8d90-4abd-bf0f-7b8034995927';
+const POLICY_ID = '5e8613e337c67a67db09373019e962e0';
 
 /**
  * A unique email per test run to avoid conflicts with existing accounts.
@@ -27,7 +21,7 @@ function uniqueEmail() {
 
 async function navigateToRegistration(page: Parameters<typeof asyncEvents>[0]) {
   const { navigate } = asyncEvents(page);
-  await navigate(`/?clientId=${CLIENT_ID}&acr_values=${FLOW_ID}`);
+  await navigate(`/?clientId=${CLIENT_ID}&acr_values=${POLICY_ID}`);
 
   // Wait for flow buttons to render (they have class 'flow-link')
   await page.waitForSelector('button.flow-link', { timeout: 10000 });
@@ -46,7 +40,7 @@ async function navigateToRegistration(page: Parameters<typeof asyncEvents>[0]) {
 }
 
 async function deleteTestUser(page: Parameters<typeof asyncEvents>[0], email: string) {
-  await page.goto(`/?clientId=${CLIENT_ID}&acr_values=${FLOW_ID}`);
+  await page.goto(`/?clientId=${CLIENT_ID}&acr_values=${POLICY_ID}`);
 
   // Wait for flow buttons to render
   await page.waitForSelector('button.flow-link', { timeout: 10000 });
@@ -150,6 +144,7 @@ test.describe('ValidatedPasswordCollector — password policy (Example - Registr
 
     // Wait for the page to navigate to the next step
     await expect(page.getByRole('heading', { name: 'Example - Registration' })).not.toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Registration Complete' })).toBeVisible();
 
     // If the flow shows a "Continue" button, click through to complete it
     const continueBtn = page.getByRole('button', { name: 'Continue' });

--- a/packages/davinci-client/api-report/davinci-client.api.md
+++ b/packages/davinci-client/api-report/davinci-client.api.md
@@ -12,6 +12,7 @@ import { FetchBaseQueryError } from '@reduxjs/toolkit/query';
 import type { FetchBaseQueryMeta } from '@reduxjs/toolkit/query';
 import { GenericError } from '@forgerock/sdk-types';
 import { LogLevel } from '@forgerock/sdk-logger';
+import type { LogLevel as LogLevel_2 } from '@forgerock/sdk-types';
 import type { MutationResultSelectorResult } from '@reduxjs/toolkit/query';
 import { QueryStatus } from '@reduxjs/toolkit/query';
 import { Reducer } from '@reduxjs/toolkit';
@@ -208,9 +209,9 @@ export type CollectorValueType<T> = T extends {
     type: 'PhoneNumberExtensionCollector';
 } ? PhoneNumberExtensionInputValue : T extends {
     type: 'FidoRegistrationCollector';
-} ? FidoRegistrationInputValue : T extends {
+} ? FidoRegistrationInputValue | GenericError : T extends {
     type: 'FidoAuthenticationCollector';
-} ? FidoAuthenticationInputValue : T extends {
+} ? FidoAuthenticationInputValue | GenericError : T extends {
     type: 'MetadataCollector';
 } ? Record<string, unknown> | MetadataError : T extends {
     category: 'SingleValueCollector';
@@ -227,7 +228,7 @@ export type CollectorValueType<T> = T extends {
 } ? never : CollectorValueTypes;
 
 // @public
-export type CollectorValueTypes = string | string[] | boolean | PhoneNumberInputValue | PhoneNumberExtensionInputValue | FidoRegistrationInputValue | FidoAuthenticationInputValue | MetadataError;
+export type CollectorValueTypes = string | string[] | boolean | PhoneNumberInputValue | PhoneNumberExtensionInputValue | FidoRegistrationInputValue | FidoAuthenticationInputValue | MetadataError | GenericError;
 
 // @public (undocumented)
 export type ComplexValueFields = DeviceAuthenticationField | DeviceRegistrationField | PhoneNumberField | PhoneNumberExtensionField | FidoRegistrationField | FidoAuthenticationField | PollingField | MetadataField;
@@ -285,18 +286,18 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
     resume: (input: {
         continueToken: string;
     }) => Promise<InternalErrorResponse | NodeStates>;
-    start: <QueryParams extends OutgoingQueryParams = OutgoingQueryParams>(options?: StartOptions<QueryParams> | undefined) => Promise<ContinueNode | ErrorNode | StartNode | SuccessNode | FailureNode>;
+    start: <QueryParams extends OutgoingQueryParams = OutgoingQueryParams>(options?: StartOptions<QueryParams> | undefined) => Promise<ContinueNode | StartNode | ErrorNode | FailureNode | SuccessNode>;
     update: <T extends SingleValueCollectors | MultiSelectCollector | ObjectValueCollectors | AutoCollectors>(collector: T) => Updater<T>;
     validate: (collector: SingleValueCollectors | ObjectValueCollectors | MultiValueCollectors | AutoCollectors) => Validator;
     pollStatus: (collector: PollingCollector) => Poller;
     getClient: () => {
+        status: "start";
+    } | {
         action: string;
         collectors: Collectors[];
         description?: string;
         name?: string;
         status: "continue";
-    } | {
-        status: "start";
     } | {
         action: string;
         collectors: Collectors[];
@@ -304,18 +305,18 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         name?: string;
         status: "error";
     } | {
+        status: "failure";
+    } | {
         authorization?: {
             code?: string;
             state?: string;
         };
         status: "success";
-    } | {
-        status: "failure";
     } | null;
     getCollectors: () => Collectors[];
     getError: () => DaVinciError | null;
     getErrorCollectors: () => CollectorErrors[];
-    getNode: () => ContinueNode | ErrorNode | StartNode | SuccessNode | FailureNode;
+    getNode: () => ContinueNode | StartNode | ErrorNode | FailureNode | SuccessNode;
     getServer: () => {
         _links?: Links;
         id?: string;
@@ -336,20 +337,20 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
     } | {
         _links?: Links;
         eventName?: string;
+        href?: string;
+        id?: string;
+        interactionId?: string;
+        interactionToken?: string;
+        status: "failure";
+    } | {
+        _links?: Links;
+        eventName?: string;
         id?: string;
         interactionId?: string;
         interactionToken?: string;
         href?: string;
         session?: string;
         status: "success";
-    } | {
-        _links?: Links;
-        eventName?: string;
-        href?: string;
-        id?: string;
-        interactionId?: string;
-        interactionToken?: string;
-        status: "failure";
     } | null;
     cache: {
         getLatestResponse: () => ({
@@ -639,7 +640,7 @@ export interface DaVinciRequest {
 }
 
 // @public
-export type DaVinciRequestValueTypes = string | number | boolean | (string | number | boolean)[] | DeviceValue | PhoneNumberInputValue | FidoRegistrationInputValue | FidoAuthenticationInputValue | MetadataError;
+export type DaVinciRequestValueTypes = string | number | boolean | (string | number | boolean)[] | DeviceValue | PhoneNumberInputValue | FidoRegistrationInputValue | FidoAuthenticationInputValue | MetadataError | GenericError;
 
 // @public (undocumented)
 export interface DaVinciSuccessResponse extends DaVinciBaseResponse {
@@ -835,10 +836,10 @@ export interface FailureNode {
 }
 
 // @public
-export function fido(): FidoClient;
+export function fido(config?: FidoClientConfig): FidoClient;
 
 // @public (undocumented)
-export type FidoAuthenticationCollector = AutoCollector<'ObjectValueAutoCollector', 'FidoAuthenticationCollector', FidoAuthenticationInputValue, FidoAuthenticationOutputValue>;
+export type FidoAuthenticationCollector = AutoCollector<'ObjectValueAutoCollector', 'FidoAuthenticationCollector', FidoAuthenticationInputValue | GenericError, FidoAuthenticationOutputValue>;
 
 // @public (undocumented)
 export type FidoAuthenticationField = {
@@ -886,7 +887,19 @@ export interface FidoClient {
 }
 
 // @public (undocumented)
-export type FidoRegistrationCollector = AutoCollector<'ObjectValueAutoCollector', 'FidoRegistrationCollector', FidoRegistrationInputValue, FidoRegistrationOutputValue>;
+export interface FidoClientConfig {
+    // (undocumented)
+    logger?: {
+        level?: LogLevel_2;
+        custom?: CustomLogger;
+    };
+}
+
+// @public
+export type FidoErrorCode = 'NotAllowedError' | 'AbortError' | 'InvalidStateError' | 'NotSupportedError' | 'SecurityError' | 'TimeoutError' | 'UnknownError';
+
+// @public (undocumented)
+export type FidoRegistrationCollector = AutoCollector<'ObjectValueAutoCollector', 'FidoRegistrationCollector', FidoRegistrationInputValue | GenericError, FidoRegistrationOutputValue>;
 
 // @public (undocumented)
 export type FidoRegistrationField = {

--- a/packages/davinci-client/api-report/davinci-client.api.md
+++ b/packages/davinci-client/api-report/davinci-client.api.md
@@ -12,7 +12,6 @@ import { FetchBaseQueryError } from '@reduxjs/toolkit/query';
 import type { FetchBaseQueryMeta } from '@reduxjs/toolkit/query';
 import { GenericError } from '@forgerock/sdk-types';
 import { LogLevel } from '@forgerock/sdk-logger';
-import type { LogLevel as LogLevel_2 } from '@forgerock/sdk-types';
 import type { MutationResultSelectorResult } from '@reduxjs/toolkit/query';
 import { QueryStatus } from '@reduxjs/toolkit/query';
 import { Reducer } from '@reduxjs/toolkit';
@@ -286,11 +285,13 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
     resume: (input: {
         continueToken: string;
     }) => Promise<InternalErrorResponse | NodeStates>;
-    start: <QueryParams extends OutgoingQueryParams = OutgoingQueryParams>(options?: StartOptions<QueryParams> | undefined) => Promise<ContinueNode | ErrorNode | FailureNode | StartNode | SuccessNode>;
+    start: <QueryParams extends OutgoingQueryParams = OutgoingQueryParams>(options?: StartOptions<QueryParams> | undefined) => Promise<ContinueNode | ErrorNode | StartNode | SuccessNode | FailureNode>;
     update: <T extends SingleValueCollectors | MultiSelectCollector | ObjectValueCollectors | AutoCollectors>(collector: T) => Updater<T>;
     validate: (collector: SingleValueCollectors | ObjectValueCollectors | MultiValueCollectors | AutoCollectors) => Validator;
     pollStatus: (collector: PollingCollector) => Poller;
     getClient: () => {
+        status: "start";
+    } | {
         action: string;
         collectors: Collectors[];
         description?: string;
@@ -303,20 +304,18 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         name?: string;
         status: "error";
     } | {
-        status: "failure";
-    } | {
-        status: "start";
-    } | {
         authorization?: {
             code?: string;
             state?: string;
         };
         status: "success";
+    } | {
+        status: "failure";
     } | null;
     getCollectors: () => Collectors[];
     getError: () => DaVinciError | null;
     getErrorCollectors: () => CollectorErrors[];
-    getNode: () => ContinueNode | ErrorNode | FailureNode | StartNode | SuccessNode;
+    getNode: () => ContinueNode | ErrorNode | StartNode | SuccessNode | FailureNode;
     getServer: () => {
         _links?: Links;
         id?: string;
@@ -326,6 +325,8 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         eventName?: string;
         status: "continue";
     } | {
+        status: "start";
+    } | {
         _links?: Links;
         eventName?: string;
         id?: string;
@@ -335,22 +336,20 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
     } | {
         _links?: Links;
         eventName?: string;
-        href?: string;
-        id?: string;
-        interactionId?: string;
-        interactionToken?: string;
-        status: "failure";
-    } | {
-        status: "start";
-    } | {
-        _links?: Links;
-        eventName?: string;
         id?: string;
         interactionId?: string;
         interactionToken?: string;
         href?: string;
         session?: string;
         status: "success";
+    } | {
+        _links?: Links;
+        eventName?: string;
+        href?: string;
+        id?: string;
+        interactionId?: string;
+        interactionToken?: string;
+        status: "failure";
     } | null;
     cache: {
         getLatestResponse: () => ({
@@ -836,7 +835,7 @@ export interface FailureNode {
 }
 
 // @public
-export function fido(config?: FidoClientConfig): FidoClient;
+export function fido(): FidoClient;
 
 // @public (undocumented)
 export type FidoAuthenticationCollector = AutoCollector<'ObjectValueAutoCollector', 'FidoAuthenticationCollector', FidoAuthenticationInputValue | GenericError, FidoAuthenticationOutputValue>;
@@ -884,15 +883,6 @@ export interface FidoAuthenticationOutputValue {
 export interface FidoClient {
     authenticate: (options: FidoAuthenticationOptions) => Promise<FidoAuthenticationInputValue | GenericError>;
     register: (options: FidoRegistrationOptions) => Promise<FidoRegistrationInputValue | GenericError>;
-}
-
-// @public (undocumented)
-export interface FidoClientConfig {
-    // (undocumented)
-    logger?: {
-        level?: LogLevel_2;
-        custom?: CustomLogger;
-    };
 }
 
 // @public

--- a/packages/davinci-client/api-report/davinci-client.api.md
+++ b/packages/davinci-client/api-report/davinci-client.api.md
@@ -286,13 +286,11 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
     resume: (input: {
         continueToken: string;
     }) => Promise<InternalErrorResponse | NodeStates>;
-    start: <QueryParams extends OutgoingQueryParams = OutgoingQueryParams>(options?: StartOptions<QueryParams> | undefined) => Promise<ContinueNode | StartNode | ErrorNode | FailureNode | SuccessNode>;
+    start: <QueryParams extends OutgoingQueryParams = OutgoingQueryParams>(options?: StartOptions<QueryParams> | undefined) => Promise<ContinueNode | ErrorNode | FailureNode | StartNode | SuccessNode>;
     update: <T extends SingleValueCollectors | MultiSelectCollector | ObjectValueCollectors | AutoCollectors>(collector: T) => Updater<T>;
     validate: (collector: SingleValueCollectors | ObjectValueCollectors | MultiValueCollectors | AutoCollectors) => Validator;
     pollStatus: (collector: PollingCollector) => Poller;
     getClient: () => {
-        status: "start";
-    } | {
         action: string;
         collectors: Collectors[];
         description?: string;
@@ -306,6 +304,8 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         status: "error";
     } | {
         status: "failure";
+    } | {
+        status: "start";
     } | {
         authorization?: {
             code?: string;
@@ -316,7 +316,7 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
     getCollectors: () => Collectors[];
     getError: () => DaVinciError | null;
     getErrorCollectors: () => CollectorErrors[];
-    getNode: () => ContinueNode | StartNode | ErrorNode | FailureNode | SuccessNode;
+    getNode: () => ContinueNode | ErrorNode | FailureNode | StartNode | SuccessNode;
     getServer: () => {
         _links?: Links;
         id?: string;
@@ -325,8 +325,6 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         href?: string;
         eventName?: string;
         status: "continue";
-    } | {
-        status: "start";
     } | {
         _links?: Links;
         eventName?: string;
@@ -342,6 +340,8 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         interactionId?: string;
         interactionToken?: string;
         status: "failure";
+    } | {
+        status: "start";
     } | {
         _links?: Links;
         eventName?: string;

--- a/packages/davinci-client/api-report/davinci-client.types.api.md
+++ b/packages/davinci-client/api-report/davinci-client.types.api.md
@@ -12,7 +12,6 @@ import { FetchBaseQueryError } from '@reduxjs/toolkit/query';
 import type { FetchBaseQueryMeta } from '@reduxjs/toolkit/query';
 import { GenericError } from '@forgerock/sdk-types';
 import { LogLevel } from '@forgerock/sdk-logger';
-import type { LogLevel as LogLevel_2 } from '@forgerock/sdk-types';
 import type { MutationResultSelectorResult } from '@reduxjs/toolkit/query';
 import { QueryStatus } from '@reduxjs/toolkit/query';
 import { Reducer } from '@reduxjs/toolkit';
@@ -286,11 +285,13 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
     resume: (input: {
         continueToken: string;
     }) => Promise<InternalErrorResponse | NodeStates>;
-    start: <QueryParams extends OutgoingQueryParams = OutgoingQueryParams>(options?: StartOptions<QueryParams> | undefined) => Promise<ContinueNode | ErrorNode | FailureNode | StartNode | SuccessNode>;
+    start: <QueryParams extends OutgoingQueryParams = OutgoingQueryParams>(options?: StartOptions<QueryParams> | undefined) => Promise<ContinueNode | ErrorNode | StartNode | SuccessNode | FailureNode>;
     update: <T extends SingleValueCollectors | MultiSelectCollector | ObjectValueCollectors | AutoCollectors>(collector: T) => Updater<T>;
     validate: (collector: SingleValueCollectors | ObjectValueCollectors | MultiValueCollectors | AutoCollectors) => Validator;
     pollStatus: (collector: PollingCollector) => Poller;
     getClient: () => {
+        status: "start";
+    } | {
         action: string;
         collectors: Collectors[];
         description?: string;
@@ -303,20 +304,18 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         name?: string;
         status: "error";
     } | {
-        status: "failure";
-    } | {
-        status: "start";
-    } | {
         authorization?: {
             code?: string;
             state?: string;
         };
         status: "success";
+    } | {
+        status: "failure";
     } | null;
     getCollectors: () => Collectors[];
     getError: () => DaVinciError | null;
     getErrorCollectors: () => CollectorErrors[];
-    getNode: () => ContinueNode | ErrorNode | FailureNode | StartNode | SuccessNode;
+    getNode: () => ContinueNode | ErrorNode | StartNode | SuccessNode | FailureNode;
     getServer: () => {
         _links?: Links;
         id?: string;
@@ -326,6 +325,8 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         eventName?: string;
         status: "continue";
     } | {
+        status: "start";
+    } | {
         _links?: Links;
         eventName?: string;
         id?: string;
@@ -335,22 +336,20 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
     } | {
         _links?: Links;
         eventName?: string;
-        href?: string;
-        id?: string;
-        interactionId?: string;
-        interactionToken?: string;
-        status: "failure";
-    } | {
-        status: "start";
-    } | {
-        _links?: Links;
-        eventName?: string;
         id?: string;
         interactionId?: string;
         interactionToken?: string;
         href?: string;
         session?: string;
         status: "success";
+    } | {
+        _links?: Links;
+        eventName?: string;
+        href?: string;
+        id?: string;
+        interactionId?: string;
+        interactionToken?: string;
+        status: "failure";
     } | null;
     cache: {
         getLatestResponse: () => ({
@@ -881,15 +880,6 @@ export interface FidoAuthenticationOutputValue {
 export interface FidoClient {
     authenticate: (options: FidoAuthenticationOptions) => Promise<FidoAuthenticationInputValue | GenericError>;
     register: (options: FidoRegistrationOptions) => Promise<FidoRegistrationInputValue | GenericError>;
-}
-
-// @public (undocumented)
-export interface FidoClientConfig {
-    // (undocumented)
-    logger?: {
-        level?: LogLevel_2;
-        custom?: CustomLogger;
-    };
 }
 
 // @public

--- a/packages/davinci-client/api-report/davinci-client.types.api.md
+++ b/packages/davinci-client/api-report/davinci-client.types.api.md
@@ -286,13 +286,11 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
     resume: (input: {
         continueToken: string;
     }) => Promise<InternalErrorResponse | NodeStates>;
-    start: <QueryParams extends OutgoingQueryParams = OutgoingQueryParams>(options?: StartOptions<QueryParams> | undefined) => Promise<ContinueNode | StartNode | ErrorNode | FailureNode | SuccessNode>;
+    start: <QueryParams extends OutgoingQueryParams = OutgoingQueryParams>(options?: StartOptions<QueryParams> | undefined) => Promise<ContinueNode | ErrorNode | FailureNode | StartNode | SuccessNode>;
     update: <T extends SingleValueCollectors | MultiSelectCollector | ObjectValueCollectors | AutoCollectors>(collector: T) => Updater<T>;
     validate: (collector: SingleValueCollectors | ObjectValueCollectors | MultiValueCollectors | AutoCollectors) => Validator;
     pollStatus: (collector: PollingCollector) => Poller;
     getClient: () => {
-        status: "start";
-    } | {
         action: string;
         collectors: Collectors[];
         description?: string;
@@ -306,6 +304,8 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         status: "error";
     } | {
         status: "failure";
+    } | {
+        status: "start";
     } | {
         authorization?: {
             code?: string;
@@ -316,7 +316,7 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
     getCollectors: () => Collectors[];
     getError: () => DaVinciError | null;
     getErrorCollectors: () => CollectorErrors[];
-    getNode: () => ContinueNode | StartNode | ErrorNode | FailureNode | SuccessNode;
+    getNode: () => ContinueNode | ErrorNode | FailureNode | StartNode | SuccessNode;
     getServer: () => {
         _links?: Links;
         id?: string;
@@ -325,8 +325,6 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         href?: string;
         eventName?: string;
         status: "continue";
-    } | {
-        status: "start";
     } | {
         _links?: Links;
         eventName?: string;
@@ -342,6 +340,8 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         interactionId?: string;
         interactionToken?: string;
         status: "failure";
+    } | {
+        status: "start";
     } | {
         _links?: Links;
         eventName?: string;

--- a/packages/davinci-client/api-report/davinci-client.types.api.md
+++ b/packages/davinci-client/api-report/davinci-client.types.api.md
@@ -12,6 +12,7 @@ import { FetchBaseQueryError } from '@reduxjs/toolkit/query';
 import type { FetchBaseQueryMeta } from '@reduxjs/toolkit/query';
 import { GenericError } from '@forgerock/sdk-types';
 import { LogLevel } from '@forgerock/sdk-logger';
+import type { LogLevel as LogLevel_2 } from '@forgerock/sdk-types';
 import type { MutationResultSelectorResult } from '@reduxjs/toolkit/query';
 import { QueryStatus } from '@reduxjs/toolkit/query';
 import { Reducer } from '@reduxjs/toolkit';
@@ -208,9 +209,9 @@ export type CollectorValueType<T> = T extends {
     type: 'PhoneNumberExtensionCollector';
 } ? PhoneNumberExtensionInputValue : T extends {
     type: 'FidoRegistrationCollector';
-} ? FidoRegistrationInputValue : T extends {
+} ? FidoRegistrationInputValue | GenericError : T extends {
     type: 'FidoAuthenticationCollector';
-} ? FidoAuthenticationInputValue : T extends {
+} ? FidoAuthenticationInputValue | GenericError : T extends {
     type: 'MetadataCollector';
 } ? Record<string, unknown> | MetadataError : T extends {
     category: 'SingleValueCollector';
@@ -227,7 +228,7 @@ export type CollectorValueType<T> = T extends {
 } ? never : CollectorValueTypes;
 
 // @public
-export type CollectorValueTypes = string | string[] | boolean | PhoneNumberInputValue | PhoneNumberExtensionInputValue | FidoRegistrationInputValue | FidoAuthenticationInputValue | MetadataError;
+export type CollectorValueTypes = string | string[] | boolean | PhoneNumberInputValue | PhoneNumberExtensionInputValue | FidoRegistrationInputValue | FidoAuthenticationInputValue | MetadataError | GenericError;
 
 // @public (undocumented)
 export type ComplexValueFields = DeviceAuthenticationField | DeviceRegistrationField | PhoneNumberField | PhoneNumberExtensionField | FidoRegistrationField | FidoAuthenticationField | PollingField | MetadataField;
@@ -285,18 +286,18 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
     resume: (input: {
         continueToken: string;
     }) => Promise<InternalErrorResponse | NodeStates>;
-    start: <QueryParams extends OutgoingQueryParams = OutgoingQueryParams>(options?: StartOptions<QueryParams> | undefined) => Promise<ContinueNode | ErrorNode | StartNode | SuccessNode | FailureNode>;
+    start: <QueryParams extends OutgoingQueryParams = OutgoingQueryParams>(options?: StartOptions<QueryParams> | undefined) => Promise<ContinueNode | StartNode | ErrorNode | FailureNode | SuccessNode>;
     update: <T extends SingleValueCollectors | MultiSelectCollector | ObjectValueCollectors | AutoCollectors>(collector: T) => Updater<T>;
     validate: (collector: SingleValueCollectors | ObjectValueCollectors | MultiValueCollectors | AutoCollectors) => Validator;
     pollStatus: (collector: PollingCollector) => Poller;
     getClient: () => {
+        status: "start";
+    } | {
         action: string;
         collectors: Collectors[];
         description?: string;
         name?: string;
         status: "continue";
-    } | {
-        status: "start";
     } | {
         action: string;
         collectors: Collectors[];
@@ -304,18 +305,18 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
         name?: string;
         status: "error";
     } | {
+        status: "failure";
+    } | {
         authorization?: {
             code?: string;
             state?: string;
         };
         status: "success";
-    } | {
-        status: "failure";
     } | null;
     getCollectors: () => Collectors[];
     getError: () => DaVinciError | null;
     getErrorCollectors: () => CollectorErrors[];
-    getNode: () => ContinueNode | ErrorNode | StartNode | SuccessNode | FailureNode;
+    getNode: () => ContinueNode | StartNode | ErrorNode | FailureNode | SuccessNode;
     getServer: () => {
         _links?: Links;
         id?: string;
@@ -336,20 +337,20 @@ export function davinci<ActionType extends ActionTypes = ActionTypes>(input: {
     } | {
         _links?: Links;
         eventName?: string;
+        href?: string;
+        id?: string;
+        interactionId?: string;
+        interactionToken?: string;
+        status: "failure";
+    } | {
+        _links?: Links;
+        eventName?: string;
         id?: string;
         interactionId?: string;
         interactionToken?: string;
         href?: string;
         session?: string;
         status: "success";
-    } | {
-        _links?: Links;
-        eventName?: string;
-        href?: string;
-        id?: string;
-        interactionId?: string;
-        interactionToken?: string;
-        status: "failure";
     } | null;
     cache: {
         getLatestResponse: () => ({
@@ -639,7 +640,7 @@ export interface DaVinciRequest {
 }
 
 // @public
-export type DaVinciRequestValueTypes = string | number | boolean | (string | number | boolean)[] | DeviceValue | PhoneNumberInputValue | FidoRegistrationInputValue | FidoAuthenticationInputValue | MetadataError;
+export type DaVinciRequestValueTypes = string | number | boolean | (string | number | boolean)[] | DeviceValue | PhoneNumberInputValue | FidoRegistrationInputValue | FidoAuthenticationInputValue | MetadataError | GenericError;
 
 // @public (undocumented)
 export interface DaVinciSuccessResponse extends DaVinciBaseResponse {
@@ -835,7 +836,7 @@ export interface FailureNode {
 }
 
 // @public (undocumented)
-export type FidoAuthenticationCollector = AutoCollector<'ObjectValueAutoCollector', 'FidoAuthenticationCollector', FidoAuthenticationInputValue, FidoAuthenticationOutputValue>;
+export type FidoAuthenticationCollector = AutoCollector<'ObjectValueAutoCollector', 'FidoAuthenticationCollector', FidoAuthenticationInputValue | GenericError, FidoAuthenticationOutputValue>;
 
 // @public (undocumented)
 export type FidoAuthenticationField = {
@@ -883,7 +884,19 @@ export interface FidoClient {
 }
 
 // @public (undocumented)
-export type FidoRegistrationCollector = AutoCollector<'ObjectValueAutoCollector', 'FidoRegistrationCollector', FidoRegistrationInputValue, FidoRegistrationOutputValue>;
+export interface FidoClientConfig {
+    // (undocumented)
+    logger?: {
+        level?: LogLevel_2;
+        custom?: CustomLogger;
+    };
+}
+
+// @public
+export type FidoErrorCode = 'NotAllowedError' | 'AbortError' | 'InvalidStateError' | 'NotSupportedError' | 'SecurityError' | 'TimeoutError' | 'UnknownError';
+
+// @public (undocumented)
+export type FidoRegistrationCollector = AutoCollector<'ObjectValueAutoCollector', 'FidoRegistrationCollector', FidoRegistrationInputValue | GenericError, FidoRegistrationOutputValue>;
 
 // @public (undocumented)
 export type FidoRegistrationField = {

--- a/packages/davinci-client/src/lib/client.types.ts
+++ b/packages/davinci-client/src/lib/client.types.ts
@@ -41,7 +41,8 @@ export type CollectorValueTypes =
   | PhoneNumberExtensionInputValue
   | FidoRegistrationInputValue
   | FidoAuthenticationInputValue
-  | MetadataError;
+  | MetadataError
+  | GenericError;
 
 /**
  * Maps collector types to the specific value type they accept.
@@ -83,9 +84,9 @@ export type CollectorValueType<T> =
               : T extends { type: 'PhoneNumberExtensionCollector' }
                 ? PhoneNumberExtensionInputValue
                 : T extends { type: 'FidoRegistrationCollector' }
-                  ? FidoRegistrationInputValue
+                  ? FidoRegistrationInputValue | GenericError
                   : T extends { type: 'FidoAuthenticationCollector' }
-                    ? FidoAuthenticationInputValue
+                    ? FidoAuthenticationInputValue | GenericError
                     : T extends { type: 'MetadataCollector' }
                       ? Record<string, unknown> | MetadataError
                       : // category catch-alls

--- a/packages/davinci-client/src/lib/collector.types.ts
+++ b/packages/davinci-client/src/lib/collector.types.ts
@@ -5,6 +5,7 @@
  * of the MIT license. See the LICENSE file for details.
  */
 
+import type { GenericError } from '@forgerock/sdk-types';
 import type {
   FidoAuthenticationOptions,
   FidoRegistrationOptions,
@@ -856,13 +857,13 @@ export type ProtectCollector = AutoCollector<
 export type FidoRegistrationCollector = AutoCollector<
   'ObjectValueAutoCollector',
   'FidoRegistrationCollector',
-  FidoRegistrationInputValue,
+  FidoRegistrationInputValue | GenericError,
   FidoRegistrationOutputValue
 >;
 export type FidoAuthenticationCollector = AutoCollector<
   'ObjectValueAutoCollector',
   'FidoAuthenticationCollector',
-  FidoAuthenticationInputValue,
+  FidoAuthenticationInputValue | GenericError,
   FidoAuthenticationOutputValue
 >;
 export type MetadataCollector = AutoCollector<

--- a/packages/davinci-client/src/lib/collector.types.ts
+++ b/packages/davinci-client/src/lib/collector.types.ts
@@ -768,19 +768,6 @@ export interface FidoRegistrationOutputValue {
   trigger: string;
 }
 
-/**
- * A structured error to return to DaVinci if the application fails to respond successfully to a MetadataCollector
- *
- * @property code - Error code
- * @property message - Error description
- */
-export interface MetadataError {
-  code: string;
-  message: string;
-}
-
-export type MetadataCollectorInputValue = Record<string, unknown> | MetadataError;
-
 export interface AssertionValue extends Omit<
   PublicKeyCredential,
   'rawId' | 'response' | 'getClientExtensionResults' | 'toJSON'
@@ -804,6 +791,18 @@ export interface FidoAuthenticationOutputValue {
   trigger: string;
 }
 
+/**
+ * A structured error to return to DaVinci if the application fails to respond successfully to a MetadataCollector
+ *
+ * @property code - Error code
+ * @property message - Error description
+ */
+export interface MetadataError {
+  code: string;
+  message: string;
+}
+
+export type MetadataCollectorInputValue = Record<string, unknown> | MetadataError;
 export interface PollingOutputValue {
   pollInterval: number;
   pollRetries: number;

--- a/packages/davinci-client/src/lib/davinci.api.ts
+++ b/packages/davinci-client/src/lib/davinci.api.ts
@@ -38,6 +38,8 @@ import type {
   StartOptions,
   ThrownQueryError,
 } from './davinci.types.js';
+import type { GenericError } from '@forgerock/sdk-types';
+import type { FidoRegistrationCollector, FidoAuthenticationCollector } from './collector.types.js';
 import type { ContinueNode } from './node.types.js';
 import type { StartNode } from '../types.js';
 
@@ -171,9 +173,29 @@ export const davinciApi = createApi({
           const hasMetadataCollector = state.node.client?.collectors?.some(
             (collector) => collector.type === 'MetadataCollector',
           );
-          requestBody = hasMetadataCollector
-            ? transformActionRequest(state.node, state.node.client?.action, logger)
-            : transformSubmitRequest(state.node, logger);
+          const fidoErrorCollector = state.node.client?.collectors?.find(
+            (
+              collector,
+            ): collector is (FidoRegistrationCollector | FidoAuthenticationCollector) & {
+              input: { value: GenericError };
+            } =>
+              (collector.type === 'FidoRegistrationCollector' ||
+                collector.type === 'FidoAuthenticationCollector') &&
+              'type' in collector.input.value &&
+              collector.input.value.type === 'fido_error',
+          );
+
+          if (hasMetadataCollector) {
+            requestBody = transformActionRequest(state.node, state.node.client?.action, logger);
+          } else if (fidoErrorCollector) {
+            requestBody = transformActionRequest(
+              state.node,
+              String(fidoErrorCollector.input.value.code ?? 'UnknownError'),
+              logger,
+            );
+          } else {
+            requestBody = transformSubmitRequest(state.node, logger);
+          }
         } else {
           requestBody = body;
         }

--- a/packages/davinci-client/src/lib/davinci.types.ts
+++ b/packages/davinci-client/src/lib/davinci.types.ts
@@ -20,6 +20,7 @@ import {
   FidoAuthenticationInputValue,
   MetadataError,
 } from './collector.types.js';
+import { GenericError } from '@forgerock/sdk-types';
 
 export interface DaVinciRequest {
   id: string;
@@ -46,7 +47,8 @@ export type DaVinciRequestValueTypes =
   | PhoneNumberInputValue
   | FidoRegistrationInputValue
   | FidoAuthenticationInputValue
-  | MetadataError;
+  | MetadataError
+  | GenericError;
 
 /**
  * Base Response for DaVinci API

--- a/packages/davinci-client/src/lib/davinci.utils.test.ts
+++ b/packages/davinci-client/src/lib/davinci.utils.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -243,6 +243,7 @@ describe('transformActionRequest', () => {
         eventType: 'action',
         data: {
           actionKey: 'TEST_ACTION',
+          formData: {},
         },
       },
     };

--- a/packages/davinci-client/src/lib/davinci.utils.ts
+++ b/packages/davinci-client/src/lib/davinci.utils.ts
@@ -96,9 +96,14 @@ export function transformActionRequest(
       collector.category === 'ValidatedSingleValueCollector' ||
       collector.category === 'ObjectValueCollector' ||
       collector.category === 'SingleValueAutoCollector' ||
-      collector.category === 'ObjectValueAutoCollector',
+      (collector.category === 'ObjectValueAutoCollector' &&
+        // FIDO collectors do not require any formData sent
+        collector.type !== 'FidoAuthenticationCollector' &&
+        collector.type !== 'FidoRegistrationCollector'),
   );
 
+  // While most action events don't have formData to send back to DaVinci,
+  // the MetadataCollector will always return data in the shape of Record<string, unknown>
   const formData = collectors?.reduce<{
     [key: string]: DaVinciRequestValueTypes | Record<string, unknown>;
   }>((acc, collector) => {
@@ -107,7 +112,6 @@ export function transformActionRequest(
   }, {});
 
   logger.debug('Transforming action request', { node, action });
-
   return {
     id: node.server.id || '',
     eventName: node.server.eventName || '',
@@ -116,7 +120,7 @@ export function transformActionRequest(
       eventType: 'action',
       data: {
         actionKey: action || node.client?.action || '',
-        ...(Object.keys(formData ?? {}).length && { formData: formData }),
+        formData: formData ?? {},
       },
     },
   };

--- a/packages/davinci-client/src/lib/fido/fido.test.ts
+++ b/packages/davinci-client/src/lib/fido/fido.test.ts
@@ -1,0 +1,487 @@
+/*
+ * Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { fido } from './fido.js';
+
+import type { FidoClientConfig } from './fido.js';
+import type { FidoRegistrationOptions, FidoAuthenticationOptions } from '../davinci.types';
+import type { GenericError } from '@forgerock/sdk-types';
+
+const silentConfig: FidoClientConfig = { logger: { level: 'none' } };
+
+const mockRegistrationOptions: FidoRegistrationOptions = {
+  rp: { id: 'test.example.com', name: 'Test RP' },
+  user: { id: [1, 2, 3], displayName: 'test@example.com', name: 'Test User' },
+  challenge: [4, 5, 6],
+  pubKeyCredParams: [{ type: 'public-key', alg: '-7' }],
+  timeout: 60000,
+  authenticatorSelection: { userVerification: 'required' },
+  attestation: 'none',
+};
+
+const mockAuthenticationOptions: FidoAuthenticationOptions = {
+  challenge: [4, 5, 6],
+  timeout: 60000,
+  rpId: 'test.example.com',
+  allowCredentials: [{ type: 'public-key', id: [1, 2, 3] }],
+  userVerification: 'required',
+};
+
+function isGenericError(result: unknown): result is GenericError {
+  return typeof result === 'object' && result !== null && 'error' in result;
+}
+
+describe('fido', () => {
+  const originalCredentials = navigator.credentials;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(navigator, 'credentials', {
+      value: originalCredentials,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  describe('register', () => {
+    it('should return GenericError with NotAllowedError code when user cancels', async () => {
+      const mockCreate = vi
+        .fn()
+        .mockRejectedValue(new DOMException('User canceled', 'NotAllowedError'));
+      Object.defineProperty(navigator, 'credentials', {
+        value: { create: mockCreate },
+        writable: true,
+        configurable: true,
+      });
+
+      const fidoClient = fido(silentConfig);
+      const result = await fidoClient.register(mockRegistrationOptions);
+
+      expect(isGenericError(result)).toBe(true);
+      if (isGenericError(result)) {
+        expect(result.code).toBe('NotAllowedError');
+        expect(result.error).toBe('registration_error');
+        expect(result.type).toBe('fido_error');
+        expect(result.message).toContain('NotAllowedError');
+      }
+    });
+
+    it('should return GenericError with AbortError code when operation is aborted', async () => {
+      const mockCreate = vi.fn().mockRejectedValue(new DOMException('Aborted', 'AbortError'));
+      Object.defineProperty(navigator, 'credentials', {
+        value: { create: mockCreate },
+        writable: true,
+        configurable: true,
+      });
+
+      const fidoClient = fido(silentConfig);
+      const result = await fidoClient.register(mockRegistrationOptions);
+
+      expect(isGenericError(result)).toBe(true);
+      if (isGenericError(result)) {
+        expect(result.code).toBe('AbortError');
+        expect(result.error).toBe('registration_error');
+        expect(result.type).toBe('fido_error');
+      }
+    });
+
+    it('should return GenericError with InvalidStateError code when authenticator already registered', async () => {
+      const mockCreate = vi
+        .fn()
+        .mockRejectedValue(new DOMException('Already registered', 'InvalidStateError'));
+      Object.defineProperty(navigator, 'credentials', {
+        value: { create: mockCreate },
+        writable: true,
+        configurable: true,
+      });
+
+      const fidoClient = fido(silentConfig);
+      const result = await fidoClient.register(mockRegistrationOptions);
+
+      expect(isGenericError(result)).toBe(true);
+      if (isGenericError(result)) {
+        expect(result.code).toBe('InvalidStateError');
+        expect(result.error).toBe('registration_error');
+        expect(result.type).toBe('fido_error');
+      }
+    });
+
+    it('should return GenericError with NotSupportedError code when algorithm not supported', async () => {
+      const mockCreate = vi
+        .fn()
+        .mockRejectedValue(new DOMException('Not supported', 'NotSupportedError'));
+      Object.defineProperty(navigator, 'credentials', {
+        value: { create: mockCreate },
+        writable: true,
+        configurable: true,
+      });
+
+      const fidoClient = fido(silentConfig);
+      const result = await fidoClient.register(mockRegistrationOptions);
+
+      expect(isGenericError(result)).toBe(true);
+      if (isGenericError(result)) {
+        expect(result.code).toBe('NotSupportedError');
+        expect(result.error).toBe('registration_error');
+        expect(result.type).toBe('fido_error');
+      }
+    });
+
+    it('should return GenericError with SecurityError code when RP ID mismatch', async () => {
+      const mockCreate = vi
+        .fn()
+        .mockRejectedValue(new DOMException('Security error', 'SecurityError'));
+      Object.defineProperty(navigator, 'credentials', {
+        value: { create: mockCreate },
+        writable: true,
+        configurable: true,
+      });
+
+      const fidoClient = fido(silentConfig);
+      const result = await fidoClient.register(mockRegistrationOptions);
+
+      expect(isGenericError(result)).toBe(true);
+      if (isGenericError(result)) {
+        expect(result.code).toBe('SecurityError');
+        expect(result.error).toBe('registration_error');
+        expect(result.type).toBe('fido_error');
+      }
+    });
+
+    it('should return GenericError with TimeoutError code when operation times out', async () => {
+      const mockCreate = vi.fn().mockRejectedValue(new DOMException('Timeout', 'TimeoutError'));
+      Object.defineProperty(navigator, 'credentials', {
+        value: { create: mockCreate },
+        writable: true,
+        configurable: true,
+      });
+
+      const fidoClient = fido(silentConfig);
+      const result = await fidoClient.register(mockRegistrationOptions);
+
+      expect(isGenericError(result)).toBe(true);
+      if (isGenericError(result)) {
+        expect(result.code).toBe('TimeoutError');
+        expect(result.error).toBe('registration_error');
+        expect(result.type).toBe('fido_error');
+      }
+    });
+
+    it('should return GenericError with UnknownError code for unrecognized errors', async () => {
+      const mockCreate = vi.fn().mockRejectedValue(new Error('Something unexpected'));
+      Object.defineProperty(navigator, 'credentials', {
+        value: { create: mockCreate },
+        writable: true,
+        configurable: true,
+      });
+
+      const fidoClient = fido(silentConfig);
+      const result = await fidoClient.register(mockRegistrationOptions);
+
+      expect(isGenericError(result)).toBe(true);
+      if (isGenericError(result)) {
+        expect(result.code).toBe('UnknownError');
+        expect(result.error).toBe('registration_error');
+        expect(result.type).toBe('fido_error');
+      }
+    });
+
+    it('should return GenericError with UnknownError code when credential is null', async () => {
+      const mockCreate = vi.fn().mockResolvedValue(null);
+      Object.defineProperty(navigator, 'credentials', {
+        value: { create: mockCreate },
+        writable: true,
+        configurable: true,
+      });
+
+      const fidoClient = fido(silentConfig);
+      const result = await fidoClient.register(mockRegistrationOptions);
+
+      expect(isGenericError(result)).toBe(true);
+      if (isGenericError(result)) {
+        expect(result.code).toBe('UnknownError');
+        expect(result.error).toBe('registration_error');
+        expect(result.type).toBe('fido_error');
+        expect(result.message).toContain('No credential returned');
+      }
+    });
+
+    it('should return success value when registration succeeds', async () => {
+      const mockCredential = {
+        id: 'test-credential-id',
+        rawId: new ArrayBuffer(8),
+        type: 'public-key',
+        authenticatorAttachment: 'platform',
+        response: {
+          clientDataJSON: new ArrayBuffer(8),
+          attestationObject: new ArrayBuffer(8),
+        },
+      };
+      const mockCreate = vi.fn().mockResolvedValue(mockCredential);
+      Object.defineProperty(navigator, 'credentials', {
+        value: { create: mockCreate },
+        writable: true,
+        configurable: true,
+      });
+
+      const fidoClient = fido(silentConfig);
+      const result = await fidoClient.register(mockRegistrationOptions);
+
+      expect(isGenericError(result)).toBe(false);
+      expect('attestationValue' in result).toBe(true);
+    });
+  });
+
+  describe('authenticate', () => {
+    it('should return GenericError with NotAllowedError code when user cancels', async () => {
+      const mockGet = vi
+        .fn()
+        .mockRejectedValue(new DOMException('User canceled', 'NotAllowedError'));
+      Object.defineProperty(navigator, 'credentials', {
+        value: { get: mockGet },
+        writable: true,
+        configurable: true,
+      });
+
+      const fidoClient = fido(silentConfig);
+      const result = await fidoClient.authenticate(mockAuthenticationOptions);
+
+      expect(isGenericError(result)).toBe(true);
+      if (isGenericError(result)) {
+        expect(result.code).toBe('NotAllowedError');
+        expect(result.error).toBe('authentication_error');
+        expect(result.type).toBe('fido_error');
+        expect(result.message).toContain('NotAllowedError');
+      }
+    });
+
+    it('should return GenericError with AbortError code when operation is aborted', async () => {
+      const mockGet = vi.fn().mockRejectedValue(new DOMException('Aborted', 'AbortError'));
+      Object.defineProperty(navigator, 'credentials', {
+        value: { get: mockGet },
+        writable: true,
+        configurable: true,
+      });
+
+      const fidoClient = fido(silentConfig);
+      const result = await fidoClient.authenticate(mockAuthenticationOptions);
+
+      expect(isGenericError(result)).toBe(true);
+      if (isGenericError(result)) {
+        expect(result.code).toBe('AbortError');
+        expect(result.error).toBe('authentication_error');
+        expect(result.type).toBe('fido_error');
+      }
+    });
+
+    it('should return GenericError with InvalidStateError code when authenticator not found', async () => {
+      const mockGet = vi.fn().mockRejectedValue(new DOMException('Not found', 'InvalidStateError'));
+      Object.defineProperty(navigator, 'credentials', {
+        value: { get: mockGet },
+        writable: true,
+        configurable: true,
+      });
+
+      const fidoClient = fido(silentConfig);
+      const result = await fidoClient.authenticate(mockAuthenticationOptions);
+
+      expect(isGenericError(result)).toBe(true);
+      if (isGenericError(result)) {
+        expect(result.code).toBe('InvalidStateError');
+        expect(result.error).toBe('authentication_error');
+        expect(result.type).toBe('fido_error');
+      }
+    });
+
+    it('should return GenericError with NotSupportedError code when not supported', async () => {
+      const mockGet = vi
+        .fn()
+        .mockRejectedValue(new DOMException('Not supported', 'NotSupportedError'));
+      Object.defineProperty(navigator, 'credentials', {
+        value: { get: mockGet },
+        writable: true,
+        configurable: true,
+      });
+
+      const fidoClient = fido(silentConfig);
+      const result = await fidoClient.authenticate(mockAuthenticationOptions);
+
+      expect(isGenericError(result)).toBe(true);
+      if (isGenericError(result)) {
+        expect(result.code).toBe('NotSupportedError');
+        expect(result.error).toBe('authentication_error');
+        expect(result.type).toBe('fido_error');
+      }
+    });
+
+    it('should return GenericError with SecurityError code when RP ID mismatch', async () => {
+      const mockGet = vi
+        .fn()
+        .mockRejectedValue(new DOMException('Security error', 'SecurityError'));
+      Object.defineProperty(navigator, 'credentials', {
+        value: { get: mockGet },
+        writable: true,
+        configurable: true,
+      });
+
+      const fidoClient = fido(silentConfig);
+      const result = await fidoClient.authenticate(mockAuthenticationOptions);
+
+      expect(isGenericError(result)).toBe(true);
+      if (isGenericError(result)) {
+        expect(result.code).toBe('SecurityError');
+        expect(result.error).toBe('authentication_error');
+        expect(result.type).toBe('fido_error');
+      }
+    });
+
+    it('should return GenericError with TimeoutError code when operation times out', async () => {
+      const mockGet = vi.fn().mockRejectedValue(new DOMException('Timeout', 'TimeoutError'));
+      Object.defineProperty(navigator, 'credentials', {
+        value: { get: mockGet },
+        writable: true,
+        configurable: true,
+      });
+
+      const fidoClient = fido(silentConfig);
+      const result = await fidoClient.authenticate(mockAuthenticationOptions);
+
+      expect(isGenericError(result)).toBe(true);
+      if (isGenericError(result)) {
+        expect(result.code).toBe('TimeoutError');
+        expect(result.error).toBe('authentication_error');
+        expect(result.type).toBe('fido_error');
+      }
+    });
+
+    it('should return GenericError with UnknownError code for unrecognized errors', async () => {
+      const mockGet = vi.fn().mockRejectedValue(new Error('Something unexpected'));
+      Object.defineProperty(navigator, 'credentials', {
+        value: { get: mockGet },
+        writable: true,
+        configurable: true,
+      });
+
+      const fidoClient = fido(silentConfig);
+      const result = await fidoClient.authenticate(mockAuthenticationOptions);
+
+      expect(isGenericError(result)).toBe(true);
+      if (isGenericError(result)) {
+        expect(result.code).toBe('UnknownError');
+        expect(result.error).toBe('authentication_error');
+        expect(result.type).toBe('fido_error');
+      }
+    });
+
+    it('should return GenericError with UnknownError code when assertion is null', async () => {
+      const mockGet = vi.fn().mockResolvedValue(null);
+      Object.defineProperty(navigator, 'credentials', {
+        value: { get: mockGet },
+        writable: true,
+        configurable: true,
+      });
+
+      const fidoClient = fido(silentConfig);
+      const result = await fidoClient.authenticate(mockAuthenticationOptions);
+
+      expect(isGenericError(result)).toBe(true);
+      if (isGenericError(result)) {
+        expect(result.code).toBe('UnknownError');
+        expect(result.error).toBe('authentication_error');
+        expect(result.type).toBe('fido_error');
+        expect(result.message).toContain('No credential returned');
+      }
+    });
+
+    it('should return success value when authentication succeeds', async () => {
+      const mockAssertion = {
+        id: 'test-credential-id',
+        rawId: new ArrayBuffer(8),
+        type: 'public-key',
+        authenticatorAttachment: 'platform',
+        response: {
+          clientDataJSON: new ArrayBuffer(8),
+          authenticatorData: new ArrayBuffer(8),
+          signature: new ArrayBuffer(8),
+          userHandle: new ArrayBuffer(8),
+        },
+      };
+      const mockGet = vi.fn().mockResolvedValue(mockAssertion);
+      Object.defineProperty(navigator, 'credentials', {
+        value: { get: mockGet },
+        writable: true,
+        configurable: true,
+      });
+
+      const fidoClient = fido(silentConfig);
+      const result = await fidoClient.authenticate(mockAuthenticationOptions);
+
+      expect(isGenericError(result)).toBe(false);
+      expect('assertionValue' in result).toBe(true);
+    });
+  });
+
+  describe('error detection pattern', () => {
+    it('should allow consumers to detect errors using "error" in result', async () => {
+      const mockCreate = vi
+        .fn()
+        .mockRejectedValue(new DOMException('User canceled', 'NotAllowedError'));
+      Object.defineProperty(navigator, 'credentials', {
+        value: { create: mockCreate },
+        writable: true,
+        configurable: true,
+      });
+
+      const fidoClient = fido(silentConfig);
+      const result = await fidoClient.register(mockRegistrationOptions);
+
+      if ('error' in result) {
+        expect(result.error).toBe('registration_error');
+        expect(result.code).toBe('NotAllowedError');
+      } else {
+        expect.fail('Expected an error result');
+      }
+    });
+  });
+
+  describe('logger configuration', () => {
+    it('should accept optional logger configuration', async () => {
+      const mockCreate = vi
+        .fn()
+        .mockRejectedValue(new DOMException('User canceled', 'NotAllowedError'));
+      Object.defineProperty(navigator, 'credentials', {
+        value: { create: mockCreate },
+        writable: true,
+        configurable: true,
+      });
+
+      const fidoClient = fido(silentConfig);
+      const result = await fidoClient.register(mockRegistrationOptions);
+
+      expect(isGenericError(result)).toBe(true);
+    });
+
+    it('should work without logger configuration', async () => {
+      const mockCreate = vi
+        .fn()
+        .mockRejectedValue(new DOMException('User canceled', 'NotAllowedError'));
+      Object.defineProperty(navigator, 'credentials', {
+        value: { create: mockCreate },
+        writable: true,
+        configurable: true,
+      });
+
+      const fidoClient = fido();
+      const result = await fidoClient.register(mockRegistrationOptions);
+
+      expect(isGenericError(result)).toBe(true);
+    });
+  });
+});

--- a/packages/davinci-client/src/lib/fido/fido.test.ts
+++ b/packages/davinci-client/src/lib/fido/fido.test.ts
@@ -7,11 +7,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { fido } from './fido.js';
 
-import type { FidoClientConfig } from './fido.js';
 import type { FidoRegistrationOptions, FidoAuthenticationOptions } from '../davinci.types';
 import type { GenericError } from '@forgerock/sdk-types';
-
-const silentConfig: FidoClientConfig = { logger: { level: 'none' } };
 
 const mockRegistrationOptions: FidoRegistrationOptions = {
   rp: { id: 'test.example.com', name: 'Test RP' },
@@ -61,7 +58,7 @@ describe('fido', () => {
         configurable: true,
       });
 
-      const fidoClient = fido(silentConfig);
+      const fidoClient = fido();
       const result = await fidoClient.register(mockRegistrationOptions);
 
       expect(isGenericError(result)).toBe(true);
@@ -81,7 +78,7 @@ describe('fido', () => {
         configurable: true,
       });
 
-      const fidoClient = fido(silentConfig);
+      const fidoClient = fido();
       const result = await fidoClient.register(mockRegistrationOptions);
 
       expect(isGenericError(result)).toBe(true);
@@ -102,7 +99,7 @@ describe('fido', () => {
         configurable: true,
       });
 
-      const fidoClient = fido(silentConfig);
+      const fidoClient = fido();
       const result = await fidoClient.register(mockRegistrationOptions);
 
       expect(isGenericError(result)).toBe(true);
@@ -123,7 +120,7 @@ describe('fido', () => {
         configurable: true,
       });
 
-      const fidoClient = fido(silentConfig);
+      const fidoClient = fido();
       const result = await fidoClient.register(mockRegistrationOptions);
 
       expect(isGenericError(result)).toBe(true);
@@ -144,7 +141,7 @@ describe('fido', () => {
         configurable: true,
       });
 
-      const fidoClient = fido(silentConfig);
+      const fidoClient = fido();
       const result = await fidoClient.register(mockRegistrationOptions);
 
       expect(isGenericError(result)).toBe(true);
@@ -163,7 +160,7 @@ describe('fido', () => {
         configurable: true,
       });
 
-      const fidoClient = fido(silentConfig);
+      const fidoClient = fido();
       const result = await fidoClient.register(mockRegistrationOptions);
 
       expect(isGenericError(result)).toBe(true);
@@ -182,7 +179,7 @@ describe('fido', () => {
         configurable: true,
       });
 
-      const fidoClient = fido(silentConfig);
+      const fidoClient = fido();
       const result = await fidoClient.register(mockRegistrationOptions);
 
       expect(isGenericError(result)).toBe(true);
@@ -201,7 +198,7 @@ describe('fido', () => {
         configurable: true,
       });
 
-      const fidoClient = fido(silentConfig);
+      const fidoClient = fido();
       const result = await fidoClient.register(mockRegistrationOptions);
 
       expect(isGenericError(result)).toBe(true);
@@ -231,7 +228,7 @@ describe('fido', () => {
         configurable: true,
       });
 
-      const fidoClient = fido(silentConfig);
+      const fidoClient = fido();
       const result = await fidoClient.register(mockRegistrationOptions);
 
       expect(isGenericError(result)).toBe(false);
@@ -250,7 +247,7 @@ describe('fido', () => {
         configurable: true,
       });
 
-      const fidoClient = fido(silentConfig);
+      const fidoClient = fido();
       const result = await fidoClient.authenticate(mockAuthenticationOptions);
 
       expect(isGenericError(result)).toBe(true);
@@ -270,7 +267,7 @@ describe('fido', () => {
         configurable: true,
       });
 
-      const fidoClient = fido(silentConfig);
+      const fidoClient = fido();
       const result = await fidoClient.authenticate(mockAuthenticationOptions);
 
       expect(isGenericError(result)).toBe(true);
@@ -289,7 +286,7 @@ describe('fido', () => {
         configurable: true,
       });
 
-      const fidoClient = fido(silentConfig);
+      const fidoClient = fido();
       const result = await fidoClient.authenticate(mockAuthenticationOptions);
 
       expect(isGenericError(result)).toBe(true);
@@ -310,7 +307,7 @@ describe('fido', () => {
         configurable: true,
       });
 
-      const fidoClient = fido(silentConfig);
+      const fidoClient = fido();
       const result = await fidoClient.authenticate(mockAuthenticationOptions);
 
       expect(isGenericError(result)).toBe(true);
@@ -331,7 +328,7 @@ describe('fido', () => {
         configurable: true,
       });
 
-      const fidoClient = fido(silentConfig);
+      const fidoClient = fido();
       const result = await fidoClient.authenticate(mockAuthenticationOptions);
 
       expect(isGenericError(result)).toBe(true);
@@ -350,7 +347,7 @@ describe('fido', () => {
         configurable: true,
       });
 
-      const fidoClient = fido(silentConfig);
+      const fidoClient = fido();
       const result = await fidoClient.authenticate(mockAuthenticationOptions);
 
       expect(isGenericError(result)).toBe(true);
@@ -369,7 +366,7 @@ describe('fido', () => {
         configurable: true,
       });
 
-      const fidoClient = fido(silentConfig);
+      const fidoClient = fido();
       const result = await fidoClient.authenticate(mockAuthenticationOptions);
 
       expect(isGenericError(result)).toBe(true);
@@ -388,7 +385,7 @@ describe('fido', () => {
         configurable: true,
       });
 
-      const fidoClient = fido(silentConfig);
+      const fidoClient = fido();
       const result = await fidoClient.authenticate(mockAuthenticationOptions);
 
       expect(isGenericError(result)).toBe(true);
@@ -420,7 +417,7 @@ describe('fido', () => {
         configurable: true,
       });
 
-      const fidoClient = fido(silentConfig);
+      const fidoClient = fido();
       const result = await fidoClient.authenticate(mockAuthenticationOptions);
 
       expect(isGenericError(result)).toBe(false);
@@ -439,7 +436,7 @@ describe('fido', () => {
         configurable: true,
       });
 
-      const fidoClient = fido(silentConfig);
+      const fidoClient = fido();
       const result = await fidoClient.register(mockRegistrationOptions);
 
       if ('error' in result) {
@@ -462,7 +459,7 @@ describe('fido', () => {
         configurable: true,
       });
 
-      const fidoClient = fido(silentConfig);
+      const fidoClient = fido();
       const result = await fidoClient.register(mockRegistrationOptions);
 
       expect(isGenericError(result)).toBe(true);

--- a/packages/davinci-client/src/lib/fido/fido.ts
+++ b/packages/davinci-client/src/lib/fido/fido.ts
@@ -1,12 +1,16 @@
 /*
- * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
  */
 import { Micro } from 'effect';
 import { exitIsFail, exitIsSuccess } from 'effect/Micro';
+
+import { logger as loggerFn } from '@forgerock/sdk-logger';
 import {
+  toFidoErrorCode,
+  createFidoError,
   transformAssertion,
   transformAuthenticationOptions,
   transformPublicKeyCredential,
@@ -14,40 +18,25 @@ import {
 } from './fido.utils.js';
 
 import type { GenericError } from '@forgerock/sdk-types';
+import type { FidoClient, FidoClientConfig } from './fido.types.js';
+
+export type { FidoClientConfig };
 import type {
   FidoAuthenticationInputValue,
   FidoRegistrationInputValue,
 } from '../collector.types.js';
 import type { FidoAuthenticationOptions, FidoRegistrationOptions } from '../davinci.types.js';
 
-export interface FidoClient {
-  /**
-   * Create a keypair and get the public key credential to send back to DaVinci for registration
-   * @function register
-   * @param { FidoRegistrationOptions } options - DaVinci FIDO registration options
-   * @returns { Promise<FidoRegistrationInputValue | GenericError> } - The formatted credential for DaVinci or an error
-   */
-  register: (
-    options: FidoRegistrationOptions,
-  ) => Promise<FidoRegistrationInputValue | GenericError>;
-  /**
-   * Get an assertion to send back to DaVinci for authentication
-   * @function authenticate
-   * @param { FidoAuthenticationOptions } options - DaVinci FIDO authentication options
-   * @returns { Promise<FidoAuthenticationInputValue | GenericError> } - The formatted assertion for DaVinci or an error
-   */
-  authenticate: (
-    options: FidoAuthenticationOptions,
-  ) => Promise<FidoAuthenticationInputValue | GenericError>;
-}
-
 /**
  * A client function that returns a set of methods for transforming DaVinci data and
  * interacting with the WebAuthn API for registration and authentication
  * @function fido
+ * @param { FidoClientConfig } [config] - Optional configuration for the FIDO client
  * @returns {FidoClient} - A set of methods for FIDO registration and authentication
  */
-export function fido(): FidoClient {
+export function fido(config?: FidoClientConfig): FidoClient {
+  const log = loggerFn({ level: config?.logger?.level ?? 'error', custom: config?.logger?.custom });
+
   return {
     /**
      * Call WebAuthn API to create keypair and get public key credential
@@ -56,11 +45,11 @@ export function fido(): FidoClient {
       options: FidoRegistrationOptions,
     ): Promise<FidoRegistrationInputValue | GenericError> {
       if (!options) {
-        return {
-          error: 'registration_error',
-          message: 'FIDO registration failed: No options available',
-          type: 'fido_error',
-        } as GenericError;
+        return createFidoError(
+          'UnknownError',
+          'registration_error',
+          'FIDO registration failed: No options available',
+        );
       }
 
       const createCredentialµ = Micro.sync(() => transformRegistrationOptions(options)).pipe(
@@ -71,28 +60,27 @@ export function fido(): FidoClient {
                 publicKey: publicKeyCredentialCreationOptions,
               }),
             catch: (error) => {
-              console.error('Failed to create keypair: ', error);
-              return {
-                error: 'registration_error',
-                message: 'FIDO registration failed',
-                type: 'fido_error',
-              } as GenericError;
+              const code = toFidoErrorCode(error);
+              log.error('Failed to create keypair: ', code);
+              return createFidoError(
+                code,
+                'registration_error',
+                `FIDO registration failed: ${code}`,
+              );
             },
           }),
         ),
         Micro.flatMap((credential) => {
           if (!credential) {
-            return Micro.fail({
-              error: 'registration_error',
-              message: 'FIDO registration failed: No credential returned',
-              type: 'fido_error',
-            } as GenericError);
-          } else {
-            const formattedCredential = transformPublicKeyCredential(
-              credential as PublicKeyCredential,
+            return Micro.fail(
+              createFidoError(
+                'UnknownError',
+                'registration_error',
+                'FIDO registration failed: No credential returned',
+              ),
             );
-            return Micro.succeed(formattedCredential);
           }
+          return Micro.succeed(transformPublicKeyCredential(credential as PublicKeyCredential));
         }),
       );
 
@@ -103,13 +91,10 @@ export function fido(): FidoClient {
       } else if (exitIsFail(result)) {
         return result.cause.error;
       } else {
-        return {
-          error: 'fido_registration_error',
-          message: result.cause.message,
-          type: 'unknown_error',
-        };
+        return createFidoError('UnknownError', 'registration_error', result.cause.message);
       }
     },
+
     /**
      * Call WebAuthn API to get assertion
      */
@@ -117,11 +102,11 @@ export function fido(): FidoClient {
       options: FidoAuthenticationOptions,
     ): Promise<FidoAuthenticationInputValue | GenericError> {
       if (!options) {
-        return {
-          error: 'authentication_error',
-          message: 'FIDO authentication failed: No options available',
-          type: 'fido_error',
-        } as GenericError;
+        return createFidoError(
+          'UnknownError',
+          'authentication_error',
+          'FIDO authentication failed: No options available',
+        );
       }
 
       const getAssertionµ = Micro.sync(() => transformAuthenticationOptions(options)).pipe(
@@ -132,26 +117,27 @@ export function fido(): FidoClient {
                 publicKey: publicKeyCredentialRequestOptions,
               }),
             catch: (error) => {
-              console.error('Failed to authenticate: ', error);
-              return {
-                error: 'authentication_error',
-                message: 'FIDO authentication failed',
-                type: 'fido_error',
-              } as GenericError;
+              const code = toFidoErrorCode(error);
+              log.error('Failed to authenticate: ', code);
+              return createFidoError(
+                code,
+                'authentication_error',
+                `FIDO authentication failed: ${code}`,
+              );
             },
           }),
         ),
         Micro.flatMap((assertion) => {
           if (!assertion) {
-            return Micro.fail({
-              error: 'authentication_error',
-              message: 'FIDO authentication failed: No credential returned',
-              type: 'fido_error',
-            } as GenericError);
-          } else {
-            const formattedAssertion = transformAssertion(assertion as PublicKeyCredential);
-            return Micro.succeed(formattedAssertion);
+            return Micro.fail(
+              createFidoError(
+                'UnknownError',
+                'authentication_error',
+                'FIDO authentication failed: No credential returned',
+              ),
+            );
           }
+          return Micro.succeed(transformAssertion(assertion as PublicKeyCredential));
         }),
       );
 
@@ -162,11 +148,7 @@ export function fido(): FidoClient {
       } else if (exitIsFail(result)) {
         return result.cause.error;
       } else {
-        return {
-          error: 'fido_authentication_error',
-          message: result.cause.message,
-          type: 'unknown_error',
-        };
+        return createFidoError('UnknownError', 'authentication_error', result.cause.message);
       }
     },
   };

--- a/packages/davinci-client/src/lib/fido/fido.ts
+++ b/packages/davinci-client/src/lib/fido/fido.ts
@@ -7,7 +7,6 @@
 import { Micro } from 'effect';
 import { exitIsFail, exitIsSuccess } from 'effect/Micro';
 
-import { logger as loggerFn } from '@forgerock/sdk-logger';
 import {
   toFidoErrorCode,
   createFidoError,
@@ -18,9 +17,7 @@ import {
 } from './fido.utils.js';
 
 import type { GenericError } from '@forgerock/sdk-types';
-import type { FidoClient, FidoClientConfig } from './fido.types.js';
-
-export type { FidoClientConfig };
+import type { FidoClient } from './fido.types.js';
 import type {
   FidoAuthenticationInputValue,
   FidoRegistrationInputValue,
@@ -31,12 +28,9 @@ import type { FidoAuthenticationOptions, FidoRegistrationOptions } from '../davi
  * A client function that returns a set of methods for transforming DaVinci data and
  * interacting with the WebAuthn API for registration and authentication
  * @function fido
- * @param { FidoClientConfig } [config] - Optional configuration for the FIDO client
  * @returns {FidoClient} - A set of methods for FIDO registration and authentication
  */
-export function fido(config?: FidoClientConfig): FidoClient {
-  const log = loggerFn({ level: config?.logger?.level ?? 'error', custom: config?.logger?.custom });
-
+export function fido(): FidoClient {
   return {
     /**
      * Call WebAuthn API to create keypair and get public key credential
@@ -61,7 +55,7 @@ export function fido(config?: FidoClientConfig): FidoClient {
               }),
             catch: (error) => {
               const code = toFidoErrorCode(error);
-              log.error('Failed to create keypair: ', code);
+              console.error('Failed to create keypair: ', code);
               return createFidoError(
                 code,
                 'registration_error',
@@ -118,7 +112,7 @@ export function fido(config?: FidoClientConfig): FidoClient {
               }),
             catch: (error) => {
               const code = toFidoErrorCode(error);
-              log.error('Failed to authenticate: ', code);
+              console.error('Failed to authenticate: ', code);
               return createFidoError(
                 code,
                 'authentication_error',

--- a/packages/davinci-client/src/lib/fido/fido.types.test.ts
+++ b/packages/davinci-client/src/lib/fido/fido.types.test.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+import { describe, it, expect } from 'vitest';
+import { toFidoErrorCode } from './fido.utils';
+
+describe('toFidoErrorCode', () => {
+  it('should return NotAllowedError for DOMException with name NotAllowedError', () => {
+    const error = new DOMException('User canceled', 'NotAllowedError');
+    expect(toFidoErrorCode(error)).toBe('NotAllowedError');
+  });
+
+  it('should return AbortError for DOMException with name AbortError', () => {
+    const error = new DOMException('Operation aborted', 'AbortError');
+    expect(toFidoErrorCode(error)).toBe('AbortError');
+  });
+
+  it('should return InvalidStateError for DOMException with name InvalidStateError', () => {
+    const error = new DOMException('Invalid state', 'InvalidStateError');
+    expect(toFidoErrorCode(error)).toBe('InvalidStateError');
+  });
+
+  it('should return NotSupportedError for DOMException with name NotSupportedError', () => {
+    const error = new DOMException('Not supported', 'NotSupportedError');
+    expect(toFidoErrorCode(error)).toBe('NotSupportedError');
+  });
+
+  it('should return SecurityError for DOMException with name SecurityError', () => {
+    const error = new DOMException('Security error', 'SecurityError');
+    expect(toFidoErrorCode(error)).toBe('SecurityError');
+  });
+
+  it('should return TimeoutError for DOMException with name TimeoutError', () => {
+    const error = new DOMException('Timeout', 'TimeoutError');
+    expect(toFidoErrorCode(error)).toBe('TimeoutError');
+  });
+
+  it('should return UnknownError for standard Error', () => {
+    const error = new Error('Something went wrong');
+    expect(toFidoErrorCode(error)).toBe('UnknownError');
+  });
+
+  it('should return UnknownError for non-Error values', () => {
+    expect(toFidoErrorCode('string error')).toBe('UnknownError');
+    expect(toFidoErrorCode(null)).toBe('UnknownError');
+    expect(toFidoErrorCode(undefined)).toBe('UnknownError');
+    expect(toFidoErrorCode(42)).toBe('UnknownError');
+    expect(toFidoErrorCode({})).toBe('UnknownError');
+  });
+
+  it('should return UnknownError for DOMException with unrecognized name', () => {
+    const error = new DOMException('Network failed', 'NetworkError');
+    expect(toFidoErrorCode(error)).toBe('UnknownError');
+  });
+});

--- a/packages/davinci-client/src/lib/fido/fido.types.ts
+++ b/packages/davinci-client/src/lib/fido/fido.types.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+import type { CustomLogger } from '@forgerock/sdk-logger';
+import type { GenericError, LogLevel } from '@forgerock/sdk-types';
+import type {
+  FidoRegistrationInputValue,
+  FidoAuthenticationInputValue,
+} from '../collector.types.js';
+import type { FidoRegistrationOptions, FidoAuthenticationOptions } from '../davinci.types.js';
+
+export interface FidoClientConfig {
+  logger?: {
+    level?: LogLevel;
+    custom?: CustomLogger;
+  };
+}
+
+export interface FidoClient {
+  /**
+   * Create a keypair and get the public key credential to send back to DaVinci for registration
+   * @function register
+   * @param { FidoRegistrationOptions } options - DaVinci FIDO registration options
+   * @returns { Promise<FidoRegistrationInputValue | GenericError> } - The formatted credential for DaVinci or an error with WebAuthn error code in `code` field
+   */
+  register: (
+    options: FidoRegistrationOptions,
+  ) => Promise<FidoRegistrationInputValue | GenericError>;
+  /**
+   * Get an assertion to send back to DaVinci for authentication
+   * @function authenticate
+   * @param { FidoAuthenticationOptions } options - DaVinci FIDO authentication options
+   * @returns { Promise<FidoAuthenticationInputValue | GenericError> } - The formatted assertion for DaVinci or an error with WebAuthn error code in `code` field
+   */
+  authenticate: (
+    options: FidoAuthenticationOptions,
+  ) => Promise<FidoAuthenticationInputValue | GenericError>;
+}
+
+/**
+ * WebAuthn error codes that can occur during FIDO operations.
+ * These align with standard DOMException names from the WebAuthn specification.
+ * Used in the `code` field of GenericError when a FIDO operation fails.
+ */
+export type FidoErrorCode =
+  | 'NotAllowedError'
+  | 'AbortError'
+  | 'InvalidStateError'
+  | 'NotSupportedError'
+  | 'SecurityError'
+  | 'TimeoutError'
+  | 'UnknownError';

--- a/packages/davinci-client/src/lib/fido/fido.types.ts
+++ b/packages/davinci-client/src/lib/fido/fido.types.ts
@@ -5,20 +5,12 @@
  * of the MIT license. See the LICENSE file for details.
  */
 
-import type { CustomLogger } from '@forgerock/sdk-logger';
-import type { GenericError, LogLevel } from '@forgerock/sdk-types';
+import type { GenericError } from '@forgerock/sdk-types';
 import type {
   FidoRegistrationInputValue,
   FidoAuthenticationInputValue,
 } from '../collector.types.js';
 import type { FidoRegistrationOptions, FidoAuthenticationOptions } from '../davinci.types.js';
-
-export interface FidoClientConfig {
-  logger?: {
-    level?: LogLevel;
-    custom?: CustomLogger;
-  };
-}
 
 export interface FidoClient {
   /**

--- a/packages/davinci-client/src/lib/fido/fido.utils.ts
+++ b/packages/davinci-client/src/lib/fido/fido.utils.ts
@@ -1,14 +1,16 @@
 /*
- * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
  */
+import type { GenericError } from '@forgerock/sdk-types';
 import type {
   FidoAuthenticationInputValue,
   FidoRegistrationInputValue,
 } from '../collector.types.js';
 import type { FidoAuthenticationOptions, FidoRegistrationOptions } from '../davinci.types.js';
+import type { FidoErrorCode } from './fido.types.js';
 
 function convertArrayToBuffer(arr: number[]): ArrayBuffer {
   return new Int8Array(arr).buffer;
@@ -137,5 +139,59 @@ export function transformAssertion(credential: PublicKeyCredential): FidoAuthent
         userHandle,
       },
     },
+  };
+}
+
+const VALID_FIDO_ERROR_CODES: ReadonlySet<FidoErrorCode> = new Set([
+  'NotAllowedError',
+  'AbortError',
+  'InvalidStateError',
+  'NotSupportedError',
+  'SecurityError',
+  'TimeoutError',
+]);
+
+function isErrorWithName(error: unknown): error is { name: string } {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'name' in error &&
+    typeof (error as { name: unknown }).name === 'string'
+  );
+}
+
+function isFidoErrorCode(name: string): name is FidoErrorCode {
+  return VALID_FIDO_ERROR_CODES.has(name as FidoErrorCode);
+}
+
+/**
+ * Maps an error to a FidoErrorCode.
+ * @param error - The error from WebAuthn API
+ * @returns The corresponding FidoErrorCode
+ */
+export function toFidoErrorCode(error: unknown): FidoErrorCode {
+  if (isErrorWithName(error) && isFidoErrorCode(error.name)) {
+    return error.name;
+  }
+  return 'UnknownError';
+}
+
+/**
+ * Creates a GenericError for FIDO operations with proper typing.
+ * @param code - The WebAuthn error code
+ * @param errorType - The error category (e.g., 'registration_error', 'authentication_error')
+ * @param message - Human-readable error message
+ * @returns A properly typed GenericError
+ */
+export function createFidoError(
+  code: FidoErrorCode,
+  errorType: string,
+  message: string,
+): GenericError {
+  return {
+    code,
+    error: errorType,
+    message,
+    type: 'fido_error',
   };
 }

--- a/packages/davinci-client/src/lib/node.reducer.test.ts
+++ b/packages/davinci-client/src/lib/node.reducer.test.ts
@@ -28,6 +28,7 @@ import type {
   BooleanCollector,
   ValidatedBooleanCollector,
 } from './collector.types.js';
+import type { GenericError } from '@forgerock/sdk-types';
 import type { FidoAuthenticationOptions, FidoRegistrationOptions } from './davinci.types.js';
 
 describe('The node collector reducer', () => {
@@ -1266,6 +1267,85 @@ describe('The node collector reducer with ProtectFieldValue', () => {
 });
 
 describe('The node collector reducer with FidoRegistrationFieldValue', () => {
+  it('should store a GenericError on collector.error when a FIDO error is passed as value', () => {
+    const fidoError: GenericError = {
+      code: 'NotAllowedError',
+      error: 'registration_error',
+      message: 'FIDO registration failed: NotAllowedError',
+      type: 'fido_error',
+    };
+    const publicKeyCredentialCreationOptions: FidoRegistrationOptions = {
+      rp: { name: 'Example RP', id: 'example.com' },
+      user: { id: [1], displayName: 'Test User', name: 'testuser' },
+      challenge: [1, 2, 3, 4],
+      pubKeyCredParams: [{ type: 'public-key', alg: -7 }],
+      timeout: 60000,
+      authenticatorSelection: {
+        residentKey: 'required',
+        requireResidentKey: true,
+        userVerification: 'required',
+      },
+      attestation: 'none',
+      extensions: { credProps: true, hmacCreateSecret: true },
+    };
+    const action = {
+      type: 'node/update',
+      payload: {
+        id: 'fido2-registration-0',
+        value: fidoError,
+      },
+    };
+    const state: FidoRegistrationCollector[] = [
+      {
+        category: 'ObjectValueAutoCollector',
+        error: null,
+        type: 'FidoRegistrationCollector',
+        id: 'fido2-registration-0',
+        name: 'fido2-registration',
+        input: {
+          key: 'fido2-registration',
+          value: {},
+          type: 'FIDO2',
+          validation: null,
+        },
+        output: {
+          key: 'fido2-registration',
+          type: 'FIDO2',
+          config: {
+            publicKeyCredentialCreationOptions,
+            action: 'REGISTER',
+            trigger: 'BUTTON',
+          },
+        },
+      },
+    ];
+
+    expect(nodeCollectorReducer(state, action)).toStrictEqual([
+      {
+        category: 'ObjectValueAutoCollector',
+        error: null,
+        type: 'FidoRegistrationCollector',
+        id: 'fido2-registration-0',
+        name: 'fido2-registration',
+        input: {
+          key: 'fido2-registration',
+          value: fidoError,
+          type: 'FIDO2',
+          validation: null,
+        },
+        output: {
+          key: 'fido2-registration',
+          type: 'FIDO2',
+          config: {
+            publicKeyCredentialCreationOptions,
+            action: 'REGISTER',
+            trigger: 'BUTTON',
+          },
+        },
+      },
+    ]);
+  });
+
   it('should handle collector updates ', () => {
     // todo: declare inputValue type as FidoRegistrationInputValue
     const mockInputValue = {
@@ -2095,6 +2175,78 @@ describe('The node collector reducer with BooleanCollector', () => {
 });
 
 describe('The node collector reducer with FidoAuthenticationFieldValue', () => {
+  it('should store a GenericError on collector.error when a FIDO error is passed as value', () => {
+    const fidoError: GenericError = {
+      code: 'TimeoutError',
+      error: 'authentication_error',
+      message: 'FIDO authentication failed: TimeoutError',
+      type: 'fido_error',
+    };
+    const publicKeyCredentialRequestOptions: FidoAuthenticationOptions = {
+      challenge: [1, 2, 3, 4],
+      timeout: 60000,
+      rpId: 'example.com',
+      allowCredentials: [{ type: 'public-key', id: [1, 2, 3, 4] }],
+      userVerification: 'preferred',
+    };
+    const action = {
+      type: 'node/update',
+      payload: {
+        id: 'fido2-authentication-0',
+        value: fidoError,
+      },
+    };
+    const state: FidoAuthenticationCollector[] = [
+      {
+        category: 'ObjectValueAutoCollector',
+        error: null,
+        type: 'FidoAuthenticationCollector',
+        id: 'fido2-authentication-0',
+        name: 'fido2-authentication',
+        input: {
+          key: 'fido2-authentication',
+          value: {},
+          type: 'FIDO2',
+          validation: null,
+        },
+        output: {
+          key: 'fido2-authentication',
+          type: 'FIDO2',
+          config: {
+            publicKeyCredentialRequestOptions,
+            action: 'AUTHENTICATE',
+            trigger: 'BUTTON',
+          },
+        },
+      },
+    ];
+
+    expect(nodeCollectorReducer(state, action)).toStrictEqual([
+      {
+        category: 'ObjectValueAutoCollector',
+        error: null,
+        type: 'FidoAuthenticationCollector',
+        id: 'fido2-authentication-0',
+        name: 'fido2-authentication',
+        input: {
+          key: 'fido2-authentication',
+          value: fidoError,
+          type: 'FIDO2',
+          validation: null,
+        },
+        output: {
+          key: 'fido2-authentication',
+          type: 'FIDO2',
+          config: {
+            publicKeyCredentialRequestOptions,
+            action: 'AUTHENTICATE',
+            trigger: 'BUTTON',
+          },
+        },
+      },
+    ]);
+  });
+
   it('should handle collector updates ', () => {
     // todo: declare inputValue type as FidoAuthenticationInputValue
     const mockInputValue = {

--- a/packages/davinci-client/src/lib/node.reducer.test.ts
+++ b/packages/davinci-client/src/lib/node.reducer.test.ts
@@ -1267,7 +1267,7 @@ describe('The node collector reducer with ProtectFieldValue', () => {
 });
 
 describe('The node collector reducer with FidoRegistrationFieldValue', () => {
-  it('should store a GenericError on collector.error when a FIDO error is passed as value', () => {
+  it('should store a GenericError on input.value when a FIDO error is passed as value', () => {
     const fidoError: GenericError = {
       code: 'NotAllowedError',
       error: 'registration_error',
@@ -2175,7 +2175,7 @@ describe('The node collector reducer with BooleanCollector', () => {
 });
 
 describe('The node collector reducer with FidoAuthenticationFieldValue', () => {
-  it('should store a GenericError on collector.error when a FIDO error is passed as value', () => {
+  it('should store a GenericError on input.value when a FIDO error is passed as value', () => {
     const fidoError: GenericError = {
       code: 'TimeoutError',
       error: 'authentication_error',

--- a/packages/davinci-client/src/lib/node.reducer.ts
+++ b/packages/davinci-client/src/lib/node.reducer.ts
@@ -36,8 +36,14 @@ import {
   returnQrCodeCollector,
   returnImageCollector,
 } from './collector.utils.js';
+import type { GenericError } from '@forgerock/sdk-types';
 import type { DaVinciField, UnknownField } from './davinci.types.js';
-import type { PhoneNumberOutputValue, PhoneNumberExtensionOutputValue } from './collector.types.js';
+import type {
+  FidoRegistrationInputValue,
+  FidoAuthenticationInputValue,
+  PhoneNumberOutputValue,
+  PhoneNumberExtensionOutputValue,
+} from './collector.types.js';
 import type { CollectorValueTypes } from './client.types.js';
 import type { Collectors } from './node.types.js';
 
@@ -320,10 +326,12 @@ export const nodeCollectorReducer = createReducer(initialCollectorValues, (build
         if (typeof action.payload.value !== 'object') {
           throw new Error('Value argument must be an object');
         }
-        if (!('attestationValue' in action.payload.value)) {
+        const isFidoError =
+          'type' in action.payload.value && action.payload.value.type === 'fido_error';
+        if (!isFidoError && !('attestationValue' in action.payload.value)) {
           throw new Error('Value argument must contain an attestationValue property');
         }
-        collector.input.value = action.payload.value;
+        collector.input.value = action.payload.value as FidoRegistrationInputValue | GenericError;
       }
 
       if (collector.type === 'FidoAuthenticationCollector') {
@@ -333,10 +341,12 @@ export const nodeCollectorReducer = createReducer(initialCollectorValues, (build
         if (typeof action.payload.value !== 'object') {
           throw new Error('Value argument must be an object');
         }
-        if (!('assertionValue' in action.payload.value)) {
+        const isFidoError =
+          'type' in action.payload.value && action.payload.value.type === 'fido_error';
+        if (!isFidoError && !('assertionValue' in action.payload.value)) {
           throw new Error('Value argument must contain an assertionValue property');
         }
-        collector.input.value = action.payload.value;
+        collector.input.value = action.payload.value as FidoAuthenticationInputValue | GenericError;
       }
 
       if (collector.type === 'MetadataCollector') {

--- a/packages/davinci-client/src/types.ts
+++ b/packages/davinci-client/src/types.ts
@@ -24,7 +24,7 @@ export * from './lib/node.types.js';
 export * from './lib/collector.types.js';
 
 // Fido types
-export type { FidoClient } from './lib/fido/fido.js';
+export * from './lib/fido/fido.types.js';
 
 // Node slice and reducer exports needed to resolve DavinciClient
 export {


### PR DESCRIPTION
# JIRA Ticket

https://pingidentity.atlassian.net/browse/SDKS-4480

## Description

- Adds support for sending FIDO errors to DaVinci with e2e tests (currently skipped but can be run manually)
- Migrates MFA flow to new env and updates client IDs and flow policies in e2e tests
- Fixes a false positive with password policy e2e test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent FIDO/WebAuthn error handling with recognized error codes and fallback support.
  * FIDO registration/authentication results and DaVinci requests now propagate structured FIDO errors (including updated TypeScript typings).
  * Added optional FIDO client configuration, including logger settings.

* **Bug Fixes**
  * Improved FIDO flow behavior so error cases follow the expected update/submit path and render the correct error states.

* **Tests**
  * Expanded FIDO/WebAuthn success, cancellation, and error coverage across relevant suites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->