### PR TITLE
fix(oidc-client): forward loginHint, acrValues, query via buildAuthorizeOptions

### DIFF
--- a/packages/oidc-client/src/lib/authorize.request.utils.test.ts
+++ b/packages/oidc-client/src/lib/authorize.request.utils.test.ts
@@ -375,6 +375,50 @@ it('buildAuthorizeOptions falls back to "openid" scope and "code" responseType w
   expect(opts.responseType).toBe('code');
 });
 
+it('buildAuthorizeOptions forwards loginHint, acrValues and query from config', () => {
+  const configWithHints: OidcConfig = {
+    ...config,
+    loginHint: 'user@example.com',
+    acrValues: 'urn:acr:example',
+    query: { ui_locales: 'en-US' },
+  };
+  const [, opts] = buildAuthorizeOptions(wellknown, configWithHints);
+  expect(opts.loginHint).toBe('user@example.com');
+  expect(opts.acrValues).toBe('urn:acr:example');
+  expect(opts.query).toStrictEqual({ ui_locales: 'en-US' });
+});
+
+it('buildAuthorizeOptions forwards nonce, display, prompt and uiLocales from config', () => {
+  const configWithExtras: OidcConfig = {
+    ...config,
+    nonce: 'abc123',
+    display: 'popup',
+    prompt: 'login',
+    uiLocales: 'fr-FR',
+  };
+  const [, opts] = buildAuthorizeOptions(wellknown, configWithExtras);
+  expect(opts.nonce).toBe('abc123');
+  expect(opts.display).toBe('popup');
+  expect(opts.prompt).toBe('login');
+  expect(opts.uiLocales).toBe('fr-FR');
+});
+
+it('buildAuthorizeOptions lets caller options override config-level values', () => {
+  const configWithHint: OidcConfig = { ...config, loginHint: 'config@example.com' };
+  const [, opts] = buildAuthorizeOptions(wellknown, configWithHint, {
+    loginHint: 'caller@example.com',
+  });
+  expect(opts.loginHint).toBe('caller@example.com');
+});
+
+it('buildAuthorizeOptions omits undefined config fields', () => {
+  const [, opts] = buildAuthorizeOptions(wellknown, config);
+  expect(opts.loginHint).toBeUndefined();
+  expect(opts.acrValues).toBeUndefined();
+  expect(opts.query).toBeUndefined();
+  expect(opts.nonce).toBeUndefined();
+});
+
 // ─── authorizeµ flow routing ──────────────────────────────────────────────────
 
 it.effect('authorizeµ uses PAR flow when useParFlow=true', () =>

--- a/packages/oidc-client/src/lib/authorize.request.utils.ts
+++ b/packages/oidc-client/src/lib/authorize.request.utils.ts
@@ -40,6 +40,13 @@ export function buildAuthorizeOptions(
       scope: config.scope || 'openid',
       responseType: config.responseType || 'code',
       ...(isPiFlow && { responseMode: 'pi.flow' as const }),
+      ...(config.loginHint !== undefined && { loginHint: config.loginHint }),
+      ...(config.nonce !== undefined && { nonce: config.nonce }),
+      ...(config.display !== undefined && { display: config.display }),
+      ...(config.prompt !== undefined && { prompt: config.prompt }),
+      ...(config.uiLocales !== undefined && { uiLocales: config.uiLocales }),
+      ...(config.acrValues !== undefined && { acrValues: config.acrValues }),
+      ...(config.query !== undefined && { query: config.query }),
       ...options,
     },
   ];


### PR DESCRIPTION
## Summary

- `buildAuthorizeOptions` only forwarded `clientId/redirectUri/scope/responseType` from config, ignoring `loginHint`, `nonce`, `display`, `prompt`, `uiLocales`, `acrValues`, and `query`.
- `authorize.url()` already read all seven fields from config correctly (client.store.ts lines 178–184), but `authorizeµ` — used by `authorize.background()` — went through `buildAuthorizeOptions` and dropped them.
- The result: post-login silent token renewal via `authorize.background()` never included these values in the authorize URL, even when configured.

## Fix

Add the same seven config-field spreads to `buildAuthorizeOptions` in `authorize.request.utils.ts`, matching the pattern already in `authorize.url()`. Caller-supplied `options` still override config-level values (existing spread order preserved).

## Tests

Added four new unit tests to `authorize.request.utils.test.ts`:
- Forwards `loginHint`, `acrValues`, `query` from config
- Forwards `nonce`, `display`, `prompt`, `uiLocales` from config
- Caller options override config-level values
- Undefined config fields are omitted from the output

## Test plan
- [ ] `nx test oidc-client` passes (32 tests in authorize.request.utils, all green)
- [ ] Verify `authorize.background()` now carries `login_hint`, `acr_values`, `ui_locales` in the authorize URL when configured