### PR TITLE
chore: release version 2.1.1

### DIFF
--- a/.changeset/oidc-prompt-none-background.md
+++ b/.changeset/oidc-prompt-none-background.md
@@ -1,5 +1,0 @@
----
-'@forgerock/oidc-client': patch
----
-
-Always include prompt=none on background authorize calls (both standard and PAR flows)

--- a/packages/davinci-client/CHANGELOG.md
+++ b/packages/davinci-client/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @forgerock/davinci-client
 
+## 2.1.1
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @forgerock/sdk-logger@2.1.1
+  - @forgerock/sdk-oidc@2.1.1
+  - @forgerock/sdk-request-middleware@2.1.1
+  - @forgerock/storage@2.1.1
+  - @forgerock/sdk-types@2.1.1
+  - @forgerock/sdk-utilities@2.1.1
+
 ## 2.1.0
 
 ### Minor Changes

--- a/packages/davinci-client/package.json
+++ b/packages/davinci-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forgerock/davinci-client",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ForgeRock/ping-javascript-sdk.git",

--- a/packages/device-client/CHANGELOG.md
+++ b/packages/device-client/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @forgerock/device-client
 
+## 2.1.1
+
 ## 2.1.0
 
 ### Patch Changes

--- a/packages/device-client/package.json
+++ b/packages/device-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forgerock/device-client",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ForgeRock/ping-javascript-sdk.git",

--- a/packages/journey-client/CHANGELOG.md
+++ b/packages/journey-client/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @forgerock/journey-client
 
+## 2.1.1
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @forgerock/sdk-logger@2.1.1
+  - @forgerock/sdk-oidc@2.1.1
+  - @forgerock/sdk-request-middleware@2.1.1
+  - @forgerock/storage@2.1.1
+  - @forgerock/sdk-types@2.1.1
+  - @forgerock/sdk-utilities@2.1.1
+
 ## 2.1.0
 
 ### Minor Changes

--- a/packages/journey-client/package.json
+++ b/packages/journey-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forgerock/journey-client",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ForgeRock/ping-javascript-sdk.git",

--- a/packages/oidc-client/CHANGELOG.md
+++ b/packages/oidc-client/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @forgerock/oidc-client
 
+## 2.1.1
+
+### Patch Changes
+
+- [`0e1e72d`](https://github.com/ForgeRock/ping-javascript-sdk/commit/0e1e72d72629b7bba560a69bf75e0e04c373930a) Thanks [@ryanbas21](https://github.com/ryanbas21)! - Always include prompt=none on background authorize calls (both standard and PAR flows)
+
+- Updated dependencies []:
+  - @forgerock/iframe-manager@2.1.1
+  - @forgerock/sdk-logger@2.1.1
+  - @forgerock/sdk-oidc@2.1.1
+  - @forgerock/sdk-request-middleware@2.1.1
+  - @forgerock/storage@2.1.1
+  - @forgerock/sdk-types@2.1.1
+  - @forgerock/sdk-utilities@2.1.1
+
 ## 2.1.0
 
 ### Minor Changes

--- a/packages/oidc-client/package.json
+++ b/packages/oidc-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forgerock/oidc-client",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ForgeRock/ping-javascript-sdk.git",

--- a/packages/protect/CHANGELOG.md
+++ b/packages/protect/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @forgerock/protect
 
+## 2.1.1
+
 ## 2.1.0
 
 ### Patch Changes

--- a/packages/protect/package.json
+++ b/packages/protect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forgerock/protect",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ForgeRock/ping-javascript-sdk.git",

--- a/packages/sdk-effects/iframe-manager/CHANGELOG.md
+++ b/packages/sdk-effects/iframe-manager/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @forgerock/iframe-manager
 
+## 2.1.1
+
 ## 2.1.0
 
 ### Minor Changes

--- a/packages/sdk-effects/iframe-manager/package.json
+++ b/packages/sdk-effects/iframe-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forgerock/iframe-manager",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "private": false,
   "repository": {
     "type": "git",

--- a/packages/sdk-effects/logger/CHANGELOG.md
+++ b/packages/sdk-effects/logger/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @forgerock/sdk-logger
 
+## 2.1.1
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @forgerock/sdk-types@2.1.1
+
 ## 2.1.0
 
 ### Patch Changes

--- a/packages/sdk-effects/logger/package.json
+++ b/packages/sdk-effects/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forgerock/sdk-logger",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "private": false,
   "repository": {
     "type": "git",

--- a/packages/sdk-effects/oidc/CHANGELOG.md
+++ b/packages/sdk-effects/oidc/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @forgerock/sdk-oidc
 
+## 2.1.1
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @forgerock/sdk-types@2.1.1
+  - @forgerock/sdk-utilities@2.1.1
+
 ## 2.1.0
 
 ### Minor Changes

--- a/packages/sdk-effects/oidc/package.json
+++ b/packages/sdk-effects/oidc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forgerock/sdk-oidc",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "private": false,
   "repository": {
     "type": "git",

--- a/packages/sdk-effects/sdk-request-middleware/CHANGELOG.md
+++ b/packages/sdk-effects/sdk-request-middleware/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @forgerock/sdk-request-middleware
 
+## 2.1.1
+
 ## 2.1.0
 
 ### Minor Changes

--- a/packages/sdk-effects/sdk-request-middleware/package.json
+++ b/packages/sdk-effects/sdk-request-middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forgerock/sdk-request-middleware",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "private": false,
   "repository": {
     "type": "git",

--- a/packages/sdk-effects/storage/CHANGELOG.md
+++ b/packages/sdk-effects/storage/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @forgerock/storage
 
+## 2.1.1
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @forgerock/sdk-types@2.1.1
+
 ## 2.1.0
 
 ### Patch Changes

--- a/packages/sdk-effects/storage/package.json
+++ b/packages/sdk-effects/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forgerock/storage",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "private": false,
   "repository": {
     "type": "git",

--- a/packages/sdk-types/CHANGELOG.md
+++ b/packages/sdk-types/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @forgerock/sdk-types
 
+## 2.1.1
+
 ## 2.1.0
 
 ### Minor Changes

--- a/packages/sdk-types/package.json
+++ b/packages/sdk-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forgerock/sdk-types",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "private": false,
   "repository": {
     "type": "git",

--- a/packages/sdk-utilities/CHANGELOG.md
+++ b/packages/sdk-utilities/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @forgerock/sdk-utilities
 
+## 2.1.1
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @forgerock/sdk-types@2.1.1
+
 ## 2.1.0
 
 ### Minor Changes

--- a/packages/sdk-utilities/package.json
+++ b/packages/sdk-utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forgerock/sdk-utilities",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "private": false,
   "repository": {
     "type": "git",


### PR DESCRIPTION
Cherry-pick of version bump from release/2.1.1. Bumps @forgerock/oidc-client to 2.1.1, updates CHANGELOGs, and removes consumed changeset.