### PR TITLE
chore: re-export JSON config helpers

### DIFF
--- a/.changeset/perky-doodles-vanish.md
+++ b/.changeset/perky-doodles-vanish.md
@@ -1,0 +1,7 @@
+---
+'@forgerock/davinci-client': minor
+'@forgerock/journey-client': minor
+'@forgerock/oidc-client': minor
+---
+
+re-export JSON client config helpers from respective client packages

--- a/packages/davinci-client/api-report/davinci-client.api.md
+++ b/packages/davinci-client/api-report/davinci-client.api.md
@@ -12,6 +12,7 @@ import { FetchBaseQueryError } from '@reduxjs/toolkit/query';
 import type { FetchBaseQueryMeta } from '@reduxjs/toolkit/query';
 import { GenericError } from '@forgerock/sdk-types';
 import { LogLevel } from '@forgerock/sdk-logger';
+import { makeDavinciConfig } from '@forgerock/sdk-utilities';
 import type { MutationResultSelectorResult } from '@reduxjs/toolkit/query';
 import { QueryStatus } from '@reduxjs/toolkit/query';
 import { Reducer } from '@reduxjs/toolkit';
@@ -1015,6 +1016,8 @@ export interface Links {
 }
 
 export { LogLevel }
+
+export { makeDavinciConfig }
 
 // @public (undocumented)
 export type MetadataCollector = AutoCollector<'ObjectValueAutoCollector', 'MetadataCollector', MetadataCollectorInputValue, Record<string, unknown>>;

--- a/packages/davinci-client/src/index.ts
+++ b/packages/davinci-client/src/index.ts
@@ -8,4 +8,7 @@
 export { davinci } from './lib/client.store.js';
 export { fido } from './lib/fido/fido.js';
 
+// Re-export necessary helpers
+export { makeDavinciConfig } from '@forgerock/sdk-utilities';
+
 export * from './types.js';

--- a/packages/journey-client/api-report/journey-client.api.md
+++ b/packages/journey-client/api-report/journey-client.api.md
@@ -18,6 +18,7 @@ import { isValidWellknownUrl } from '@forgerock/sdk-utilities';
 import { JourneyClientConfig } from '@forgerock/sdk-types';
 import { JourneyServerConfig } from '@forgerock/sdk-types';
 import { LogLevel } from '@forgerock/sdk-logger';
+import { makeJourneyConfig } from '@forgerock/sdk-utilities';
 import { NameValue } from '@forgerock/sdk-types';
 import { PolicyKey } from '@forgerock/sdk-types';
 import { PolicyParams } from '@forgerock/sdk-types';
@@ -257,6 +258,8 @@ export class KbaCreateCallback extends BaseCallback {
 }
 
 export { LogLevel }
+
+export { makeJourneyConfig }
 
 // @public (undocumented)
 export interface MessageCreator {

--- a/packages/journey-client/src/index.ts
+++ b/packages/journey-client/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2020 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -8,5 +8,6 @@
 export * from './lib/client.store.js';
 export * from './types.js';
 
-// Re-export types from internal packages that consumers need
+// Re-export helpers and constants from internal packages that consumers need
 export { callbackType } from '@forgerock/sdk-types';
+export { makeJourneyConfig } from '@forgerock/sdk-utilities';

--- a/packages/oidc-client/api-report/oidc-client.api.md
+++ b/packages/oidc-client/api-report/oidc-client.api.md
@@ -18,6 +18,7 @@ import type { JWTPayload } from 'jose';
 import { logger } from '@forgerock/sdk-logger';
 import { LogLevel } from '@forgerock/sdk-logger';
 import { LogMessage } from '@forgerock/sdk-logger';
+import { makeOidcConfig } from '@forgerock/sdk-utilities';
 import { MutationDefinition } from '@reduxjs/toolkit/query';
 import { OidcConfig } from '@forgerock/sdk-types';
 import { QueryDefinition } from '@reduxjs/toolkit/query';
@@ -259,6 +260,8 @@ export type LogoutErrorResult = {
 export type LogoutSuccessResult = RevokeSuccessResult & {
     sessionResponse: null;
 };
+
+export { makeOidcConfig }
 
 // @public (undocumented)
 export interface OauthTokens {

--- a/packages/oidc-client/src/index.ts
+++ b/packages/oidc-client/src/index.ts
@@ -6,3 +6,6 @@
  */
 export { oidc } from './lib/client.store.js';
 export * from './types.js';
+
+// Re-export necessary helpers
+export { makeOidcConfig } from '@forgerock/sdk-utilities';


### PR DESCRIPTION
# JIRA Ticket

https://pingidentity.atlassian.net/browse/SDKS-5241

## Description

Re-export `makeJourneyConfig`, `makeDavinciConfig`, `makeOidcConfig` JSON helpers from respective client packages.
